### PR TITLE
Colored calendar refinements

### DIFF
--- a/Backpack/src/androidTest/java/net/skyscanner/backpack/calendar/view/MonthViewKtTest.kt
+++ b/Backpack/src/androidTest/java/net/skyscanner/backpack/calendar/view/MonthViewKtTest.kt
@@ -41,7 +41,7 @@ class MonthViewKtTest {
     )
     )
 
-    val drawingPaintMap = calendarDrawingParams.toDrawingPaintMap()
+    val drawingPaintMap = calendarDrawingParams.toDrawingPaintMap(isSelectedColor = false)
 
     assertEquals(drawingPaintMap.getValue(day_group1_1).color, group1Color)
     assertEquals(drawingPaintMap.getValue(day_group1_2).color, group1Color)

--- a/Backpack/src/androidTest/java/net/skyscanner/backpack/calendar/view/NonDrawnDaysOffset.kt
+++ b/Backpack/src/androidTest/java/net/skyscanner/backpack/calendar/view/NonDrawnDaysOffset.kt
@@ -119,4 +119,16 @@ class NonDrawnDaysOffset {
       // unused
     }
   }
+
+  private fun CalendarDay.Companion.of(str: String): CalendarDay? {
+    val yearMonthDay = str.split("-")
+    if (yearMonthDay.size == 3) {
+      return CalendarDay(
+        yearMonthDay[0].toInt(),
+        yearMonthDay[1].toInt() - 1,
+        yearMonthDay[2].toInt()
+      )
+    }
+    return null
+  }
 }

--- a/Backpack/src/androidTest/java/net/skyscanner/backpack/calendar/view/NonDrawnDaysOffset.kt
+++ b/Backpack/src/androidTest/java/net/skyscanner/backpack/calendar/view/NonDrawnDaysOffset.kt
@@ -1,0 +1,122 @@
+package net.skyscanner.backpack.calendar.view
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import net.skyscanner.backpack.calendar.model.CalendarDay
+import net.skyscanner.backpack.calendar.model.CalendarDrawingParams
+import net.skyscanner.backpack.calendar.model.CalendarSelection
+import net.skyscanner.backpack.calendar.presenter.BpkCalendarController
+import net.skyscanner.backpack.calendar.presenter.SelectionType
+import org.junit.Assert
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Locale
+
+@RunWith(AndroidJUnit4::class)
+class NonDrawnDaysOffset {
+
+  @Test
+  fun givenFirstFewDaysInMonth_whenGetOffset_thenNoOffset() {
+    val monthView = givenMonthView(
+      locale = Locale.US,
+      startDate = CalendarDay.of("2019-01-02")!!,
+      drawMonth = 2
+    )
+
+    val offset = monthView.getNonDrawnDaysOffset()
+
+    Assert.assertEquals(0, offset)
+  }
+
+  @Test
+  fun givenMidMonthAndSunWeekStart_whenGetOffset_thenOffsetToPreviousSat() {
+    val monthView = givenMonthView(
+      locale = Locale.US,
+      startDate = CalendarDay.of("2019-02-13")!!,
+      drawMonth = 2
+    )
+
+    val offset = monthView.getNonDrawnDaysOffset()
+
+    Assert.assertEquals(9, offset)
+  }
+
+  @Test
+  fun givenMidMonthAndMonWeekStart_whenGetOffset_thenOffsetToPreviousSun() {
+    val monthView = givenMonthView(
+      locale = Locale.GERMANY,
+      startDate = CalendarDay.of("2019-02-13")!!,
+      drawMonth = 2
+    )
+
+    val offset = monthView.getNonDrawnDaysOffset()
+
+    Assert.assertEquals(10, offset)
+  }
+
+  @Test
+  fun givenLastDayInMonthOnSunAndSunWeekStart_whenGetOffset_thenOffsetToPreviousSun() {
+    val monthView = givenMonthView(
+      locale = Locale.US,
+      startDate = CalendarDay.of("2019-03-31")!!,
+      drawMonth = 3
+    )
+
+    val offset = monthView.getNonDrawnDaysOffset()
+
+    Assert.assertEquals(30, offset)
+  }
+
+  @Test
+  fun givenLastDayInMonthOnSunAndMonWeekStart_whenGetOffset_thenOffsetToPreviousMon() {
+    val monthView = givenMonthView(
+      locale = Locale.GERMANY,
+      startDate = CalendarDay.of("2019-03-31")!!,
+      drawMonth = 3
+    )
+
+    val offset = monthView.getNonDrawnDaysOffset()
+
+    Assert.assertEquals(24, offset)
+  }
+
+  @Test
+  fun givenOtherMonthIsDrawn_whenGetOffset_thenNoOffset() {
+    val monthView = givenMonthView(
+      locale = Locale.GERMANY,
+      startDate = CalendarDay.of("2019-03-31")!!,
+      drawMonth = 4
+    )
+
+    val offset = monthView.getNonDrawnDaysOffset()
+
+    Assert.assertEquals(0, offset)
+  }
+
+  private fun givenMonthView(locale: Locale, startDate: CalendarDay, drawMonth: Int): MonthView {
+    val context = InstrumentationRegistry.getInstrumentation().targetContext
+    val monthView = MonthView(context = context)
+
+    monthView.controller = object : TestBpkCalendarController() {
+      override val locale: Locale
+        get() {
+          return locale
+        }
+      override val startDate: CalendarDay
+        get() {
+          return startDate
+        }
+    }
+    monthView.calendarDrawingParams = CalendarDrawingParams(2019, drawMonth - 1, null, null)
+    return monthView
+  }
+
+  abstract class TestBpkCalendarController : BpkCalendarController(SelectionType.RANGE) {
+    override val isRtl: Boolean
+      get() = false // unused
+
+    override fun onRangeSelected(range: CalendarSelection) {
+      // unused
+    }
+  }
+}

