### PR TITLE
[BPK-2141] Support tint for drawables on BpkText

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/text/BpkText.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/text/BpkText.kt
@@ -103,21 +103,24 @@ open class BpkText(
     }
 
     // Adding tint and compoundDrawables does not work. Converting compoundDrawables to compoundDrawablesRelative
-    if (this.layoutDirection == View.LAYOUT_DIRECTION_LTR) {
-      this.setCompoundDrawablesRelative(
-        compoundDrawablesRelative[0] ?: compoundDrawables[0],
-        compoundDrawablesRelative[1] ?: compoundDrawables[1],
-        compoundDrawablesRelative[2] ?: compoundDrawables[2],
-        compoundDrawablesRelative[3] ?: compoundDrawables[3])
-    } else {
-      this.setCompoundDrawablesRelative(
-        compoundDrawablesRelative[0] ?: compoundDrawables[2],
-        compoundDrawablesRelative[1] ?: compoundDrawables[1],
-        compoundDrawablesRelative[2] ?: compoundDrawables[0],
-        compoundDrawablesRelative[3] ?: compoundDrawables[3])
+
+    var start = compoundDrawablesRelative[0] ?: compoundDrawables[0]
+    val top = compoundDrawablesRelative[1] ?: compoundDrawables[1]
+    var end = compoundDrawablesRelative[2] ?: compoundDrawables[2]
+    val bottom = compoundDrawablesRelative[3] ?: compoundDrawables[3]
+
+    // Swapping drawables in case of RTL.
+    // compoundDrawablesRelative order is `start`,`top`,`end`,`bottom`
+    // compoundDrawables order is  `left`,`top`,`right`,`bottom`
+
+    if (this.layoutDirection == View.LAYOUT_DIRECTION_RTL) {
+      start = compoundDrawables[2]
+      end = compoundDrawables[0]
     }
+    setCompoundDrawablesRelative(start, top, end, bottom)
+
     val drawableTint = a.getColorStateList(R.styleable.BpkText_drawableTint)
-    if (drawableTint!= null) {
+    if (drawableTint != null) {
       setDrawableTint(drawableTint.getColorForState(EMPTY_STATE_SET, Color.WHITE))
     }
     a.recycle()

--- a/Backpack/src/main/java/net/skyscanner/backpack/text/BpkText.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/text/BpkText.kt
@@ -12,7 +12,6 @@ import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.widget.TextViewCompat
 import net.skyscanner.backpack.R
 
-
 open class BpkText(
   context: Context,
   attrs: AttributeSet?,
@@ -52,13 +51,6 @@ open class BpkText(
       field = value
       setup()
     }
-
-  /*var drawableTint: ColorStateList = null
-  set(value){
-    for (drawable in compoundDrawables) {
-      drawable?.colorFilter = PorterDuffColorFilter(getColor(value), PorterDuff.Mode.SRC_IN)
-    }
-  }*/
 
   /**
    * Sets the text style to emphasized.
@@ -112,17 +104,29 @@ open class BpkText(
 
     // Adding tint and compoundDrawables does not work. Converting compoundDrawables to compoundDrawablesRelative
     if (this.layoutDirection == View.LAYOUT_DIRECTION_LTR) {
-      this.setCompoundDrawablesRelative(compoundDrawables[0], compoundDrawables[1], compoundDrawables[2], compoundDrawables[3])
+      this.setCompoundDrawablesRelative(
+        compoundDrawablesRelative[0] ?: compoundDrawables[0],
+        compoundDrawablesRelative[1] ?: compoundDrawables[1],
+        compoundDrawablesRelative[2] ?: compoundDrawables[2],
+        compoundDrawablesRelative[3] ?: compoundDrawables[3])
     } else {
-      this.setCompoundDrawablesRelative(compoundDrawables[2], compoundDrawables[1], compoundDrawables[0], compoundDrawables[3])
+      this.setCompoundDrawablesRelative(
+        compoundDrawablesRelative[0] ?: compoundDrawables[2],
+        compoundDrawablesRelative[1] ?: compoundDrawables[1],
+        compoundDrawablesRelative[2] ?: compoundDrawables[0],
+        compoundDrawablesRelative[3] ?: compoundDrawables[3])
     }
     if (a.getColorStateList(R.styleable.BpkText_drawableTint) != null) {
       val drawableTint = a.getColorStateList(R.styleable.BpkText_drawableTint)
-      for (drawable in compoundDrawablesRelative) {
-        drawable?.colorFilter = PorterDuffColorFilter(drawableTint!!.getColorForState(EMPTY_STATE_SET, Color.WHITE), PorterDuff.Mode.SRC_IN)
-      }
+      setDrawableTint(drawableTint!!.getColorForState(EMPTY_STATE_SET, Color.WHITE))
     }
     a.recycle()
+  }
+
+  open fun setDrawableTint(color: Int) {
+    for (drawable in compoundDrawablesRelative) {
+      drawable?.colorFilter = PorterDuffColorFilter(color, PorterDuff.Mode.SRC_IN)
+    }
   }
 
   private fun setup() {
@@ -131,7 +135,8 @@ open class BpkText(
     styleProps ?: throw IllegalStateException("Invalid textStyle")
 
     val textAppearance = styleProps[weight.ordinal]
-    textAppearance ?: throw IllegalStateException("Weight $weight is not supported for the current size")
+    textAppearance
+      ?: throw IllegalStateException("Weight $weight is not supported for the current size")
 
     if (textStyle == CAPS) {
       isAllCaps = true

--- a/Backpack/src/main/java/net/skyscanner/backpack/text/BpkText.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/text/BpkText.kt
@@ -2,11 +2,16 @@ package net.skyscanner.backpack.text
 
 import android.content.Context
 import android.content.res.TypedArray
+import android.graphics.Color
+import android.graphics.PorterDuff
+import android.graphics.PorterDuffColorFilter
 import android.util.AttributeSet
+import android.view.View
 import androidx.annotation.IntDef
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.widget.TextViewCompat
 import net.skyscanner.backpack.R
+
 
 open class BpkText(
   context: Context,
@@ -47,6 +52,13 @@ open class BpkText(
       field = value
       setup()
     }
+
+  /*var drawableTint: ColorStateList = null
+  set(value){
+    for (drawable in compoundDrawables) {
+      drawable?.colorFilter = PorterDuffColorFilter(getColor(value), PorterDuff.Mode.SRC_IN)
+    }
+  }*/
 
   /**
    * Sets the text style to emphasized.
@@ -98,6 +110,18 @@ open class BpkText(
       weight = Weight.values()[weightArg]
     }
 
+    // Adding tint and compoundDrawables does not work. Converting compoundDrawables to compoundDrawablesRelative
+    if (this.layoutDirection == View.LAYOUT_DIRECTION_LTR) {
+      this.setCompoundDrawablesRelative(compoundDrawables[0], compoundDrawables[1], compoundDrawables[2], compoundDrawables[3])
+    } else {
+      this.setCompoundDrawablesRelative(compoundDrawables[2], compoundDrawables[1], compoundDrawables[0], compoundDrawables[3])
+    }
+    if (a.getColorStateList(R.styleable.BpkText_drawableTint) != null) {
+      val drawableTint = a.getColorStateList(R.styleable.BpkText_drawableTint)
+      for (drawable in compoundDrawablesRelative) {
+        drawable?.colorFilter = PorterDuffColorFilter(drawableTint!!.getColorForState(EMPTY_STATE_SET, Color.WHITE), PorterDuff.Mode.SRC_IN)
+      }
+    }
     a.recycle()
   }
 

--- a/Backpack/src/main/java/net/skyscanner/backpack/text/BpkText.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/text/BpkText.kt
@@ -116,14 +116,14 @@ open class BpkText(
         compoundDrawablesRelative[2] ?: compoundDrawables[0],
         compoundDrawablesRelative[3] ?: compoundDrawables[3])
     }
-    if (a.getColorStateList(R.styleable.BpkText_drawableTint) != null) {
-      val drawableTint = a.getColorStateList(R.styleable.BpkText_drawableTint)
-      setDrawableTint(drawableTint!!.getColorForState(EMPTY_STATE_SET, Color.WHITE))
+    val drawableTint = a.getColorStateList(R.styleable.BpkText_drawableTint)
+    if (drawableTint!= null) {
+      setDrawableTint(drawableTint.getColorForState(EMPTY_STATE_SET, Color.WHITE))
     }
     a.recycle()
   }
 
-  open fun setDrawableTint(color: Int) {
+  fun setDrawableTint(color: Int) {
     for (drawable in compoundDrawablesRelative) {
       drawable?.colorFilter = PorterDuffColorFilter(color, PorterDuff.Mode.SRC_IN)
     }

--- a/Backpack/src/main/res/values/attrs.xml
+++ b/Backpack/src/main/res/values/attrs.xml
@@ -33,7 +33,7 @@
       <enum name="emphasized" value="1" />
       <enum name="heavy" value="2" />
     </attr>
-    <attr name="drawableTint"/>
+    <attr name="drawableTint" format="reference"/>
   </declare-styleable>
 
   <declare-styleable name="BpkPanel">

--- a/Backpack/src/main/res/values/attrs.xml
+++ b/Backpack/src/main/res/values/attrs.xml
@@ -33,6 +33,7 @@
       <enum name="emphasized" value="1" />
       <enum name="heavy" value="2" />
     </attr>
+    <attr name="drawableTint"/>
   </declare-styleable>
 
   <declare-styleable name="BpkPanel">

--- a/app/src/main/java/net/skyscanner/backpack/demo/data/ComponentRegistry.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/data/ComponentRegistry.kt
@@ -106,7 +106,8 @@ object ComponentRegistry {
       mapOf(
         "Default" story NodeData { Story of R.layout.fragment_text },
         "Emphasized" story NodeData { Story of R.layout.fragment_text_emphasized },
-        "Heavy" story NodeData { Story of R.layout.fragment_text_heavy }
+        "Heavy" story NodeData { Story of R.layout.fragment_text_heavy },
+        "With drawables" story NodeData { Story of R.layout.fragment_text_drawables }
       ))
   )
 

--- a/app/src/main/res/layout/fragment_text_drawables.xml
+++ b/app/src/main/res/layout/fragment_text_drawables.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  style="@style/App.Story"
+  android:orientation="vertical">
+
+  <net.skyscanner.backpack.text.BpkText
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/txt_flights_to_edinburgh"
+    app:drawableTint="@color/bpkGreen900"
+    android:drawableStart="@drawable/bpk_flight"
+    android:drawableEnd="@drawable/bpk_arrow_right"
+    app:textStyle="lg" />
+
+  <net.skyscanner.backpack.text.BpkText
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:text="@string/txt_flights_to_edinburgh"
+    app:drawableTint="@color/bpkGreen900"
+    android:drawableRight="@drawable/bpk_arrow_right"
+    android:drawableLeft="@drawable/bpk_flight"
+    app:textStyle="lg" />
+
+</LinearLayout>


### PR DESCRIPTION
Support using `drawableTint` on BpkText for android API < 23

The developer needs to change from 

`android:drawableTint="@color/bpkRed500"` to 
`app:drawableTint="@color/bpkRed500"`

in java/kotlin use

`view.setDrawableTint(ContextCompat.getColor(holder.view.context,R.color.bpkGreen600))`

This also supports tint for `drawableLeft` and `drawableRight`
