### PR TITLE
[No-JIRA] Publish task for modules

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -5,9 +5,6 @@
       "release": true
     }
   },
-  "src": {
-    "afterReleaseCommand": "./gradlew bintrayUpload"
-  },
   "dry-run": false,
   "npm": {
     "publish": false

--- a/Backpack/build.gradle
+++ b/Backpack/build.gradle
@@ -3,7 +3,8 @@ apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'com.jfrog.bintray'
 
 version = rootProject.ext.version
-group = 'net.skyscanner.backpack'
+group='com.github.Skyscanner.backpack-android'
+
 repositories {
   google()
   mavenCentral()
@@ -94,8 +95,8 @@ bintray {
 }
 
 dependencies {
-  implementation project(':core')
-  implementation project(':panel')
-  implementation project(':badge')
+  api project(':core')
+  api project(':panel')
+  api project(':badge')
 }
 

--- a/Backpack/build.gradle
+++ b/Backpack/build.gradle
@@ -1,6 +1,4 @@
 apply plugin: 'com.android.library'
-apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'com.jfrog.bintray'
 
 version = rootProject.ext.version
 group='com.github.Skyscanner.backpack-android'
@@ -20,80 +18,6 @@ android {
   }
 
 }
-
-install {
-  repositories.mavenInstaller {
-    pom {
-      project {
-        packaging 'aar'
-        groupId 'net.skyscanner.backpack'
-        artifactId 'Backpack'
-
-        name 'Backpack'
-        description 'The Skyscanner Design System, Backpack, for Android'
-        url 'https://github.com/Skyscanner/backpack-android'
-
-        licenses {
-          license {
-            name 'The Apache Software License, Version 2.0'
-            url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-          }
-        }
-        developers {
-          developer {
-            id 'Backpack Squad'
-          }
-        }
-        scm {
-          connection 'https://github.com/Skyscanner/backpack-android.git'
-          developerConnection 'https://github.com/Skyscanner/backpack-android.git'
-          url 'https://backpack.github.io'
-
-        }
-      }
-    }
-  }
-}
-
-task sourcesJar(type: Jar) {
-  from android.sourceSets.main.java.srcDirs
-  classifier = 'sources'
-}
-
-task javadoc(type: Javadoc) {
-  source = android.sourceSets.main.java.srcDirs
-  excludes = ['**/*.kt']
-  classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-}
-
-task javadocJar(type: Jar, dependsOn: javadoc) {
-  classifier = 'javadoc'
-  from javadoc.destinationDir
-}
-
-artifacts {
-  archives javadocJar
-  archives sourcesJar
-}
-
-bintray {
-  user = System.getenv('BINTRAY_USER')
-  key = System.getenv('BINTRAY_KEY')
-  configurations = ['archives']
-  pkg {
-    repo = 'Backpack'
-    name = 'Backpack'
-    userOrg = 'skyscanner'
-    licenses = ['Apache-2.0']
-    vcsUrl = 'https://github.com/Skyscanner/backpack-android'
-    labels = ['android', 'skyscanner', 'designsystem']
-    version {
-      name = version
-      released = new Date()
-    }
-  }
-}
-
 dependencies {
   api project(':core')
   api project(':panel')

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,8 @@ Once the component it generated, add it to the `settings.gradle` file to start u
 
 > Backpack team only
 
-To issue a new release make sure you've set the project up as above, that you have push acess to the Backpack Bintray repo and the `BINTRAY_USER` and `BINTRAY_KEY` env vars are set
-
-Run `npm run release` and follow the process through, you'll be asked which semantic version the release
+Run `npm run release` and follow the process through, you'll be asked which semantic version the release.Once released verify the artifacts on [`jitpack`][3]
 
 [1]: https://github.com/creationix/nvm
+[2]: https://github.com/audreyr/cookiecutter
+[3]: https://jitpack.io/#Skyscanner/backpack-android

--- a/README.md
+++ b/README.md
@@ -8,18 +8,23 @@
 
 ## Installation
 
-Backpack is available through [Bintray](https://bintray.com/skyscanner/Backpack/Backpack). To install
-all of it, simply add the following line to your `build.gradle` (in your app module) in the `dependencies` block:
+Backpack is available through [Jitpack](https://jitpack.io/#Skyscanner/backpack-android). To install
+all of it, add the following line to your `build.gradle` (in your app module) in the `dependencies` block:
 
 ```gradle
-compile 'net.skyscanner.backpack:Backpack:0.1.0'
+implementation 'com.github.Skyscanner:backpack-android:0.2.1'
+```
+To install a single component, add the following line to your `build.gradle` (in your app module) in the `dependencies` block:
+
+```gradle
+implementation 'com.github.Skyscanner.backpack-android:badge:0.2.1'
 ```
 
-Backpack is availabe in JCenter so if your app resolves dependencies through JCenter you're all set, if not add in your root `build.gradle`
+Backpack is available in Jitpack so if your app resolves dependencies through Jitpack you're all set, if not add in your root `build.gradle`
 
 ```gradle
 repositories {
-    jcenter()
+    maven { url 'https://jitpack.io' }
 }
 ```
 ## Usage

--- a/badge/build.gradle
+++ b/badge/build.gradle
@@ -1,5 +1,6 @@
 apply from: "../base.gradle"
 
+
 dependencies {
   implementation project(':core')
 }

--- a/base.gradle
+++ b/base.gradle
@@ -1,5 +1,9 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
+apply plugin: 'com.github.dcendents.android-maven'
+apply plugin: 'org.jetbrains.dokka-android'
+
+group='com.github.Skyscanner.backpack-android'
 
 repositories {
   mavenCentral()
@@ -29,3 +33,8 @@ dependencies {
   testImplementation 'junit:junit:4.12'
 }
 
+dokka {
+  outputFormat = 'html-as-java'
+  outputDirectory = "docs"
+  reportUndocumented = false
+}

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
   dependencies {
     classpath 'com.android.tools.build:gradle:3.1.3'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
+    classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:$dokka_version"
     // NOTE: Do not place your application dependencies here; they belong
     // in the individual module build.gradle files
@@ -32,7 +32,7 @@ task clean(type: Delete) {
   delete rootProject.buildDir
 }
 
-def BpkVersion = '0.2.1'
+def BpkVersion = '0.2.2'
 
 ext {
   version = "$BpkVersion"
@@ -45,12 +45,3 @@ ext {
   androidMapsUtilsVersion = "0.5+"
 }
 
-subprojects {
-
-  apply plugin: 'org.jetbrains.dokka-android'
-  dokka {
-    outputFormat = 'html-as-java'
-    outputDirectory = "docs"
-    reportUndocumented = false
-  }
-}

--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ task clean(type: Delete) {
   delete rootProject.buildDir
 }
 
-def BpkVersion = '0.2.2'
+def BpkVersion = '0.2.1'
 
 ext {
   version = "$BpkVersion"

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,1 +1,2 @@
 apply from: "../base.gradle"
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "backpack-android",
-  "version": "0.2.2",
+  "version": "0.2.1",
   "engines": {
     "node": "^8.11.4",
     "npm": "^5.6.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "backpack-android",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "engines": {
     "node": "^8.11.4",
     "npm": "^5.6.0"

--- a/release.js
+++ b/release.js
@@ -117,9 +117,6 @@ async function release() {
           release: true,
         },
       },
-      src: {
-        afterReleaseCommand: './gradlew bintrayUpload',
-      },
     };
     await releaseit(releaseOptions);
   } catch (exc) {


### PR DESCRIPTION
Adding publishing logic for jitpack. The Backpack dependecies can now be included using 

`implementation 'com.github.Skyscanner:backpack-android:no-jira-publish-tasks-SNAPSHOT' `

After release 
`implementation 'com.github.Skyscanner:backpack-android:0.2.2' `

or as individual packages:
    
`implementation 'com.github.Skyscanner.backpack-android:badge:0.2.2' `

