### PR TITLE
[BpkButton] should be possible to set isEnabled from code

### DIFF
--- a/Backpack/src/androidTest/java/net/skyscanner/backpack/button/BpkButtonTest.kt
+++ b/Backpack/src/androidTest/java/net/skyscanner/backpack/button/BpkButtonTest.kt
@@ -58,13 +58,13 @@ class BpkButtonTest {
       type = BpkButton.Type.Primary
     }
     val newState = false
-    val disabledBackgroundColor = R.color.bpkGray100
+    val expectedBackgroundState = subjectUnderTest.disabledBackground
 
     // When
     subjectUnderTest.isEnabled = newState
 
     // Then
     Assert.assertEquals(subjectUnderTest.isEnabled, newState)
-    Assert.assertEquals(subjectUnderTest.drawingCacheBackgroundColor, disabledBackgroundColor)
+    Assert.assertEquals(subjectUnderTest.background, expectedBackgroundState)
   }
 }

--- a/Backpack/src/androidTest/java/net/skyscanner/backpack/button/BpkButtonTest.kt
+++ b/Backpack/src/androidTest/java/net/skyscanner/backpack/button/BpkButtonTest.kt
@@ -4,9 +4,6 @@ import android.content.Context
 import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
 import android.support.v7.content.res.AppCompatResources
-import com.nhaarman.mockito_kotlin.atLeastOnce
-import com.nhaarman.mockito_kotlin.spy
-import com.nhaarman.mockito_kotlin.verify
 import net.skyscanner.backpack.R
 import org.junit.Assert
 import org.junit.Before
@@ -67,7 +64,7 @@ class BpkButtonTest {
     subjectUnderTest.isEnabled = newState
 
     // Then
-    assert(subjectUnderTest.isEnabled == newState)
-    assert(subjectUnderTest.drawingCacheBackgroundColor == disabledBackgroundColor)
+    Assert.assertEquals(subjectUnderTest.isEnabled, newState)
+    Assert.assertEquals(subjectUnderTest.drawingCacheBackgroundColor, disabledBackgroundColor)
   }
 }

--- a/Backpack/src/androidTest/java/net/skyscanner/backpack/button/BpkButtonTest.kt
+++ b/Backpack/src/androidTest/java/net/skyscanner/backpack/button/BpkButtonTest.kt
@@ -51,20 +51,16 @@ class BpkButtonTest {
   }
 
   @Test
