### PR TITLE
[NO-JIRA] Run npm ci before release

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "preemulator": "npm run emulator:boot",
     "emulator": "adb wait-for-device && sleep 5 && npm run emulator:build && npm run emulator:test",
     "postemulator": "npm run emulator:kill",
-    "prerelease": "npm run emulator",
+    "prerelease": "npm ci && npm run emulator",
     "release": "node release.js",
     "test": "eslint . --ext .js,.jsx",
     "prebuild": "npm test",


### PR DESCRIPTION
We (I) recently released a version of backpack-android with outdated tokens. This happened for two reasons:

1. My local version of `bpk-tokens` was outdated and the release process generates a bunch of things based on that.
2. Our snapshot tests don't capture elevation (and those where elevation tokens)

Point 2 is really hard to fix so I added `npm ci` command before the release process to make sure we do it with a clean and updated environment.