### PR TITLE
[NO-JIRA] Overlay wrapper

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/button/BpkButton.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/button/BpkButton.kt
@@ -18,6 +18,7 @@ import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.widget.TextViewCompat
 import net.skyscanner.backpack.R
+import net.skyscanner.backpack.util.createContextThemeOverlayWrapper
 
 private fun getStyle(context: Context, attrs: AttributeSet?): Int {
   val attr = context.theme.obtainStyledAttributes(attrs, R.styleable.BpkButton, 0, 0)
@@ -40,7 +41,8 @@ open class BpkButton : AppCompatButton {
   constructor(context: Context, type: Type) : this(context, null, getStyle(type), type)
   constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, getStyle(context, attrs))
   constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : this(context, attrs, defStyleAttr, Type.Primary)
-  constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, type: Type) : super(context, attrs, defStyleAttr) {
+  constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, type: Type)
+    : super(createContextThemeOverlayWrapper(context, attrs), attrs, defStyleAttr) {
     this.initialType = type
     initialize(attrs, defStyleAttr)
   }

--- a/Backpack/src/main/java/net/skyscanner/backpack/toggle/BpkSwitch.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/toggle/BpkSwitch.kt
@@ -5,8 +5,15 @@ import android.content.res.ColorStateList
 import android.util.AttributeSet
 import androidx.appcompat.widget.SwitchCompat
 import net.skyscanner.backpack.R
+import net.skyscanner.backpack.util.createContextThemeOverlayWrapper
 import net.skyscanner.backpack.util.createContextThemeWrapper
 import net.skyscanner.backpack.util.getColor
+import net.skyscanner.backpack.util.withContextWrappers
+
+private fun wrapContext(context: Context, attrs: AttributeSet?) = withContextWrappers(context,
+  { createContextThemeWrapper(it, attrs, androidx.appcompat.R.attr.switchStyle) },
+  { createContextThemeOverlayWrapper(it, attrs) }
+)
 
 /**
  * BpkSwitch allow users to toggle between two states, on or off.
@@ -21,9 +28,13 @@ open class BpkSwitch @JvmOverloads constructor(
   context: Context,
   attrs: AttributeSet? = null,
   defStyleAttr: Int = R.attr.bpkSwitchStyle
-) : SwitchCompat(createContextThemeWrapper(context, attrs, androidx.appcompat.R.attr.switchStyle), attrs, defStyleAttr) {
+) : SwitchCompat(wrapContext(context, attrs), attrs, defStyleAttr) {
 
   init {
+    initialize(attrs, defStyleAttr)
+  }
+
+  fun initialize(attrs: AttributeSet?, defStyleAttr: Int) {
     val a = context.theme.obtainStyledAttributes(attrs, R.styleable.BpkSwitch, defStyleAttr, 0)
     val primaryColor = a.getColor(R.styleable.BpkSwitch_switchPrimaryColor, getColor(R.color.bpkBlue500))
     a.recycle()

--- a/Backpack/src/main/java/net/skyscanner/backpack/util/ThemesUtil.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/util/ThemesUtil.kt
@@ -1,6 +1,7 @@
 package net.skyscanner.backpack.util
 
 import android.content.Context
+import android.content.ContextWrapper
 import android.util.AttributeSet
 import android.util.TypedValue
 import androidx.appcompat.view.ContextThemeWrapper
@@ -38,9 +39,75 @@ class ThemesUtil {
  * @param attributeSet List of attributes for the current component.
  * @param styleAttr Style attribute to provide default values for the current context.
  */
