### PR TITLE
[BPK-1920] Update dependencies and minSDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,7 @@ android:
     - tools
     - build-tools-$ANDROID_BUILD_TOOLS_VERSION
     - android-$ANDROID_API_LEVEL
+    - android-$ANDROID_MIN_SDK_LEVEL
     - android-$EMULATOR_API_LEVEL
     # For Google APIs
     - addon-google_apis-google-$ANDROID_API_LEVEL
@@ -92,6 +93,7 @@ notifications:
 env:
   global:
     - ANDROID_API_LEVEL=27
+    - ANDROID_MIN_SDK_LEVEL=19
     - EMULATOR_API_LEVEL=21
     - ANDROID_BUILD_TOOLS_VERSION=27.0.3
     - ANDROID_ABI=armeabi-v7a

--- a/Backpack/build.gradle
+++ b/Backpack/build.gradle
@@ -29,8 +29,8 @@ dependencies {
   implementation "com.android.support:support-annotations:$rootProject.ext.supportLibVersion"
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
   implementation "com.android.support:appcompat-v7:$rootProject.ext.supportLibVersion"
-  androidTestImplementation 'com.android.support.test:runner:1.0.1'
-  androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
+  androidTestImplementation 'com.android.support.test:runner:1.0.2'
+  androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
   testImplementation 'junit:junit:4.12'
 }
 

--- a/Backpack/src/main/java/net/skyscanner/backpack/panel/BpkPanel.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/panel/BpkPanel.kt
@@ -3,6 +3,7 @@ package net.skyscanner.backpack.panel
 import android.content.Context
 import android.support.annotation.Dimension
 import android.support.annotation.Nullable
+import android.support.v4.content.res.ResourcesCompat
 import android.support.v7.widget.LinearLayoutCompat
 import android.util.AttributeSet
 import net.skyscanner.backpack.R
@@ -42,7 +43,7 @@ open class BpkPanel(
 
         val a = context.obtainStyledAttributes(attrs, R.styleable.BpkPanel, R.attr.padding, defStyleAttr)
         padding = a.getBoolean(R.styleable.BpkPanel_padding, true)
-        this.background = context.getDrawable(R.drawable.border)
+        this.background = ResourcesCompat.getDrawable(resources,R.drawable.border,null)
         a.recycle()
     }
 }

--- a/Backpack/src/main/java/net/skyscanner/backpack/text/BpkText.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/text/BpkText.kt
@@ -14,7 +14,7 @@ open class BpkText(
   attrs: AttributeSet?,
   defStyleAttr: Int) : AppCompatTextView(context, attrs, defStyleAttr) {
 
-  @IntDef(XS.toLong(), SM.toLong(), BASE.toLong(), LG.toLong(), XL.toLong(), XXL.toLong())
+  @IntDef(XS, SM, BASE, LG, XL, XXL)
 
   annotation class Styles
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-  ext.kotlin_version = '1.2.51'
+  ext.kotlin_version = '1.2.60'
   ext.dokka_version = '0.9.17'
   repositories {
     google()
@@ -33,9 +33,9 @@ ext {
   version = "$BpkVersion"
   compileSdkVersion = 27
   targetSdkVersion = 27
-  minSdkVersion = 21
+  minSdkVersion = 19
   buildToolsVersion = "27.0.3"
-  supportLibVersion = "27.0.1"
+  supportLibVersion = "27.1.1"
   googlePlayServicesVersion = "15.0.1"
   androidMapsUtilsVersion = "0.5+"
 }


### PR DESCRIPTION
Updates minSDK to 19. Changes include

- Use `ResourceCompat` to get resources for backward compatibility


Update kotlin version from `1.2.51` to `1.2.60`. Causes minor syntax change for `@IntDef` 
Update `Junit` and `Espresso` dependencies