-  fun givenBpkButtonInAnyTypeAndFormWhenIsEnabledIsSetThenSetupIsCalled() {
-    // Given
-    val subjectUnderTest = BpkButton(context).apply {
+  fun test_enabled_state() {
+    val button = BpkButton(context).apply {
       isEnabled = true
       type = BpkButton.Type.Primary
     }
     val newState = false
-    val expectedBackgroundState = subjectUnderTest.disabledBackground
+    val expectedBackgroundState = button.disabledBackground
+    button.isEnabled = newState
 
-    // When
-    subjectUnderTest.isEnabled = newState
-
-    // Then
-    Assert.assertEquals(subjectUnderTest.isEnabled, newState)
-    Assert.assertEquals(subjectUnderTest.background, expectedBackgroundState)
+    Assert.assertEquals(button.isEnabled, newState)
+    Assert.assertEquals(button.background, expectedBackgroundState)
   }
 }

--- a/Backpack/src/androidTest/java/net/skyscanner/backpack/button/BpkButtonTest.kt
+++ b/Backpack/src/androidTest/java/net/skyscanner/backpack/button/BpkButtonTest.kt
@@ -1,19 +1,30 @@
 package net.skyscanner.backpack.button
 
+import android.content.Context
 import android.support.test.InstrumentationRegistry
 import android.support.test.runner.AndroidJUnit4
 import android.support.v7.content.res.AppCompatResources
+import com.nhaarman.mockito_kotlin.atLeastOnce
+import com.nhaarman.mockito_kotlin.spy
+import com.nhaarman.mockito_kotlin.verify
 import net.skyscanner.backpack.R
 import org.junit.Assert
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class BpkButtonTest {
 
+  private lateinit var context: Context
+
+  @Before
+  fun beforeAll() {
+    context = InstrumentationRegistry.getInstrumentation().targetContext
+  }
+
   @Test
   fun test_message() {
-    val context = InstrumentationRegistry.getInstrumentation().targetContext
     val button = BpkButton(context).apply {
       text = "Message"
 
@@ -24,23 +35,39 @@ class BpkButtonTest {
   // The drawables are set as start,top,end,bottom and are accessible in the compoundDrawables array
   @Test
   fun test_icon_end() {
-    val context = InstrumentationRegistry.getInstrumentation().targetContext
     val trainIcon = AppCompatResources.getDrawable(context, R.drawable.bpk_train)
     val button = BpkButton(context).apply {
       icon = trainIcon
       iconPosition = BpkButton.END
     }
-    Assert.assertEquals(button.compoundDrawables[2],trainIcon)
+    Assert.assertEquals(button.compoundDrawables[2], trainIcon)
   }
 
   @Test
   fun test_icon_start() {
-    val context = InstrumentationRegistry.getInstrumentation().targetContext
     val trainIcon = AppCompatResources.getDrawable(context, R.drawable.bpk_train)
     val button = BpkButton(context).apply {
       icon = trainIcon
       iconPosition = BpkButton.START
     }
-    Assert.assertEquals(button.compoundDrawables[0],trainIcon)
+    Assert.assertEquals(button.compoundDrawables[0], trainIcon)
+  }
+
+  @Test
+  fun givenBpkButtonInAnyTypeAndFormWhenIsEnabledIsSetThenSetupIsCalled() {
+    // Given
+    val subjectUnderTest = BpkButton(context).apply {
+      isEnabled = true
+      type = BpkButton.Type.Primary
+    }
+    val newState = false
+    val disabledBackgroundColor = R.color.bpkGray100
+
+    // When
+    subjectUnderTest.isEnabled = newState
+
+    // Then
+    assert(subjectUnderTest.isEnabled == newState)
+    assert(subjectUnderTest.drawingCacheBackgroundColor == disabledBackgroundColor)
   }
 }

--- a/Backpack/src/main/java/net/skyscanner/backpack/button/BpkButton.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/button/BpkButton.kt
@@ -12,7 +12,6 @@ import android.os.Build
 import android.support.annotation.ColorInt
 import android.support.annotation.ColorRes
 import android.support.annotation.IntDef
-import android.support.annotation.VisibleForTesting
 import android.support.v4.content.ContextCompat
 import android.support.v4.graphics.drawable.DrawableCompat
 import android.support.v4.widget.TextViewCompat
@@ -69,18 +68,7 @@ open class BpkButton @JvmOverloads constructor(
       }
     }
 
-  internal val disabledBackground by lazy {
-    getSelectorDrawable(
-      normalColor = ContextCompat.getColor(context, type.bgColor),
-      pressedColor = darken(ContextCompat.getColor(context, type.bgColor)),
-      disabledColor = ContextCompat.getColor(context, R.color.bpkGray100),
-      cornerRadius = roundedButtonCorner,
-      strokeWidth = strokeWidth,
-      strokeColor = ContextCompat.getColor(context, type.strokeColor)
-    )
-  }
-
-  internal val enabledBackground by lazy {
+  internal val disabledBackground =
     getSelectorDrawable(
       normalColor = ContextCompat.getColor(context, R.color.bpkGray100),
       pressedColor = darken(ContextCompat.getColor(context, R.color.bpkGray100)),
@@ -89,7 +77,6 @@ open class BpkButton @JvmOverloads constructor(
       strokeWidth = 0,
       strokeColor = ContextCompat.getColor(context, android.R.color.transparent)
     )
-  }
 
   init {
     val attr = context.theme.obtainStyledAttributes(attrs, R.styleable.BpkButton, defStyleAttr, 0)
@@ -152,7 +139,16 @@ open class BpkButton @JvmOverloads constructor(
       compoundDrawablePadding = paddingWithIcon / 2
     }
 
-    this.background = if (this.isEnabled) enabledBackground else disabledBackground
+    this.background = if (this.isEnabled) {
+      getSelectorDrawable(
+        normalColor = ContextCompat.getColor(context, type.bgColor),
+        pressedColor = darken(ContextCompat.getColor(context, type.bgColor)),
+        disabledColor = ContextCompat.getColor(context, R.color.bpkGray100),
+        cornerRadius = roundedButtonCorner,
+        strokeWidth = strokeWidth,
+        strokeColor = ContextCompat.getColor(context, type.strokeColor)
+      )
+    } else disabledBackground
 
     this.setTextColor(ContextCompat.getColor(context, if (this.isEnabled) type.textColor else R.color.bpkGray300))
     TextViewCompat.setTextAppearance(this, R.style.bpkButtonBase)

--- a/Backpack/src/main/java/net/skyscanner/backpack/button/BpkButton.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/button/BpkButton.kt
@@ -28,7 +28,6 @@ open class BpkButton @JvmOverloads constructor(
 ) : AppCompatButton(context, attrs, defStyleAttr) {
 
   @IntDef(START, END, ICON_ONLY)
-
   annotation class IconPosition
 
   companion object {
@@ -50,7 +49,7 @@ open class BpkButton @JvmOverloads constructor(
   // padding needs to be reduced by 2 dp on both sides
   private val paddingWithIcon = (context.resources.getDimension(R.dimen.bpkSpacingLg).toInt() / 2) - 2
 
-  val roundedButtonCorner = context.resources.getDimension(R.dimen.bpkSpacingLg)
+  private val roundedButtonCorner = context.resources.getDimension(R.dimen.bpkSpacingLg)
   private val strokeWidth = context.resources.getDimension(R.dimen.bpkBorderRadiusSm).toInt()
 
   private val INVALID_RESOURCE = -1
@@ -86,7 +85,12 @@ open class BpkButton @JvmOverloads constructor(
     setup()
   }
 
-  enum class Type(internal var id: Int, @ColorRes internal var bgColor: Int, @ColorRes internal var textColor: Int, @ColorRes internal var strokeColor: Int) {
+  override fun setEnabled(enabled: Boolean) {
+    super.setEnabled(enabled)
+    setup()
+  }
+
+  enum class Type(internal val id: Int, @ColorRes internal val bgColor: Int, @ColorRes internal val textColor: Int, @ColorRes internal val strokeColor: Int) {
     Primary(0, R.color.bpkGreen500, R.color.bpkWhite, android.R.color.transparent),
     Secondary(1, R.color.bpkWhite, R.color.bpkBlue600, R.color.bpkGray100),
     Featured(2, R.color.bpkPink500, R.color.bpkWhite, android.R.color.transparent),
@@ -103,7 +107,6 @@ open class BpkButton @JvmOverloads constructor(
   }
 
   private fun setup() {
-
     this.isClickable = isEnabled
     //enforce null text for icon only
     if (iconPosition == ICON_ONLY) {
@@ -112,9 +115,10 @@ open class BpkButton @JvmOverloads constructor(
 
     this.setPadding(
       if (iconPosition == ICON_ONLY) paddingWithIcon else defaultPadding,
-      if (this.icon != null)  paddingWithIcon else defaultPadding,
+      if (this.icon != null) paddingWithIcon else defaultPadding,
       if (iconPosition == ICON_ONLY) paddingWithIcon else defaultPadding,
-      if (this.icon != null) paddingWithIcon else defaultPadding)
+      if (this.icon != null) paddingWithIcon else defaultPadding
+    )
 
     if (!text.isNullOrEmpty()) {
       compoundDrawablePadding = paddingWithIcon / 2
@@ -122,12 +126,18 @@ open class BpkButton @JvmOverloads constructor(
 
     this.background = getSelectorDrawable(
       normalColor = ContextCompat.getColor(context, if (this.isEnabled) type.bgColor else R.color.bpkGray100),
+      pressedColor = darken(ContextCompat.getColor(context, if (this.isEnabled) type.bgColor else R.color.bpkGray100)),
+      disabledColor = ContextCompat.getColor(context, R.color.bpkGray100),
       cornerRadius = roundedButtonCorner,
       strokeWidth = if (this.isEnabled) strokeWidth else 0,
-      strokeColor = if (this.isEnabled) ContextCompat.getColor(context,type.strokeColor) else ContextCompat.getColor(context,android.R.color.transparent)
+      strokeColor = ContextCompat.getColor(
+        context,
+        if (this.isEnabled) type.strokeColor else android.R.color.transparent
+      )
     )
+    
     this.setTextColor(ContextCompat.getColor(context, if (this.isEnabled) type.textColor else R.color.bpkGray300))
-    TextViewCompat.setTextAppearance(this,  R.style.bpkButtonBase)
+    TextViewCompat.setTextAppearance(this, R.style.bpkButtonBase)
     this.gravity = Gravity.CENTER
 
     this.icon?.let {
@@ -146,7 +156,8 @@ open class BpkButton @JvmOverloads constructor(
       if (iconPosition == START || iconPosition == ICON_ONLY) icon else null,
       null,
       if (iconPosition == END) icon else null,
-      null)
+      null
+    )
   }
 }
 
@@ -168,13 +179,14 @@ fun getSelectorDrawable(
   cornerRadius: Float? = null,
   @ColorInt strokeColor: Int? = null,
   strokeWidth: Int? = null,
-  @ColorInt pressedColor: Int = darken(normalColor)
+  @ColorInt pressedColor: Int,
+  @ColorInt disabledColor: Int
 ): Drawable {
   if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
     val states = StateListDrawable()
     states.addState(
       intArrayOf(-android.R.attr.state_enabled),
-      corneredDrawable(greyOut(normalColor), cornerRadius, strokeColor, strokeWidth)
+      corneredDrawable(disabledColor, cornerRadius, strokeColor, strokeWidth)
     )
     states.addState(
       intArrayOf(android.R.attr.state_pressed),
@@ -188,7 +200,7 @@ fun getSelectorDrawable(
     return states
   } else {
     return RippleDrawable(
-      getColorSelector(normalColor, pressedColor, greyOut(normalColor)),
+      getColorSelector(normalColor, pressedColor, disabledColor),
       corneredDrawable(normalColor, cornerRadius, strokeColor, strokeWidth),
       corneredDrawable(Color.BLACK, cornerRadius, strokeColor, strokeWidth)
     )
@@ -260,20 +272,4 @@ private fun darken(@ColorInt normalColor: Int, factor: Float = .2f): Int {
   Color.colorToHSV(normalColor, hsv)
   hsv[2] *= 1f - factor // value component
   return Color.HSVToColor(hsv)
-}
-
-/**
- * Utility function for darkening out a given color
- *
- * @param normalColor required, representing the color we will darken, given as a color resource int
- *
- * @return Int
- */
-private fun greyOut(@ColorInt normalColor: Int): Int {
-  return Color.argb(
-    Color.alpha(normalColor),
-    Color.red(normalColor) / 2,
-    Color.green(normalColor) / 2,
-    Color.blue(normalColor) / 2
-  )
 }

--- a/Backpack/src/main/java/net/skyscanner/backpack/button/BpkButton.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/button/BpkButton.kt
@@ -12,6 +12,7 @@ import android.os.Build
 import android.support.annotation.ColorInt
 import android.support.annotation.ColorRes
 import android.support.annotation.IntDef
+import android.support.annotation.VisibleForTesting
 import android.support.v4.content.ContextCompat
 import android.support.v4.graphics.drawable.DrawableCompat
 import android.support.v4.widget.TextViewCompat
@@ -68,6 +69,28 @@ open class BpkButton @JvmOverloads constructor(
       }
     }
 
+  internal val disabledBackground by lazy {
+    getSelectorDrawable(
+      normalColor = ContextCompat.getColor(context, type.bgColor),
+      pressedColor = darken(ContextCompat.getColor(context, type.bgColor)),
+      disabledColor = ContextCompat.getColor(context, R.color.bpkGray100),
+      cornerRadius = roundedButtonCorner,
+      strokeWidth = strokeWidth,
+      strokeColor = ContextCompat.getColor(context, type.strokeColor)
+    )
+  }
+
+  internal val enabledBackground by lazy {
+    getSelectorDrawable(
+      normalColor = ContextCompat.getColor(context, R.color.bpkGray100),
+      pressedColor = darken(ContextCompat.getColor(context, R.color.bpkGray100)),
+      disabledColor = ContextCompat.getColor(context, R.color.bpkGray100),
+      cornerRadius = roundedButtonCorner,
+      strokeWidth = 0,
+      strokeColor = ContextCompat.getColor(context, android.R.color.transparent)
+    )
+  }
+
   init {
     val attr = context.theme.obtainStyledAttributes(attrs, R.styleable.BpkButton, defStyleAttr, 0)
     try {
@@ -85,6 +108,11 @@ open class BpkButton @JvmOverloads constructor(
     setup()
   }
 
+  /**
+   * Even though we have a StateListDrawable, it is not enough just to rely on the state of
+   * the background for enabled/disabled change as we have text color and other properties
+   * changing incl the stroke of the background which means we need to change that as well.
+   */
   override fun setEnabled(enabled: Boolean) {
     super.setEnabled(enabled)
     setup()
@@ -124,18 +152,8 @@ open class BpkButton @JvmOverloads constructor(
       compoundDrawablePadding = paddingWithIcon / 2
     }
 
-    this.background = getSelectorDrawable(
-      normalColor = ContextCompat.getColor(context, if (this.isEnabled) type.bgColor else R.color.bpkGray100),
-      pressedColor = darken(ContextCompat.getColor(context, if (this.isEnabled) type.bgColor else R.color.bpkGray100)),
-      disabledColor = ContextCompat.getColor(context, R.color.bpkGray100),
-      cornerRadius = roundedButtonCorner,
-      strokeWidth = if (this.isEnabled) strokeWidth else 0,
-      strokeColor = ContextCompat.getColor(
-        context,
-        if (this.isEnabled) type.strokeColor else android.R.color.transparent
-      )
-    )
-    
+    this.background = if (this.isEnabled) enabledBackground else disabledBackground
+
     this.setTextColor(ContextCompat.getColor(context, if (this.isEnabled) type.textColor else R.color.bpkGray300))
     TextViewCompat.setTextAppearance(this, R.style.bpkButtonBase)
     this.gravity = Gravity.CENTER

--- a/app/src/main/java/net/skyscanner/backpack/demo/stories/ButtonStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/stories/ButtonStory.kt
@@ -7,6 +7,9 @@ import net.skyscanner.backpack.demo.R
 
 class ButtonStory : Story() {
 
+  private lateinit var disabledButton: BpkButton
+  private lateinit var iconButton: BpkButton
+
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     val type = arguments?.getString(ButtonStory.TYPE) ?: savedInstanceState?.getString(ButtonStory.TYPE)
 
@@ -27,6 +30,13 @@ class ButtonStory : Story() {
     view.findViewById<BpkButton>(R.id.btn_icon).type = buttonType
     super.onViewCreated(view, savedInstanceState)
 
+    disabledButton = view.findViewById<BpkButton>(R.id.btn_disabled)
+    iconButton = view.findViewById<BpkButton>(R.id.btn_icon)
+
+    iconButton.setOnClickListener {
+      disabledButton.isEnabled = !disabledButton.isEnabled
+      disabledButton.text = if (disabledButton.isEnabled) "Enabled" else "Disabled"
+    }
   }
 
   companion object {

--- a/app/src/main/java/net/skyscanner/backpack/demo/stories/ButtonStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/stories/ButtonStory.kt
@@ -7,9 +7,6 @@ import net.skyscanner.backpack.demo.R
 
 class ButtonStory : Story() {
 
-  private lateinit var disabledButton: BpkButton
-  private lateinit var iconButton: BpkButton
-
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     val type = arguments?.getString(ButtonStory.TYPE) ?: savedInstanceState?.getString(ButtonStory.TYPE)
 
@@ -29,14 +26,6 @@ class ButtonStory : Story() {
     view.findViewById<BpkButton>(R.id.btn_start_icon).type = buttonType
     view.findViewById<BpkButton>(R.id.btn_icon).type = buttonType
     super.onViewCreated(view, savedInstanceState)
-
-    disabledButton = view.findViewById<BpkButton>(R.id.btn_disabled)
-    iconButton = view.findViewById<BpkButton>(R.id.btn_icon)
-
-    iconButton.setOnClickListener {
-      disabledButton.isEnabled = !disabledButton.isEnabled
-      disabledButton.text = if (disabledButton.isEnabled) "Enabled" else "Disabled"
-    }
   }
 
   companion object {

--- a/app/src/main/res/layout/fragment_button.xml
+++ b/app/src/main/res/layout/fragment_button.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-                xmlns:app="http://schemas.android.com/apk/res-auto"
-                android:layout_width="wrap_content"
-                android:layout_margin="@dimen/bpkSpacingBase"
-                android:layout_gravity="center_vertical"
-                android:layout_height="wrap_content">
+<RelativeLayout
+  xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  xmlns:tools="http://schemas.android.com/tools"
+  android:layout_width="wrap_content"
+  android:layout_margin="@dimen/bpkSpacingBase"
+  android:layout_gravity="center_vertical"
+  android:layout_height="wrap_content"
+  tools:ignore="HardcodedText">
 
   <net.skyscanner.backpack.button.BpkButton
     android:layout_margin="@dimen/bpkSpacingSm"
@@ -18,7 +21,7 @@
     android:layout_margin="@dimen/bpkSpacingSm"
     android:layout_width="wrap_content"
     android:id="@+id/btn_disabled"
-    android:layout_toRightOf="@id/btn_default"
+    android:layout_toEndOf="@id/btn_default"
     android:layout_height="wrap_content"
     android:text="Disabled"
     android:enabled="false"
@@ -29,8 +32,7 @@
     android:layout_width="wrap_content"
     android:id="@+id/btn_start_icon"
     android:layout_height="wrap_content"
-    android:layout_toRightOf="@id/btn_disabled"
-
+    android:layout_toEndOf="@id/btn_disabled"
     android:text="With icon"
     app:buttonIconPosition="end"
     app:buttonIcon="@drawable/bpk_long_arrow_right"
@@ -51,7 +53,7 @@
     android:layout_margin="@dimen/bpkSpacingSm"
     android:layout_width="wrap_content"
     android:id="@+id/btn_icon"
-    android:layout_toRightOf="@+id/btn_end_icon"
+    android:layout_toEndOf="@+id/btn_end_icon"
     android:layout_below="@id/btn_default"
     android:layout_height="wrap_content"
     app:buttonIconPosition="icon_only"


### PR DESCRIPTION
**Issue:** with the current API if you set isEnabled from code (f.x. disabling the button upon certain condition in code, and not from XML) then it had no effect

**Cause:** `setEnabled` is called on the AppCompatButton API and the `setup()` is not called.

**Solution:** Overriding the `setEnabled` API call and triggering a `setup()` call after the state change (similar to how we do it after any custom property change - icon, type)

![button-isenabled-fix](https://user-images.githubusercontent.com/935897/46164760-21530180-c28f-11e8-96e0-bf565fd6be69.gif)

I also added a hidden click listener on the icon button on each story so we can flip the state of the disabled button to show this functionality. *If you prefer, it can be removed.*