### PR TITLE
[BPK-2340] Fix RN rendering

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/calendar/BpkCalendar.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/calendar/BpkCalendar.kt
@@ -32,12 +32,12 @@ open class BpkCalendar @JvmOverloads constructor(
   }
 
   override fun onYearChanged(year: Int) {
-    this.post { updateYearPill(year) }
+    updateYearPill(year)
   }
 
   private fun updateYearPill(year: Int) {
     val currentYear = Calendar.getInstance().get(Calendar.YEAR)
-    year_pill_view.visibility = if (currentYear == year) View.GONE else View.VISIBLE
     year_pill_view.message = year.toString()
+    year_pill_view.visibility = if (currentYear == year) View.GONE else View.VISIBLE
   }
 }

--- a/Backpack/src/main/java/net/skyscanner/backpack/calendar/view/CalendarView.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/calendar/view/CalendarView.kt
@@ -18,7 +18,6 @@ package net.skyscanner.backpack.calendar.view
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.View
 import android.view.ViewConfiguration
 import android.widget.AbsListView
 import android.widget.ListView
@@ -64,21 +63,6 @@ internal class CalendarView constructor(
     this.setDrawSelectorOnTop(false)
 
     setUpListView()
-  }
-
-  private val measureAndLayout = Runnable {
-    measure(
-      View.MeasureSpec.makeMeasureSpec(width, View.MeasureSpec.EXACTLY),
-      View.MeasureSpec.makeMeasureSpec(height, View.MeasureSpec.UNSPECIFIED))
-    layout(left, top, right, bottom)
-  }
-
-  override fun requestLayout() {
-    super.requestLayout()
-
-    // This is required for the bridged component to render correctly
-    // based on: https://github.com/facebook/react-native/blob/1151c096dab17e5d9a6ac05b61aacecd4305f3db/ReactAndroid/src/main/java/com/facebook/react/views/picker/ReactPicker.java#L75
-    this.post(measureAndLayout)
   }
 
   override fun updateContent() {


### PR DESCRIPTION
Removing all the logic we had to make the RN bridge work, I'm changing the bridge implementation to handle layout in a better way and moving all "hacks" to that code, so the native Android version can stay clean.

As an added benefit the year pill now works when rendered in the same UI thread 🎉 

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
