### PR TITLE
RTL testing support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,8 +36,5 @@ dependencies {
   testImplementation 'junit:junit:4.12'
   androidTestImplementation 'com.android.support.test:runner:1.0.1'
   androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
-  implementation ('com.squareup.picasso:picasso:2.71828'){
-    exclude group: 'com.android.support'
-  }
   implementation project(':Backpack')
 }

--- a/app/src/main/java/net/skyscanner/backpack/demo/ComponentDetailActivity.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/ComponentDetailActivity.kt
@@ -4,8 +4,6 @@ import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.Toolbar
 import android.view.View
-import android.widget.ImageView
-import com.squareup.picasso.Picasso
 import net.skyscanner.backpack.demo.data.ComponentRegistry
 
 /**
@@ -21,9 +19,6 @@ class ComponentDetailActivity : AppCompatActivity() {
         setContentView(R.layout.activity_component_detail)
         val toolbar = findViewById<View>(R.id.detail_toolbar) as Toolbar
         setSupportActionBar(toolbar)
-        val image = findViewById<ImageView>(R.id.img)
-        Picasso.get().load(R.drawable.header).resize(1024, 800)
-                .onlyScaleDown().into(image)
 
         // Show the Up button in the action bar.
         val actionBar = supportActionBar

--- a/app/src/main/java/net/skyscanner/backpack/demo/ComponentDetailFragment.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/ComponentDetailFragment.kt
@@ -1,8 +1,16 @@
 package net.skyscanner.backpack.demo
 
 import android.os.Bundle
+import android.support.annotation.LayoutRes
 import android.support.design.widget.CollapsingToolbarLayout
 import android.support.v4.app.Fragment
+import android.support.v7.widget.LinearLayoutCompat
+import android.support.v7.widget.SwitchCompat
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.CompoundButton
 import net.skyscanner.backpack.demo.data.ComponentRegistry
 
 /**
@@ -17,34 +25,45 @@ import net.skyscanner.backpack.demo.data.ComponentRegistry
  */
 open class ComponentDetailFragment : Fragment() {
 
+  /**
+   * The dummy content this fragment is presenting.
+   */
+  private var mItem: ComponentRegistry.Component? = null
+  var childView: LinearLayoutCompat? = null
+
+  override fun onCreate(savedInstanceState: Bundle?) {
+    super.onCreate(savedInstanceState)
+
+    if (arguments!!.containsKey(ARG_ITEM_ID)) {
+      // Load the dummy content specified by the fragment
+      // arguments. In a real-world scenario, use a Loader
+      // to load content from a content provider.
+      mItem = ComponentRegistry.ITEM_MAP[arguments!!.getString(ARG_ITEM_ID)]
+    }
+  }
+
+  override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+    val view: View = inflater.inflate(R.layout.fragment_detail, container, false)
+    val switch = view.findViewById<SwitchCompat>(R.id.toggle_rtl)
+    switch.setOnCheckedChangeListener({ _, isChecked ->
+      Log.i("switch_compat", "checked state is $isChecked")
+      childView?.layoutDirection = if (isChecked) View.LAYOUT_DIRECTION_RTL else View.LAYOUT_DIRECTION_LTR
+    })
+    return view
+  }
+
+  fun merge(@LayoutRes layout: Int) {
+
+    childView = view?.findViewById(R.id.story_container)
+    childView?.addView(layoutInflater.inflate(layout, childView, false))
+  }
+
+  companion object {
     /**
-     * The dummy content this fragment is presenting.
+     * The fragment argument representing the item ID that this fragment
+     * represents.
      */
-    private var mItem: ComponentRegistry.Component? = null
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-
-        if (arguments!!.containsKey(ARG_ITEM_ID)) {
-            // Load the dummy content specified by the fragment
-            // arguments. In a real-world scenario, use a Loader
-            // to load content from a content provider.
-            mItem = ComponentRegistry.ITEM_MAP[arguments!!.getString(ARG_ITEM_ID)]
-
-            val activity = this.activity
-            val appBarLayout = activity!!.findViewById<CollapsingToolbarLayout>(R.id.toolbar_layout)
-            if (appBarLayout != null) {
-                appBarLayout.title = mItem!!.id
-            }
-        }
-    }
-
-    companion object {
-        /**
-         * The fragment argument representing the item ID that this fragment
-         * represents.
-         */
-        val ARG_ITEM_ID = "item_id"
-    }
+    val ARG_ITEM_ID = "item_id"
+  }
 
 }

--- a/app/src/main/java/net/skyscanner/backpack/demo/stories/BadgeFragment.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/stories/BadgeFragment.kt
@@ -1,18 +1,15 @@
 package net.skyscanner.backpack.demo.stories
 
 import android.os.Bundle
-import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
-
 import net.skyscanner.backpack.demo.ComponentDetailFragment
 import net.skyscanner.backpack.demo.R
 
 class BadgeFragment : ComponentDetailFragment() {
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.fragment_badge, container, false)
-    }
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.merge(R.layout.fragment_badge)
+  }
 
 }
 

--- a/app/src/main/java/net/skyscanner/backpack/demo/stories/PanelFragment.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/stories/PanelFragment.kt
@@ -10,8 +10,8 @@ import net.skyscanner.backpack.demo.R
 
 class PanelFragment : ComponentDetailFragment() {
 
-    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        return inflater.inflate(R.layout.fragment_panel, container, false)
-    }
+  override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+    super.merge(R.layout.fragment_panel)
+  }
 
 }

--- a/app/src/main/res/layout-land/component_list.xml
+++ b/app/src/main/res/layout-land/component_list.xml
@@ -26,7 +26,7 @@
     android:layout_marginLeft="@dimen/bpkSpacingLg"
     android:layout_marginRight="@dimen/bpkSpacingLg"
     android:layout_marginTop="@dimen/bpkSpacingLg"
