### PR TITLE
[Bpk-2080] Add debug markers 

### DIFF
--- a/Backpack/build.gradle
+++ b/Backpack/build.gradle
@@ -35,6 +35,7 @@ dependencies {
   androidTestImplementation 'androidx.test:rules:1.1.1'
   androidTestImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.1.0'
   androidTestImplementation 'org.mockito:mockito-android:2.23.4'
+  api 'io.github.inflationx:viewpump:1.0.0'
   testImplementation 'junit:junit:4.12'
   // NOTE: This is here and not in the root file because snyk is not ignoring it otherwise.
   // This is a test dependency and should be ignored (as stated in snyk docs)

--- a/Backpack/src/main/java/net/skyscanner/backpack/util/BpkInterceptor.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/util/BpkInterceptor.kt
@@ -6,14 +6,14 @@ import androidx.annotation.RequiresApi
 import io.github.inflationx.viewpump.InflateResult
 import io.github.inflationx.viewpump.Interceptor
 
-class BpkInterceptor(private val enable: Boolean = false) : Interceptor {
+class BpkInterceptor : Interceptor {
 
   @RequiresApi(Build.VERSION_CODES.M)
   override fun intercept(chain: Interceptor.Chain): InflateResult {
     val result = chain.proceed(chain.request())
     val view = result.view()
 
-    if (enable && view != null && isBpkView(view.javaClass)) {
+    if (view != null && isBpkView(view.javaClass)) {
       if (view.background == null) {
 
         view.background = ColorDrawable(0x77ac650c)

--- a/Backpack/src/main/java/net/skyscanner/backpack/util/BpkInterceptor.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/util/BpkInterceptor.kt
@@ -13,13 +13,25 @@ class BpkInterceptor(private val enable: Boolean = false) : Interceptor {
     val result = chain.proceed(chain.request())
     val view = result.view()
 
-    if (enable && view != null && view.javaClass.name.contains("Bpk")) {
+    if (enable && view != null && isBpkView(view.javaClass)) {
       if (view.background == null) {
+
         view.background = ColorDrawable(0x77ac650c)
       } else {
         view.foreground = ColorDrawable(0x77ac650c)
       }
     }
     return result
+  }
+
+  private fun isBpkView(javaClass: Class<Any>): Boolean {
+    var inClass = javaClass
+    while (inClass.superclass != null) {
+      if (inClass.name.toLowerCase().contains("bpk")) {
+        return true
+      }
+      inClass = (inClass.superclass as Class<Any>?)!!
+    }
+    return false
   }
 }

--- a/Backpack/src/main/java/net/skyscanner/backpack/util/BpkInterceptor.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/util/BpkInterceptor.kt
@@ -12,13 +12,14 @@ class BpkInterceptor : Interceptor {
   override fun intercept(chain: Interceptor.Chain): InflateResult {
     val result = chain.proceed(chain.request())
     val view = result.view()
+    // brown marker highlight color
+    val highlightColor = 0x77ac650c
 
     if (view != null && isBpkView(view.javaClass)) {
       if (view.background == null) {
-
-        view.background = ColorDrawable(0x77ac650c)
+        view.background = ColorDrawable(highlightColor)
       } else {
-        view.foreground = ColorDrawable(0x77ac650c)
+        view.foreground = ColorDrawable(highlightColor)
       }
     }
     return result

--- a/Backpack/src/main/java/net/skyscanner/backpack/util/BpkInterceptor.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/util/BpkInterceptor.kt
@@ -1,17 +1,24 @@
 package net.skyscanner.backpack.util
 
 import android.graphics.drawable.ColorDrawable
+import android.os.Build
+import androidx.annotation.RequiresApi
 import io.github.inflationx.viewpump.InflateResult
 import io.github.inflationx.viewpump.Interceptor
 
 class BpkInterceptor(private val enable: Boolean = false) : Interceptor {
 
+  @RequiresApi(Build.VERSION_CODES.M)
   override fun intercept(chain: Interceptor.Chain): InflateResult {
     val result = chain.proceed(chain.request())
     val view = result.view()
 
     if (enable && view != null && view.javaClass.name.contains("Bpk")) {
-      view.background = ColorDrawable(0x77ac650c)
+      if (view.background == null) {
+        view.background = ColorDrawable(0x77ac650c)
+      } else {
+        view.foreground = ColorDrawable(0x77ac650c)
+      }
     }
     return result
   }

--- a/Backpack/src/main/java/net/skyscanner/backpack/util/BpkInterceptor.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/util/BpkInterceptor.kt
@@ -1,0 +1,18 @@
+package net.skyscanner.backpack.util
+
+import android.graphics.drawable.ColorDrawable
+import io.github.inflationx.viewpump.InflateResult
+import io.github.inflationx.viewpump.Interceptor
+
+
+class BpkInterceptor : Interceptor {
+  override fun intercept(chain: Interceptor.Chain): InflateResult {
+    val result = chain.proceed(chain.request())
+    val view = result.view()
+
+    if (view != null && view.javaClass.name.contains("Bpk")) {
+      view.background = ColorDrawable(0x77008c4d)
+    }
+    return result
+  }
+}

--- a/Backpack/src/main/java/net/skyscanner/backpack/util/BpkInterceptor.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/util/BpkInterceptor.kt
@@ -4,14 +4,14 @@ import android.graphics.drawable.ColorDrawable
 import io.github.inflationx.viewpump.InflateResult
 import io.github.inflationx.viewpump.Interceptor
 
+class BpkInterceptor(private val enable: Boolean = false) : Interceptor {
 
-class BpkInterceptor : Interceptor {
   override fun intercept(chain: Interceptor.Chain): InflateResult {
     val result = chain.proceed(chain.request())
     val view = result.view()
 
-    if (view != null && view.javaClass.name.contains("Bpk")) {
-      view.background = ColorDrawable(0x77008c4d)
+    if (enable && view != null && view.javaClass.name.contains("Bpk")) {
+      view.background = ColorDrawable(0x77ac650c)
     }
     return result
   }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,7 @@ To run connected tests run
 
 - `Shift + D` : Toggle story view between RTL and LTR
 - `Shift + T` : Hide the toolbar
+- `Shift + H` : Show/Hide debug markers
 
 ## Code Style
 Code style is ensured by [ktlint](https://github.com/shyiko/ktlint). It runs automatically during the `check` phase but can also be executed by running `gradlew ktlint`.

--- a/app/src/main/java/net/skyscanner/backpack/demo/BackpackDemoApplication.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/BackpackDemoApplication.kt
@@ -37,7 +37,7 @@ class BackpackDemoApplication : Application() {
 
   override fun onCreate() {
     super.onCreate()
-    instance = (applicationContext as BackpackDemoApplication?)!!
+    instance = applicationContext!! as BackpackDemoApplication
     Stetho.initializeWithDefaults(this)
     AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
     highlight = SharedPreferences.shouldHighlight(this)

--- a/app/src/main/java/net/skyscanner/backpack/demo/BackpackDemoApplication.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/BackpackDemoApplication.kt
@@ -3,7 +3,6 @@ package net.skyscanner.backpack.demo
 import android.app.Application
 import android.content.Context
 import android.content.Intent
-import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate
 import io.github.inflationx.viewpump.ViewPump
 import net.skyscanner.backpack.demo.data.SharedPreferences
@@ -43,7 +42,7 @@ class BackpackDemoApplication : Application() {
     AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
     highlight = SharedPreferences.shouldHighlight(this)
 
-    if(highlight){
+    if (highlight) {
       ViewPump.init(ViewPump.builder()
         .addInterceptor(BpkInterceptor())
         .build())

--- a/app/src/main/java/net/skyscanner/backpack/demo/BackpackDemoApplication.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/BackpackDemoApplication.kt
@@ -1,21 +1,52 @@
 package net.skyscanner.backpack.demo
 
 import android.app.Application
+import android.content.Context
+import android.content.Intent
+import android.util.Log
 import androidx.appcompat.app.AppCompatDelegate
-import com.facebook.stetho.Stetho
 import io.github.inflationx.viewpump.ViewPump
+import net.skyscanner.backpack.demo.data.SharedPreferences
 import net.skyscanner.backpack.util.BpkInterceptor
+import com.facebook.stetho.Stetho
 
 /**
  * Application class registered in AndroidManifest.xml
  */
+
 class BackpackDemoApplication : Application() {
+
+  companion object {
+
+    private lateinit var instance: BackpackDemoApplication
+
+    var highlight = false
+      set(value) {
+        field = value
+        SharedPreferences.saveHighlightState(instance, value)
+      }
+
+    fun triggerRebirth(context: Context) {
+      val packageManager = context.packageManager
+      val intent = packageManager.getLaunchIntentForPackage(context.packageName)
+      val componentName = intent!!.component
+      val mainIntent = Intent.makeRestartActivityTask(componentName)
+      context.startActivity(mainIntent)
+      Runtime.getRuntime().exit(0)
+    }
+  }
+
   override fun onCreate() {
     super.onCreate()
+    instance = (applicationContext as BackpackDemoApplication?)!!
     Stetho.initializeWithDefaults(this)
     AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
-    ViewPump.init(ViewPump.builder()
-      .addInterceptor(BpkInterceptor(true))
-      .build())
+    highlight = SharedPreferences.shouldHighlight(this)
+
+    if(highlight){
+      ViewPump.init(ViewPump.builder()
+        .addInterceptor(BpkInterceptor())
+        .build())
+    }
   }
 }

--- a/app/src/main/java/net/skyscanner/backpack/demo/BackpackDemoApplication.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/BackpackDemoApplication.kt
@@ -6,7 +6,6 @@ import com.facebook.stetho.Stetho
 import io.github.inflationx.viewpump.ViewPump
 import net.skyscanner.backpack.util.BpkInterceptor
 
-
 /**
  * Application class registered in AndroidManifest.xml
  */
@@ -16,7 +15,7 @@ class BackpackDemoApplication : Application() {
     Stetho.initializeWithDefaults(this)
     AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
     ViewPump.init(ViewPump.builder()
-      .addInterceptor(BpkInterceptor())
+      .addInterceptor(BpkInterceptor(true))
       .build())
   }
 }

--- a/app/src/main/java/net/skyscanner/backpack/demo/BackpackDemoApplication.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/BackpackDemoApplication.kt
@@ -3,6 +3,9 @@ package net.skyscanner.backpack.demo
 import android.app.Application
 import androidx.appcompat.app.AppCompatDelegate
 import com.facebook.stetho.Stetho
+import io.github.inflationx.viewpump.ViewPump
+import net.skyscanner.backpack.util.BpkInterceptor
+
 
 /**
  * Application class registered in AndroidManifest.xml
@@ -12,5 +15,8 @@ class BackpackDemoApplication : Application() {
     super.onCreate()
     Stetho.initializeWithDefaults(this)
     AppCompatDelegate.setCompatVectorFromResourcesEnabled(true)
+    ViewPump.init(ViewPump.builder()
+      .addInterceptor(BpkInterceptor())
+      .build())
   }
 }

--- a/app/src/main/java/net/skyscanner/backpack/demo/BpkBaseActivity.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/BpkBaseActivity.kt
@@ -1,0 +1,13 @@
+package net.skyscanner.backpack.demo
+
+import android.annotation.SuppressLint
+import android.content.Context
+import androidx.appcompat.app.AppCompatActivity
+import io.github.inflationx.viewpump.ViewPumpContextWrapper
+
+@SuppressLint("Registered")
+open class BpkBaseActivity: AppCompatActivity(){
+  override fun attachBaseContext(newBase: Context) {
+    super.attachBaseContext(ViewPumpContextWrapper.wrap(newBase))
+  }
+}

--- a/app/src/main/java/net/skyscanner/backpack/demo/BpkBaseActivity.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/BpkBaseActivity.kt
@@ -6,7 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import io.github.inflationx.viewpump.ViewPumpContextWrapper
 
 @SuppressLint("Registered")
-open class BpkBaseActivity: AppCompatActivity(){
+open class BpkBaseActivity : AppCompatActivity() {
   override fun attachBaseContext(newBase: Context) {
     super.attachBaseContext(ViewPumpContextWrapper.wrap(newBase))
   }

--- a/app/src/main/java/net/skyscanner/backpack/demo/ComponentDetailActivity.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/ComponentDetailActivity.kt
@@ -59,6 +59,7 @@ class ComponentDetailActivity : BpkBaseActivity() {
   /*
    Hide/Un-hide toolbar: Shift + T
    toggle layout direction: Shift + D
+   toggle markers: Shift + H
   */
   override fun onKeyUp(keyCode: Int, event: KeyEvent?): Boolean {
     if (keyCode == KeyEvent.KEYCODE_T && event?.isShiftPressed == true) {

--- a/app/src/main/java/net/skyscanner/backpack/demo/ComponentDetailActivity.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/ComponentDetailActivity.kt
@@ -55,6 +55,7 @@ class ComponentDetailActivity : BpkBaseActivity() {
     }
     return true
   }
+
   /*
    Hide/Un-hide toolbar: Shift + T
    toggle layout direction: Shift + D
@@ -76,5 +77,4 @@ class ComponentDetailActivity : BpkBaseActivity() {
     }
     return super.onKeyUp(keyCode, event)
   }
-
 }

--- a/app/src/main/java/net/skyscanner/backpack/demo/ComponentDetailActivity.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/ComponentDetailActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.KeyEvent
 import android.view.MenuItem
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import kotlinx.android.synthetic.main.activity_component_detail.*
 import net.skyscanner.backpack.demo.data.ComponentRegistry
 
@@ -14,7 +13,7 @@ import net.skyscanner.backpack.demo.data.ComponentRegistry
  * item details are presented side-by-side with a list of items
  * in a [MainActivity].
  */
-class ComponentDetailActivity : AppCompatActivity() {
+class ComponentDetailActivity : BpkBaseActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
@@ -77,4 +76,5 @@ class ComponentDetailActivity : AppCompatActivity() {
     }
     return super.onKeyUp(keyCode, event)
   }
+
 }

--- a/app/src/main/java/net/skyscanner/backpack/demo/ComponentDetailActivity.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/ComponentDetailActivity.kt
@@ -75,6 +75,10 @@ class ComponentDetailActivity : BpkBaseActivity() {
         component_detail_container.layoutDirection = View.LAYOUT_DIRECTION_LTR
       }
     }
+    if (keyCode == KeyEvent.KEYCODE_H && event?.isShiftPressed == true) {
+      BackpackDemoApplication.highlight = !BackpackDemoApplication.highlight
+      BackpackDemoApplication.triggerRebirth(this)
+    }
     return super.onKeyUp(keyCode, event)
   }
 }

--- a/app/src/main/java/net/skyscanner/backpack/demo/MainActivity.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/MainActivity.kt
@@ -2,12 +2,12 @@ package net.skyscanner.backpack.demo
 
 import android.os.Bundle
 import android.view.View
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.recyclerview.widget.RecyclerView
 import net.skyscanner.backpack.demo.StoriesRecyclerViewAdapter.HeaderItem
 import net.skyscanner.backpack.demo.StoriesRecyclerViewAdapter.StoryItem
 import net.skyscanner.backpack.demo.data.ComponentRegistry
+
 
 /**
  * An activity representing a list of Components. This activity
@@ -17,7 +17,7 @@ import net.skyscanner.backpack.demo.data.ComponentRegistry
  * item details. On tablets, the activity presents the list of items and
  * item details side-by-side using two vertical panes.
  */
-class MainActivity : AppCompatActivity() {
+class MainActivity : BpkBaseActivity() {
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)

--- a/app/src/main/java/net/skyscanner/backpack/demo/MainActivity.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/MainActivity.kt
@@ -8,7 +8,6 @@ import net.skyscanner.backpack.demo.StoriesRecyclerViewAdapter.HeaderItem
 import net.skyscanner.backpack.demo.StoriesRecyclerViewAdapter.StoryItem
 import net.skyscanner.backpack.demo.data.ComponentRegistry
 
-
 /**
  * An activity representing a list of Components. This activity
  * has different presentations for handset and tablet-size devices. On

--- a/app/src/main/java/net/skyscanner/backpack/demo/data/SharedPreferences.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/data/SharedPreferences.kt
@@ -9,7 +9,6 @@ class SharedPreferences {
   companion object {
     val SHOULD_HIGHLIGHT = "highlight"
 
-
     fun shouldHighlight(context: Context): Boolean {
       return context
         .getSharedPreferences(context.getString(R.string.preference_file_key),

--- a/app/src/main/java/net/skyscanner/backpack/demo/data/SharedPreferences.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/data/SharedPreferences.kt
@@ -1,0 +1,31 @@
+package net.skyscanner.backpack.demo.data
+
+import android.annotation.SuppressLint
+import android.content.Context
+import net.skyscanner.backpack.demo.R
+
+class SharedPreferences {
+
+  companion object {
+    val SHOULD_HIGHLIGHT = "highlight"
+
+
+    fun shouldHighlight(context: Context): Boolean {
+      return context
+        .getSharedPreferences(context.getString(R.string.preference_file_key),
+          Context.MODE_PRIVATE)
+        .getBoolean(SHOULD_HIGHLIGHT, false)
+    }
+
+    @SuppressLint("ApplySharedPref")
+    fun saveHighlightState(context: Context, state: Boolean) {
+      val sharedPref = context
+        .getSharedPreferences(context.getString(R.string.preference_file_key),
+          Context.MODE_PRIVATE)
+      with(sharedPref.edit()) {
+        putBoolean(SHOULD_HIGHLIGHT, state)
+        commit()
+      }
+    }
+  }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
   <string name="stub_xs" translatable="false">Lorem ipsum dolor sit amet.</string>
 
   <string name="txt_flights_to_edinburgh">Flights to Edinburgh</string>
+  <string name="preference_file_key">bpk_preferences</string>
 </resources>


### PR DESCRIPTION
Adds debug markers to all Backpack views.
Installation instructions:

Add the interceptor inr the Application class's `onCreate` as follows:

```
    ViewPump.init(ViewPump.builder()
      .addInterceptor(BpkInterceptor())
      .build())
```

Add the contextWrapper to the base activity as:
```
  override fun attachBaseContext(newBase: Context) {
    super.attachBaseContext(ViewPumpContextWrapper.wrap(newBase))
  }
```
Caveats:
- Introduces the dependecy on `inflaterX` in the app. This can be moved to test dependency if required
- Adds another function in the all the base class activities.