--- a/Backpack/src/main/java/net/skyscanner/backpack/calendar/model/CalendarColoring.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/calendar/model/CalendarColoring.kt
@@ -7,6 +7,7 @@ data class CalendarColoring(
 )
 
 data class ColoredBucket(
-  @ColorInt val color: Int,
-  val days: Set<CalendarDay>
+  @ColorInt val color: Int?,
+  val days: Set<CalendarDay>,
+  @ColorInt val selectedColor: Int? = color
 )

--- a/Backpack/src/main/java/net/skyscanner/backpack/calendar/model/CalendarDay.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/calendar/model/CalendarDay.kt
@@ -19,7 +19,19 @@ data class CalendarDay(
       return utcCalendar.toCalendarDay()
     }
 
-    fun today(): CalendarDay = of(System.currentTimeMillis())
+    fun of(str: String): CalendarDay? {
+      val yearMonthDay = str.split("-")
+      if (yearMonthDay.size == 3) {
+        return CalendarDay(
+          yearMonthDay[0].toInt(),
+          yearMonthDay[1].toInt() - 1,
+          yearMonthDay[2].toInt()
+        )
+      }
+      return null
+    }
+
+    fun today(): CalendarDay = Calendar.getInstance().toCalendarDay()
 
     fun utcCalendar(): Calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
   }

--- a/Backpack/src/main/java/net/skyscanner/backpack/calendar/model/CalendarDay.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/calendar/model/CalendarDay.kt
@@ -19,18 +19,6 @@ data class CalendarDay(
       return utcCalendar.toCalendarDay()
     }
 
-    fun of(str: String): CalendarDay? {
-      val yearMonthDay = str.split("-")
-      if (yearMonthDay.size == 3) {
-        return CalendarDay(
-          yearMonthDay[0].toInt(),
-          yearMonthDay[1].toInt() - 1,
-          yearMonthDay[2].toInt()
-        )
-      }
-      return null
-    }
-
     fun today(): CalendarDay = Calendar.getInstance().toCalendarDay()
 
     fun utcCalendar(): Calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"))

--- a/Backpack/src/main/java/net/skyscanner/backpack/calendar/view/MonthView.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/calendar/view/MonthView.kt
@@ -526,8 +526,9 @@ internal class MonthView @JvmOverloads constructor(
       0
     } else {
       var dayOffset = dayOfWeekStart - weekStart
-      if (dayOfWeekStart < weekStart)
+      if (dayOfWeekStart < weekStart){
         dayOffset += numberOfDaysInAWeek
+      }
       dayOffset
     }
 