-internal fun createContextThemeWrapper(context: Context, attributeSet: AttributeSet?, styleAttr: Int): ContextThemeWrapper {
+internal fun createContextThemeWrapper(context: Context, attributeSet: AttributeSet?, styleAttr: Int): Context {
   val a = context.obtainStyledAttributes(attributeSet, intArrayOf(styleAttr), 0, 0)
   val themeId = a.getResourceId(0, 0)
   a.recycle()
   return ContextThemeWrapper(context, themeId)
 }
+
+/**
+ * Return a [ContextThemeWrapper] wrapping the current context with [R.attr.bpkThemeOverlay] if `context`
+ * has been wrapped with [ThemeOverlayEnforcement]
+ *
+ * @param context Context to be wrapped.
+ * @param attributeSet List of attributes for the current component.
+ */
+internal fun createContextThemeOverlayWrapper(context: Context, attributeSet: AttributeSet?): Context {
+  val a = context.obtainStyledAttributes(attributeSet, intArrayOf(R.attr.bpkThemeOverlay), 0, 0)
+  val themeId = a.getResourceId(0, 0)
+  a.recycle()
+
+  if (shouldEnforceThemeOverlay(context)) {
+    return ContextThemeWrapper(context, themeId)
+  }
+
+  return context
+}
+
+/**
+ * Apply a list of wrappers to a context. The order of precedence is last to first, meaning
+ * the last wrapper will be checked first and then the one before than, an so on.
+ *
+ * @param context The base context.
+ * @param wrappers A list of functions to wrap the context.
+ */
+internal fun withContextWrappers(context: Context, vararg wrappers: (Context) -> Context): Context {
+  return wrappers.fold(context) { acc, wrapper -> wrapper(acc) }
+}
+
+/**
+ * Check if the context, or any of its base contexts, are wrapped with ThemeOverlayEnforcement.
+ *
+ * @see [ThemeOverlayEnforcement]
+ */
+private fun shouldEnforceThemeOverlay(context: Context?): Boolean {
+  if (context == null) {
+    return false
+  }
+
+  return context is ThemeOverlayEnforcement ||
+    context is ContextWrapper && shouldEnforceThemeOverlay(context.baseContext)
+}
+
+/**
+ * ThemeOverlayEnforcement is a dummy [ContextWrapper] used to indicate to Backpack components
+ * that the theme defined inside the `bpkThemeOverlay` should be used to style components.
+ *
+ * Consider this theme:
+ *
+ * ```xml
+ *  <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+ *    <item name="colorPrimary">@color/bpkBlue500</item>
+ *    <item name="colorPrimaryDark">@color/bpkBlue700</item>
+ *    <item name="colorAccent">@color/bpkGreen500</item>
+ *    <item name="android:windowBackground">@color/bpkWhite</item>
+ *    <item name="bpkThemeOverlay">@style/DohaTheme</item>
+ *  </style>
+ *```
+ *
+ * Now you can wrap any context during runtime with [ThemeOverlayEnforcement] to apply "DohaTheme"
+ * to all Backpack components.
+ *
+ */
+class ThemeOverlayEnforcement(context: Context) : ContextWrapper(context)

--- a/Backpack/src/main/res/values/attrs.xml
+++ b/Backpack/src/main/res/values/attrs.xml
@@ -2,6 +2,7 @@
 <resources>
 
   <attr name="bpkPrimaryColor" format="color" />
+  <attr name="bpkThemeOverlay" format="reference" />
 
   <declare-styleable name="BpkBadge">
     <!-- type of badge -->

--- a/app/src/main/java/net/skyscanner/backpack/demo/BpkBaseActivity.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/BpkBaseActivity.kt
@@ -13,6 +13,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.res.ResourcesCompat
 import io.github.inflationx.viewpump.ViewPumpContextWrapper
 import net.skyscanner.backpack.demo.data.SharedPreferences
+import net.skyscanner.backpack.util.ThemeOverlayEnforcement
 
 @SuppressLint("Registered")
 open class BpkBaseActivity : AppCompatActivity() {
@@ -30,7 +31,7 @@ open class BpkBaseActivity : AppCompatActivity() {
   }
 
   override fun attachBaseContext(newBase: Context) {
-    super.attachBaseContext(ViewPumpContextWrapper.wrap(newBase))
+    super.attachBaseContext(ThemeOverlayEnforcement(ViewPumpContextWrapper.wrap(newBase)))
   }
 
   override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/net/skyscanner/backpack/demo/SettingsActivity.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/SettingsActivity.kt
@@ -1,5 +1,6 @@
 package net.skyscanner.backpack.demo
 
+import android.content.Context
 import android.os.Bundle
 import android.view.MenuItem
 import android.view.View
@@ -10,6 +11,7 @@ import androidx.appcompat.widget.Toolbar
 import net.skyscanner.backpack.demo.components.SettingsThemeOption
 import net.skyscanner.backpack.demo.data.SharedPreferences
 import net.skyscanner.backpack.toggle.BpkSwitch
+import net.skyscanner.backpack.util.ThemeOverlayEnforcement
 
 class SettingsActivity : AppCompatActivity() {
   private lateinit var themes: List<SettingsThemeOption>
@@ -20,6 +22,10 @@ class SettingsActivity : AppCompatActivity() {
   )
 
   private var restartMessageShown = false
+
+  override fun attachBaseContext(newBase: Context) {
+    super.attachBaseContext(ThemeOverlayEnforcement(newBase))
+  }
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,20 +2,32 @@
 <resources>
   <style name="LondonTheme" parent="AppTheme">
     <item name="colorPrimary">#ED1B28</item>
-    <item name="bpkSwitchStyle">@style/BpkSwitch.Themed</item>
+    <item name="bpkThemeOverlay">@style/LondonTheme.BpkOverlay</item>
+  </style>
+
+  <style name="LondonTheme.BpkOverlay" parent="">
+    <item name="bpkSwitchStyle">@style/LondonThemeBpkSwitch</item>
     <item name="bpkButtonPrimaryStyle">@style/LondonThemeButtonPrimary</item>
     <item name="bpkButtonSecondaryStyle">@style/LondonThemeButtonSecondary</item>
   </style>
 
   <style name="DohaTheme" parent="AppTheme">
     <item name="colorPrimary">#9B104C</item>
-    <item name="bpkSwitchStyle">@style/BpkSwitch.Themed</item>
+    <item name="bpkThemeOverlay">@style/DohaTheme.BpkOverlay</item>
+  </style>
+
+  <style name="DohaTheme.BpkOverlay" parent="AppTheme">
+    <item name="bpkSwitchStyle">@style/DohaThemeBpkSwitch</item>
     <item name="bpkButtonPrimaryStyle">@style/DohaThemeButtonPrimary</item>
     <item name="bpkButtonSecondaryStyle">@style/DohaThemeButtonSecondary</item>
   </style>
 
-  <style name="BpkSwitch.Themed" parent="">
-    <item name="switchPrimaryColor">?colorPrimary</item>
+  <style name="DohaThemeBpkSwitch" parent="">
+    <item name="switchPrimaryColor">@color/bpkYellow900</item>
+  </style>
+
+  <style name="LondonThemeBpkSwitch" parent="">
+    <item name="switchPrimaryColor">#ED1B28</item>
   </style>
 
   <style name="DohaThemeButtonPrimary">

--- a/docs/THEMING.md
+++ b/docs/THEMING.md
@@ -22,3 +22,30 @@ Define a theme in `themes.xml`
 You can theme all instances of `BpkSwitch` in your app/activity by setting the `theme` to `MyCustomTheme`, or change it to a single view by either setting the `style` to `@style/BpkSwitch.Red` or to your custom theme.
 
 __For supported attributes check each component's documentation.__
+
+## Theme overlays and runtime theming
+
+Another option to apply a custom theme during runtime without having to change your application/activity theme is to 
+use the `bpkThemeOverlay` attribute.
+
+E.g.:
+
+```xml
+ <style name="AppTheme">
+    <item name="bpkThemeOverlay">@style/MyCustomTheme</item>
+  </style>
+```
+
+**By default this attribute will have no effect**, in order to enforce it you need to wrapped the context with `ThemeOverlayEnforcement`.
+
+E.g.:
+
+```Kotlin
+override fun attachBaseContext(newBase: Context) {
+  if (useBpkTheme) {
+    super.attachBaseContext(ThemeOverlayEnforcement(newBase))
+  } else {
+    super.attachBaseContext(newBase)
+  }
+}
+```


### PR DESCRIPTION
This adds `bpkThemeOverlay` attribute and the `ThemeOverlayEnforcement` class to wrap a context and indicate `bpkThemeOverlay` should be used.

This means we can now just define `bpkThemeOverlay` in the current app theme and wrap the context with `ThemeOverlayEnforcement` based on a config flag during runtime to enforce its usage.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
