### PR TITLE
Kotlin version bump

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
-  ext.kotlin_version = '1.2.71'
+  ext.kotlin_version = '1.3.10'
   ext.dokka_version = '0.9.17'
   repositories {
     google()


### PR DESCRIPTION
Not using any new features of Kotlin 1.3 yet. This PR is for being in sync with dependencies on the client apps.