-    app:layoutManager="LinearLayoutManager"
+    app:layoutManager="android.support.v7.widget.LinearLayoutManager"
     tools:context="net.skyscanner.backpack.demo.MainActivity"
     tools:listitem="@layout/component_list_content" />
 

--- a/app/src/main/res/layout/activity_component_detail.xml
+++ b/app/src/main/res/layout/activity_component_detail.xml
@@ -1,51 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
+<android.support.v7.widget.LinearLayoutCompat
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent"
+  android:orientation="vertical"
+  android:fitsSystemWindows="true"
+  tools:context=".ComponentDetailActivity"
+  tools:ignore="MergeRootFrame">
+
+
+  <android.support.design.widget.AppBarLayout
+    android:id="@+id/app_bar"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
-    tools:context=".demo.ComponentDetailActivity"
-    tools:ignore="MergeRootFrame">
+    android:layout_height="wrap_content"
+    android:theme="@style/AppTheme.AppBarOverlay">
 
-    <android.support.design.widget.AppBarLayout
-        android:id="@+id/app_bar"
-        android:layout_width="match_parent"
-        android:layout_height="@dimen/app_bar_height"
-        android:fitsSystemWindows="true"
-        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+    <android.support.v7.widget.Toolbar
+      android:id="@+id/detail_toolbar"
+      android:layout_width="match_parent"
+      android:layout_height="?attr/actionBarSize"
+      app:popupTheme="@style/AppTheme.PopupOverlay"/>
 
-        <android.support.design.widget.CollapsingToolbarLayout
-            android:id="@+id/toolbar_layout"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:fitsSystemWindows="true"
-            app:contentScrim="?attr/colorPrimary"
-            app:layout_scrollFlags="scroll|exitUntilCollapsed"
-            app:toolbarId="@+id/toolbar">
+  </android.support.design.widget.AppBarLayout>
 
-            <ImageView
-                android:id="@+id/img"
-                android:scaleType="centerCrop"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent" />
+  <android.support.v4.widget.NestedScrollView
+    android:id="@+id/component_detail_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"/>
 
-            <android.support.v7.widget.Toolbar
-                android:id="@+id/detail_toolbar"
-                android:layout_width="match_parent"
-                android:layout_height="?attr/actionBarSize"
-                app:layout_collapseMode="pin"
-                app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
-
-        </android.support.design.widget.CollapsingToolbarLayout>
-
-    </android.support.design.widget.AppBarLayout>
-
-    <android.support.v4.widget.NestedScrollView
-        android:id="@+id/component_detail_container"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
-
-
-</android.support.design.widget.CoordinatorLayout>
+</android.support.v7.widget.LinearLayoutCompat>

--- a/app/src/main/res/layout/fragment_detail.xml
+++ b/app/src/main/res/layout/fragment_detail.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+            xmlns:app="http://schemas.android.com/apk/res-auto"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+  <android.support.v7.widget.LinearLayoutCompat
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="@dimen/bpkSpacingBase">
+
+    <android.support.v7.widget.SwitchCompat
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="RTL"
+      android:paddingBottom="@dimen/bpkSpacingXl"
+      android:id="@+id/toggle_rtl"/>
+
+    <android.support.v7.widget.LinearLayoutCompat
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:id="@+id/story_container"
+      android:orientation="vertical"/>
+  </android.support.v7.widget.LinearLayoutCompat>
+
+</ScrollView>

--- a/app/src/main/res/layout/fragment_panel.xml
+++ b/app/src/main/res/layout/fragment_panel.xml
@@ -1,35 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
+<android.support.v7.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
+       xmlns:app="http://schemas.android.com/apk/res-auto"
+       android:layout_width="match_parent"
         android:orientation="vertical"
-        android:padding="@dimen/bpkSpacingBase">
+       android:layout_height="match_parent">
 
-        <net.skyscanner.backpack.panel.BpkPanel
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:bpk_padding="false">
+  <net.skyscanner.backpack.panel.BpkPanel
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:bpk_padding="false">
 
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:text="@string/stub" />
-        </net.skyscanner.backpack.panel.BpkPanel>
+    <TextView
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:text="@string/stub"/>
+  </net.skyscanner.backpack.panel.BpkPanel>
 
-        <net.skyscanner.backpack.panel.BpkPanel
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            app:bpk_padding="true">
+  <net.skyscanner.backpack.panel.BpkPanel
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:bpk_padding="true">
 
-            <TextView
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:text="@string/stub" />
-        </net.skyscanner.backpack.panel.BpkPanel>
-    </LinearLayout>
-</ScrollView>
+    <TextView
+      android:layout_width="match_parent"
+      android:layout_height="match_parent"
+      android:text="@string/stub"/>
+  </net.skyscanner.backpack.panel.BpkPanel>
+</android.support.v7.widget.LinearLayoutCompat>


### PR DESCRIPTION
This PR adds ability to test the components for RTL support. The storybook has a toggle switch to enable and disable RTL on the viewgroup that holds the sample components. This may change in the future as:

1. When screenshot tests are added, we might need to test for RTL and LTR

2. When we add documentation with screenshots, we might need to remove the toggle switch to something less visual.

Currently this is a testing support mechanism and it is upto the developer to visually ensure that component does not break for RTL languages.

![device-2018-08-28-094536](https://user-images.githubusercontent.com/2570336/44712039-c9668680-aaa7-11e8-9648-5d9436a32a20.png)


![device-2018-08-28-094552](https://user-images.githubusercontent.com/2570336/44712040-c9668680-aaa7-11e8-8177-24953a26ae72.png)
 


