### PR TITLE
[BPK-1836] Config API docs

### DIFF
--- a/Backpack/build.gradle
+++ b/Backpack/build.gradle
@@ -18,6 +18,7 @@ android {
   }
 
 }
+
 dependencies {
   api project(':core')
   api project(':panel')

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,12 @@ Once the component it generated, add it to the `settings.gradle` file to start u
 
 Run `npm run release` and follow the process through, you'll be asked which semantic version the release.Once released verify the artifacts on [`jitpack`][3]
 
+## Docs
+
+Run `npm run docs` to genere API docs. Docs will be generated in the `build/docs` folder by default. To provide a different output folder use `npm run docs -- -PdokkaOutput=/path/to/folder`
+
+Run `npm run docs:clean` to remove generated docs.
+
 [1]: https://github.com/creationix/nvm
 [2]: https://github.com/audreyr/cookiecutter
 [3]: https://jitpack.io/#Skyscanner/backpack-android

--- a/base.gradle
+++ b/base.gradle
@@ -33,8 +33,31 @@ dependencies {
   testImplementation 'junit:junit:4.12'
 }
 
+ext.modules = rootProject.subprojects
+  .findAll { it.project.name != "Backpack" && it.project.name != "app" }
+
 dokka {
-  outputFormat = 'html-as-java'
-  outputDirectory = "docs"
+  moduleName = "$rootProject.name"
+  outputFormat = 'html'
+  outputDirectory = "$rootProject.buildDir/docs"
   reportUndocumented = false
+
+  if (project.hasProperty("dokkaOutput")) {
+    outputDirectory = dokkaOutput
+  }
+
+  sourceDirs += files(
+    modules
+      .findAll { it.name != project.name }
+      .collect { new File(it.projectDir, "/src/main/java") }
+  )
+
+  modules.each { p ->
+    linkMapping {
+      dir = "${p.projectDir}/src/main/java"
+      url = "https://github.com/Skyscanner/backpack-android/tree/master/${p.name}/src/main/java"
+      suffix = "#L"
+    }
+  }
 }
+

--- a/build.gradle
+++ b/build.gradle
@@ -44,4 +44,3 @@ ext {
   googlePlayServicesVersion = "15.0.1"
   androidMapsUtilsVersion = "0.5+"
 }
-

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "test": "eslint . --ext .js,.jsx",
     "prebuild": "npm test",
     "build": "gulp",
-    "prettier": "prettier --config .prettierrc --write \"**/*.js\""
+    "prettier": "prettier --config .prettierrc --write \"**/*.js\"",
+    "docs": "./gradlew dokka",
+    "docs:clean": "./gradlew cleanDokka"
   },
   "lint-staged": {
     "*.js": [


### PR DESCRIPTION
It looks like this:
<img width="934" alt="screen shot 2018-08-30 at 16 02 46" src="https://user-images.githubusercontent.com/1457263/44860480-2c097f00-ac6e-11e8-84fd-789ff1dee6e9.png">

The little `source` link at the top links to the source code on github \o/

It can be generated locally with `npm run docs` and viewed with `chrome build/docs/backpack-android/index.html`

To configure the outputFolder `npm run docs -- -PdokkaOutput=/path/to/folder`