### PR TITLE
Change Kotlin stdlib dependency coordinates

### DIFF
--- a/Backpack/build.gradle
+++ b/Backpack/build.gradle
@@ -28,7 +28,7 @@ android {
 
 dependencies {
   implementation "androidx.annotation:annotation:$rootProject.ext.androidx"
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+  implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "androidx.appcompat:appcompat:$rootProject.ext.androidx"
   implementation "androidx.cardview:cardview:$rootProject.ext.androidx"
   androidTestImplementation 'com.android.support.test:runner:1.0.2'


### PR DESCRIPTION
I believe it's not necessary to specify the JDK anymore, and that would align with our main app. It will also allow our main app to transition to Kotlin 1.3 without Backpack having to commit to it yet.