### PR TITLE
[NO-JIRA] Correctly run snapshots before release

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/calendar/presenter/BpkCalendarController.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/calendar/presenter/BpkCalendarController.kt
@@ -100,7 +100,7 @@ abstract class BpkCalendarController(
       }
       is SingleDay -> {
         selectedRange.start = selection.selectedDay
-        selectedRange.end = selection.selectedDay
+        selectedRange.end = null
         onRangeSelected(SingleDay(selection.selectedDay))
       }
     }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "preinstall": "npx ensure-node-env",
     "emulator:build": "./gradlew build",
-    "emulator:test": "./gradlew cAT",
-    "emulator:boot": "$ANDROID_HOME/emulator/emulator -avd bpk-avd -no-snapshot  &",
+    "emulator:test": "./gradlew cAT app:verifyDebugAndroidTestScreenshotTest",
+    "emulator:boot": "$ANDROID_HOME/emulator/emulator -avd bpk-droid-avd -sdcard sd.img -no-snapshot &",
     "emulator:kill": "adb emu kill",
     "preemulator": "npm run emulator:boot",
     "emulator": "adb wait-for-device && sleep 5 && npm run emulator:build && npm run emulator:test",


### PR DESCRIPTION
This also fixes a small bug in the calendar (that was happening because we were not running snapshots before release)

This ensures we run all snapshot tests before release. We run them on CI too with the exception of `FlakyTests` which fail very often because of timeouts. Those we still want to check locally before releasing.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
