### PR TITLE
[no-jira] Icons bugfix for API 19

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher"
         android:supportsRtl="true"
+        android:name="net.skyscanner.backpack.demo.BackpackDemoApplication"
         android:theme="@style/AppTheme">
         <activity android:name=".MainActivity">
             <intent-filter>

--- a/app/src/main/java/net/skyscanner/backpack/demo/BackpackDemoApplication.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/BackpackDemoApplication.kt
@@ -1,0 +1,14 @@
+package net.skyscanner.backpack.demo
+
+import android.support.multidex.MultiDexApplication
+import android.support.v7.app.AppCompatDelegate
+
+/**
+ * Application class registered in AndroidManifest.xml
+ */
+class BackpackDemoApplication : MultiDexApplication() {
+  override fun onCreate() {
+    super.onCreate()
+    AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
+  }
+}


### PR DESCRIPTION
Fixes a crash on API-19 while loading vector icons. This fix enables using vector resources using compatibility library.
see https://stackoverflow.com/a/42956161