### PR TITLE
Improve BPK calendar date selection

### DIFF
--- a/Backpack/src/androidTest/java/net/skyscanner/backpack/calendar/presenter/BpkCalendarControllerTest.kt
+++ b/Backpack/src/androidTest/java/net/skyscanner/backpack/calendar/presenter/BpkCalendarControllerTest.kt
@@ -116,13 +116,13 @@ class BpkCalendarControllerTest {
     val spy = spy(subject)
     val start = CalendarDay(2019, 0, 1)
     val end1 = CalendarDay(2019, 0, 4)
-    val end2 = CalendarDay(2019, 0, 3)
+    val start2 = CalendarDay(2019, 0, 3)
 
-    val expectedRange = CalendarRange(start, end2)
+    val expectedRange = CalendarRange(start2, null)
 
     spy.onDayOfMonthSelected(start)
     spy.onDayOfMonthSelected(end1)
-    spy.onDayOfMonthSelected(end2)
+    spy.onDayOfMonthSelected(start2)
 
     verify(spy, times(3)).onRangeSelected(expectedRange)
   }

--- a/Backpack/src/main/java/net/skyscanner/backpack/calendar/presenter/BpkCalendarController.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/calendar/presenter/BpkCalendarController.kt
@@ -37,15 +37,13 @@ abstract class BpkCalendarController {
           selectedRange.start = null
           selectedRange.end = null
         }
-        currentRangeStart.date != selectedDay.date && currentRangeEnd != null && currentRangeEnd.date == selectedDay.date -> {
-          selectedRange.start = currentRangeStart
-          selectedRange.end = null
-        }
-        selectedDay.date.before(currentRangeStart.date) -> {
+        currentRangeEnd != null || selectedDay.date.before(currentRangeStart.date) -> {
           selectedRange.start = selectedDay
           selectedRange.end = null
         }
-        currentRangeEnd == null || currentRangeEnd.date != selectedDay.date -> selectedRange.end = selectedDay
+        currentRangeEnd == null -> {
+          selectedRange.end = selectedDay
+        }
       }
     } else {
       selectedRange.start = selectedDay

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,1 +1,2 @@
 # Unreleased
+- Calendar date changing mechanism is updated with new logic (every selection after a range defined clears the previously selected range).


### PR DESCRIPTION
BPK calendar date changing mechanism is updated with new logic (every selection after a range defined clears the previously selected range).