--- a/Backpack/src/main/java/net/skyscanner/backpack/calendar/view/MonthView.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/calendar/view/MonthView.kt
@@ -106,7 +106,7 @@ internal class MonthView @JvmOverloads constructor(
   private var coloredSelectedPaints = mapOf<CalendarDay, Paint>()
 
   @VisibleForTesting
-  lateinit var calendarDrawingParams: CalendarDrawingParams
+  internal lateinit var calendarDrawingParams: CalendarDrawingParams
 
   private var dayOfWeekStart = 0
   private var hasToday = false
@@ -210,7 +210,7 @@ internal class MonthView @JvmOverloads constructor(
   }
 
   @VisibleForTesting
-  fun getNonDrawnDaysOffset(): Int {
+  internal fun getNonDrawnDaysOffset(): Int {
     controller?.let {
       val shouldApplyOffset =
         calendarDrawingParams.year == it.startDate.year && calendarDrawingParams.month == it.startDate.month && it.startDate.day > numberOfDaysInAWeek

--- a/Backpack/src/main/java/net/skyscanner/backpack/calendar/view/MonthView.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/calendar/view/MonthView.kt
@@ -196,6 +196,8 @@ internal class MonthView @JvmOverloads constructor(
 
     weekStart = calendar.firstDayOfWeek
 
+    monthHeaderString = controller?.getLocalizedDate(calendar.time, MONTH_HEADLINE_PATTERN) ?: ""
+
     numberOfCells = getDaysInMonth(params.month, params.year)
     for (i in 0 until numberOfCells) {
       val day = i + 1

--- a/Backpack/src/main/java/net/skyscanner/backpack/calendar/view/MonthView.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/calendar/view/MonthView.kt
@@ -526,7 +526,7 @@ internal class MonthView @JvmOverloads constructor(
       0
     } else {
       var dayOffset = dayOfWeekStart - weekStart
-      if (dayOfWeekStart < weekStart){
+      if (dayOfWeekStart < weekStart) {
         dayOffset += numberOfDaysInAWeek
       }
       dayOffset

--- a/Backpack/src/main/java/net/skyscanner/backpack/calendar/view/MonthView.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/calendar/view/MonthView.kt
@@ -186,8 +186,8 @@ internal class MonthView @JvmOverloads constructor(
     hasToday = false
     today = -1
     calendarDrawingParams = params
-    coloredCirclePaints = params.toDrawingPaintMap()
-    coloredSelectedPaints = params.toSelectedDrawingPaintMap()
+    coloredCirclePaints = params.toDrawingPaintMap(isSelectedColor = false)
+    coloredSelectedPaints = params.toDrawingPaintMap(isSelectedColor = true)
 
     calendar.set(Calendar.MONTH, params.month)
     calendar.set(Calendar.YEAR, params.year)
@@ -592,29 +592,14 @@ internal class MonthView @JvmOverloads constructor(
   }
 }
 
-internal fun CalendarDrawingParams.toDrawingPaintMap(): Map<CalendarDay, Paint> {
+internal fun CalendarDrawingParams.toDrawingPaintMap(isSelectedColor: Boolean): Map<CalendarDay, Paint> {
   return mutableMapOf<CalendarDay, Paint>().also { resultMap ->
     this.calendarColoring?.coloredBuckets?.forEach { bucket ->
-      if (bucket.color != null) {
+      val bucketColor = if (isSelectedColor) bucket.selectedColor else bucket.color
+      if (bucketColor != null) {
         val paint = Paint().apply {
           style = Style.FILL_AND_STROKE
-          color = bucket.color
-        }
-        bucket.days.forEach { day ->
-          resultMap[day] = paint
-        }
-      }
-    }
-  }.toMap()
-}
-
-internal fun CalendarDrawingParams.toSelectedDrawingPaintMap(): Map<CalendarDay, Paint> {
-  return mutableMapOf<CalendarDay, Paint>().also { resultMap ->
-    this.calendarColoring?.coloredBuckets?.forEach { bucket ->
-      if (bucket.selectedColor != null) {
-        val paint = Paint().apply {
-          style = Style.FILL_AND_STROKE
-          color = bucket.selectedColor
+          color = bucketColor
         }
         bucket.days.forEach { day ->
           resultMap[day] = paint

--- a/Backpack/src/main/java/net/skyscanner/backpack/calendar/view/WeekdayHeaderView.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/calendar/view/WeekdayHeaderView.kt
@@ -31,7 +31,7 @@ internal class WeekdayHeaderView @JvmOverloads constructor(
 
   internal fun initializeWithLocale(locale: Locale) {
     val simpleDateFormat = SimpleDateFormat("ccc", locale)
-    val calendar = Calendar.getInstance()
+    val calendar = Calendar.getInstance(locale)
     val weekStart = calendar.firstDayOfWeek
     val numberOfDaysInWeek = 7
 

--- a/Backpack/src/main/res/layout/view_bpk_calendar_weekday_header.xml
+++ b/Backpack/src/main/res/layout/view_bpk_calendar_weekday_header.xml
@@ -12,8 +12,8 @@
     android:layout_height="wrap_content"
     android:orientation="horizontal"
     android:gravity="center_vertical"
-    android:paddingTop="@dimen/bpkSpacingLg"
-    android:paddingBottom="@dimen/bpkSpacingLg"
+    android:paddingTop="@dimen/bpkSpacingBase"
+    android:paddingBottom="@dimen/bpkSpacingBase"
     >
 
     <net.skyscanner.backpack.text.BpkText

--- a/Backpack/src/main/res/layout/view_bpk_calendar_weekday_header.xml
+++ b/Backpack/src/main/res/layout/view_bpk_calendar_weekday_header.xml
@@ -1,104 +1,113 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<FrameLayout
   xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:tools="http://schemas.android.com/tools"
   xmlns:app="http://schemas.android.com/apk/res-auto"
   android:layout_width="match_parent"
   android:layout_height="wrap_content"
-  android:orientation="vertical">
+  >
 
-  <androidx.constraintlayout.widget.ConstraintLayout
+  <LinearLayout
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:paddingStart="@dimen/bpkSpacingBase"
-    android:paddingEnd="@dimen/bpkSpacingBase">
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:paddingTop="@dimen/bpkSpacingLg"
+    android:paddingBottom="@dimen/bpkSpacingLg"
+    >
 
     <net.skyscanner.backpack.text.BpkText
       android:id="@+id/first_weekday_label"
-      android:layout_width="wrap_content"
+      android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:textColor="@color/bpkGray500"
-      android:paddingTop="@dimen/bpkSpacingLg"
-      android:paddingBottom="@dimen/bpkSpacingLg"
-      app:layout_constraintStart_toStartOf="parent"
-      app:layout_constraintEnd_toStartOf="@+id/second_weekday_label"
-      app:chainUseRtl="true"
-      app:layout_constraintHorizontal_chainStyle="spread_inside"
-      tools:text="Mon"/>
+      android:layout_weight="1"
+      android:gravity="center"
+      android:lines="1"
+      android:ellipsize="end"
+      tools:text="Mon"
+      />
 
     <net.skyscanner.backpack.text.BpkText
       android:id="@+id/second_weekday_label"
-      android:layout_width="wrap_content"
+      android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:textColor="@color/bpkGray500"
-      android:paddingTop="@dimen/bpkSpacingLg"
-      android:paddingBottom="@dimen/bpkSpacingLg"
-      app:layout_constraintStart_toEndOf="@+id/first_weekday_label"
-      app:layout_constraintEnd_toStartOf="@+id/third_weekday_label"
-      tools:text="Tue"/>
+      android:layout_weight="1"
+      android:gravity="center"
+      android:lines="1"
+      android:ellipsize="end"
+      tools:text="Tue"
+      />
 
     <net.skyscanner.backpack.text.BpkText
       android:id="@+id/third_weekday_label"
-      android:layout_width="wrap_content"
+      android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:textColor="@color/bpkGray500"
-      android:paddingTop="@dimen/bpkSpacingLg"
-      android:paddingBottom="@dimen/bpkSpacingLg"
-      app:layout_constraintStart_toEndOf="@+id/second_weekday_label"
-      app:layout_constraintEnd_toStartOf="@+id/fourth_weekday_label"
-      tools:text="Wed"/>
+      android:layout_weight="1"
+      android:gravity="center"
+      android:lines="1"
+      android:ellipsize="end"
+      tools:text="Wed"
+      />
 
     <net.skyscanner.backpack.text.BpkText
       android:id="@+id/fourth_weekday_label"
-      android:layout_width="wrap_content"
+      android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:textColor="@color/bpkGray500"
-      android:paddingTop="@dimen/bpkSpacingLg"
-      android:paddingBottom="@dimen/bpkSpacingLg"
-      app:layout_constraintStart_toEndOf="@+id/third_weekday_label"
-      app:layout_constraintEnd_toStartOf="@+id/fifth_weekday_label"
-      tools:text="Thu"/>
+      android:layout_weight="1"
+      android:gravity="center"
+      android:lines="1"
+      android:ellipsize="end"
+      tools:text="Thu"
+      />
 
     <net.skyscanner.backpack.text.BpkText
       android:id="@+id/fifth_weekday_label"
-      android:layout_width="wrap_content"
+      android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:textColor="@color/bpkGray500"
-      android:paddingTop="@dimen/bpkSpacingLg"
-      android:paddingBottom="@dimen/bpkSpacingLg"
-      app:layout_constraintStart_toEndOf="@+id/fourth_weekday_label"
-      app:layout_constraintEnd_toStartOf="@+id/sixth_weekday_label"
-      tools:text="Fri"/>
+      android:layout_weight="1"
+      android:gravity="center"
+      android:lines="1"
+      android:ellipsize="end"
+      tools:text="Fri"
+      />
 
     <net.skyscanner.backpack.text.BpkText
       android:id="@+id/sixth_weekday_label"
-      android:layout_width="wrap_content"
+      android:layout_width="0dp"
       android:layout_height="wrap_content"
       android:textColor="@color/bpkGray500"
-      android:paddingTop="@dimen/bpkSpacingLg"
-      android:paddingBottom="@dimen/bpkSpacingLg"
-      app:layout_constraintStart_toEndOf="@+id/fifth_weekday_label"
-      app:layout_constraintEnd_toStartOf="@+id/seventh_weekday_label"
-      tools:text="Sat"/>
+      android:layout_weight="1"
+      android:gravity="center"
+      android:lines="1"
+      android:ellipsize="end"
+      tools:text="Sat"
+      />
 
     <net.skyscanner.backpack.text.BpkText
       android:id="@+id/seventh_weekday_label"
-      android:layout_width="wrap_content"
+      android:layout_width="0dp"
       android:layout_height="wrap_content"
+      android:gravity="center"
       android:textColor="@color/bpkGray500"
-      android:paddingTop="@dimen/bpkSpacingLg"
-      android:paddingBottom="@dimen/bpkSpacingLg"
-      app:layout_constraintStart_toEndOf="@+id/sixth_weekday_label"
-      app:layout_constraintEnd_toEndOf="parent"
-      tools:text="Sun"/>
+      android:layout_weight="1"
+      android:lines="1"
+      android:ellipsize="end"
+      tools:text="Sun Sun"
+      />
 
-  </androidx.constraintlayout.widget.ConstraintLayout>
+  </LinearLayout>
 
   <View
     android:layout_width="match_parent"
     android:layout_height="1dp"
     android:background="@color/bpkGray100"
     android:visibility="visible"
-    app:layout_constraintBottom_toBottomOf="parent"/>
+    android:layout_gravity="bottom"
+    />
 
-</LinearLayout>
+</FrameLayout>

--- a/app/src/main/java/net/skyscanner/backpack/demo/data/ExampleBpkCalendarController.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/data/ExampleBpkCalendarController.kt
@@ -49,7 +49,7 @@ class ExampleBpkCalendarController(
 }
 
 @VisibleForTesting
-fun multiColoredExampleCalendarColoring(
+internal fun multiColoredExampleCalendarColoring(
   colorOffset: Long,
   startDate: CalendarDay,
   endDate: CalendarDay,

--- a/app/src/main/java/net/skyscanner/backpack/demo/data/ExampleBpkCalendarController.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/data/ExampleBpkCalendarController.kt
@@ -47,19 +47,21 @@ class ExampleBpkCalendarController(
   }
 
   private fun multiColoredExampleCalendarColoring(): CalendarColoring {
-    val daysBetweenStartAndEnd = TimeUnit.DAYS.convert(endDate.date.time - startDate.date.time, TimeUnit.MILLISECONDS)
+    val daysBetweenStartAndEnd = TimeUnit.DAYS.convert(endDate.date.time - startDate.date.time, TimeUnit.MILLISECONDS) + 1
     val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
     val redSet = mutableSetOf<CalendarDay>()
     val yellowSet = mutableSetOf<CalendarDay>()
     val greenSet = mutableSetOf<CalendarDay>()
     val greySet = mutableSetOf<CalendarDay>()
+    val emptySet = mutableSetOf<CalendarDay>()
     for (i in 0 until daysBetweenStartAndEnd) {
       val shiftedIterator = i + colorGenerationOffset
       when {
-        shiftedIterator % 4 == 0L -> redSet
-        shiftedIterator % 4 == 1L -> yellowSet
-        shiftedIterator % 4 == 2L -> greenSet
-        shiftedIterator % 4 == 3L -> greySet
+        shiftedIterator % 5 == 0L -> redSet
+        shiftedIterator % 5 == 1L -> yellowSet
+        shiftedIterator % 5 == 2L -> greenSet
+        shiftedIterator % 5 == 3L -> greySet
+        shiftedIterator % 5 == 4L -> emptySet
         else -> mutableSetOf()
       }.add(CalendarDay(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH), calendar.get(Calendar.DAY_OF_MONTH)))
       calendar.add(Calendar.DATE, 1)
@@ -68,8 +70,9 @@ class ExampleBpkCalendarController(
       setOf(
         ColoredBucket(ContextCompat.getColor(context, R.color.bpkRed500), redSet),
         ColoredBucket(ContextCompat.getColor(context, R.color.bpkYellow500), yellowSet),
-        ColoredBucket(ContextCompat.getColor(context, R.color.bpkGreen500), greenSet),
-        ColoredBucket(ContextCompat.getColor(context, R.color.bpkGray100), greySet)
+        ColoredBucket(ContextCompat.getColor(context, R.color.bpkGreen500), greenSet, ContextCompat.getColor(context, R.color.bpkGreen900)),
+        ColoredBucket(ContextCompat.getColor(context, R.color.bpkGray100), greySet),
+        ColoredBucket(null, emptySet, ContextCompat.getColor(context, R.color.bpkPink500))
       )
     )
   }

--- a/app/src/main/java/net/skyscanner/backpack/demo/data/ExampleBpkCalendarController.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/data/ExampleBpkCalendarController.kt
@@ -3,6 +3,7 @@ package net.skyscanner.backpack.demo.data
 import android.content.Context
 import android.text.TextUtils.getLayoutDirectionFromLocale
 import android.widget.Toast
+import androidx.annotation.VisibleForTesting
 import androidx.core.content.ContextCompat
 import androidx.core.view.ViewCompat.LAYOUT_DIRECTION_RTL
 import net.skyscanner.backpack.calendar.model.CalendarColoring
@@ -37,7 +38,7 @@ class ExampleBpkCalendarController(
   override val locale: Locale = Locale.getDefault()
   override val calendarColoring: CalendarColoring?
     get() = if (isColoredCalendar) {
-      multiColoredExampleCalendarColoring()
+      multiColoredExampleCalendarColoring(colorGenerationOffset, startDate, endDate, context)
     } else {
       null
     }
@@ -46,34 +47,44 @@ class ExampleBpkCalendarController(
     colorGenerationOffset += 1
   }
 
-  private fun multiColoredExampleCalendarColoring(): CalendarColoring {
-    val daysBetweenStartAndEnd = TimeUnit.DAYS.convert(endDate.date.time - startDate.date.time, TimeUnit.MILLISECONDS) + 1
-    val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
-    val redSet = mutableSetOf<CalendarDay>()
-    val yellowSet = mutableSetOf<CalendarDay>()
-    val greenSet = mutableSetOf<CalendarDay>()
-    val greySet = mutableSetOf<CalendarDay>()
-    val emptySet = mutableSetOf<CalendarDay>()
-    for (i in 0 until daysBetweenStartAndEnd) {
-      val shiftedIterator = i + colorGenerationOffset
-      when {
-        shiftedIterator % 5 == 0L -> redSet
-        shiftedIterator % 5 == 1L -> yellowSet
-        shiftedIterator % 5 == 2L -> greenSet
-        shiftedIterator % 5 == 3L -> greySet
-        shiftedIterator % 5 == 4L -> emptySet
-        else -> mutableSetOf()
-      }.add(CalendarDay(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH), calendar.get(Calendar.DAY_OF_MONTH)))
-      calendar.add(Calendar.DATE, 1)
-    }
-    return CalendarColoring(
-      setOf(
-        ColoredBucket(ContextCompat.getColor(context, R.color.bpkRed500), redSet),
-        ColoredBucket(ContextCompat.getColor(context, R.color.bpkYellow500), yellowSet),
-        ColoredBucket(ContextCompat.getColor(context, R.color.bpkGreen500), greenSet, ContextCompat.getColor(context, R.color.bpkGreen900)),
-        ColoredBucket(ContextCompat.getColor(context, R.color.bpkGray100), greySet),
-        ColoredBucket(null, emptySet, ContextCompat.getColor(context, R.color.bpkPink500))
-      )
-    )
+}
+
+@VisibleForTesting
+fun multiColoredExampleCalendarColoring(
+  colorOffset: Long,
+  startDate: CalendarDay,
+  endDate: CalendarDay,
+  context: Context
+): CalendarColoring {
+  val daysBetweenStartAndEnd = TimeUnit.DAYS.convert(endDate.date.time - startDate.date.time, TimeUnit.MILLISECONDS) + 1
+  val calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"))
+  calendar.set(Calendar.YEAR, startDate.year)
+  calendar.set(Calendar.MONTH, startDate.month)
+  calendar.set(Calendar.DAY_OF_MONTH, startDate.day)
+  val redSet = mutableSetOf<CalendarDay>()
+  val yellowSet = mutableSetOf<CalendarDay>()
+  val greenSet = mutableSetOf<CalendarDay>()
+  val greySet = mutableSetOf<CalendarDay>()
+  val emptySet = mutableSetOf<CalendarDay>()
+  for (i in 0 until daysBetweenStartAndEnd) {
+    val shiftedIterator = i + colorOffset
+    when {
+      shiftedIterator % 5 == 0L -> redSet
+      shiftedIterator % 5 == 1L -> yellowSet
+      shiftedIterator % 5 == 2L -> greenSet
+      shiftedIterator % 5 == 3L -> greySet
+      shiftedIterator % 5 == 4L -> emptySet
+      else -> mutableSetOf()
+    }.add(CalendarDay(calendar.get(Calendar.YEAR), calendar.get(Calendar.MONTH), calendar.get(Calendar.DAY_OF_MONTH)))
+    calendar.add(Calendar.DATE, 1)
   }
+  return CalendarColoring(
+    setOf(
+      ColoredBucket(ContextCompat.getColor(context, R.color.bpkRed500), redSet),
+      ColoredBucket(ContextCompat.getColor(context, R.color.bpkYellow500), yellowSet),
+      ColoredBucket(ContextCompat.getColor(context, R.color.bpkGreen500), greenSet, ContextCompat.getColor(context, R.color.bpkGreen900)),
+      ColoredBucket(ContextCompat.getColor(context, R.color.bpkGray100), greySet),
+      ColoredBucket(null, emptySet, ContextCompat.getColor(context, R.color.bpkPink500))
+    )
+  )
 }

--- a/app/src/main/java/net/skyscanner/backpack/demo/data/ExampleBpkCalendarController.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/data/ExampleBpkCalendarController.kt
@@ -46,7 +46,6 @@ class ExampleBpkCalendarController(
   fun newColors() {
     colorGenerationOffset += 1
   }
-
 }
 
 @VisibleForTesting

--- a/app/src/main/java/net/skyscanner/backpack/demo/stories/ColoredCalendarStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/stories/ColoredCalendarStory.kt
@@ -47,6 +47,7 @@ class ColoredCalendarStory : Story() {
           controller = ExampleBpkCalendarController(requireContext(), SelectionType.RANGE)
         }
       }
+      controller.isColoredCalendar = true
       bpkCalendar.setController(controller)
     }
   }


### PR DESCRIPTION
- Fixed 1 px white line in range when 2 dates dates selected besides each other (Pixel 2 XL)
- Introduced a new selected color and made original one optional (non-breaking)
- Unavailable dates are not useful for the first month -> we do not draw them
- Days header(Mon,Tue,Wed, ...) at the top were not perfectly aligned to days in the calendar
- Reduced days header padding (lg->base)
- Use the locale from the controller for first day of week everywhere

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
