### PR TITLE
[BPK-2390] Disable ViewPump on Android Q

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/util/BpkViewPumpContextWrapper.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/util/BpkViewPumpContextWrapper.kt
@@ -1,0 +1,19 @@
+@file:JvmName("BpkViewPumpContextWrapper")
+
+package net.skyscanner.backpack.util
+
+import android.content.Context
+import android.content.ContextWrapper
+import io.github.inflationx.viewpump.ViewPumpContextWrapper
+
+class BpkViewPumpContextWrapper {
+  companion object {
+    fun wrap(context: Context): ContextWrapper {
+      return if (android.os.Build.VERSION.SDK_INT > android.os.Build.VERSION_CODES.P) {
+        ContextWrapper(context)
+      } else {
+        ViewPumpContextWrapper.wrap(context)
+      }
+    }
+  }
+}

--- a/Backpack/src/main/java/net/skyscanner/backpack/util/BpkViewPumpContextWrapper.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/util/BpkViewPumpContextWrapper.kt
@@ -5,11 +5,15 @@ import android.content.ContextWrapper
 import io.github.inflationx.viewpump.ViewPumpContextWrapper
 
 object BpkViewPumpContextWrapper {
-    fun wrap(context: Context): ContextWrapper {
-      return if (android.os.Build.VERSION.SDK_INT > android.os.Build.VERSION_CODES.P) {
-        ContextWrapper(context)
-      } else {
-        ViewPumpContextWrapper.wrap(context)
-      }
+  /**
+   * Disables Viewpump on Android Q and above.
+   * See https://github.com/InflationX/ViewPump/issues/21
+   */
+  fun wrap(context: Context): Context {
+    return if (android.os.Build.VERSION.SDK_INT > android.os.Build.VERSION_CODES.P) {
+      ContextWrapper(context)
+    } else {
+      ViewPumpContextWrapper.wrap(context)
+    }
   }
 }

--- a/Backpack/src/main/java/net/skyscanner/backpack/util/BpkViewPumpContextWrapper.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/util/BpkViewPumpContextWrapper.kt
@@ -1,5 +1,3 @@
-@file:JvmName("BpkViewPumpContextWrapper")
-
 package net.skyscanner.backpack.util
 
 import android.content.Context

--- a/Backpack/src/main/java/net/skyscanner/backpack/util/BpkViewPumpContextWrapper.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/util/BpkViewPumpContextWrapper.kt
@@ -4,14 +4,12 @@ import android.content.Context
 import android.content.ContextWrapper
 import io.github.inflationx.viewpump.ViewPumpContextWrapper
 
-class BpkViewPumpContextWrapper {
-  companion object {
+object BpkViewPumpContextWrapper {
     fun wrap(context: Context): ContextWrapper {
       return if (android.os.Build.VERSION.SDK_INT > android.os.Build.VERSION_CODES.P) {
         ContextWrapper(context)
       } else {
         ViewPumpContextWrapper.wrap(context)
       }
-    }
   }
 }

--- a/Backpack/src/main/java/net/skyscanner/backpack/util/BpkViewPumpContextWrapper.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/util/BpkViewPumpContextWrapper.kt
@@ -1,7 +1,6 @@
 package net.skyscanner.backpack.util
 
 import android.content.Context
-import android.content.ContextWrapper
 import io.github.inflationx.viewpump.ViewPumpContextWrapper
 
 object BpkViewPumpContextWrapper {
@@ -11,7 +10,7 @@ object BpkViewPumpContextWrapper {
    */
   fun wrap(context: Context): Context {
     return if (android.os.Build.VERSION.SDK_INT > android.os.Build.VERSION_CODES.P) {
-      ContextWrapper(context)
+      context
     } else {
       ViewPumpContextWrapper.wrap(context)
     }

--- a/app/src/main/java/net/skyscanner/backpack/demo/BpkBaseActivity.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/BpkBaseActivity.kt
@@ -11,8 +11,8 @@ import android.view.Menu
 import android.view.MenuItem
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.res.ResourcesCompat
-import io.github.inflationx.viewpump.ViewPumpContextWrapper
 import net.skyscanner.backpack.demo.data.SharedPreferences
+import net.skyscanner.backpack.util.BpkViewPumpContextWrapper
 import net.skyscanner.backpack.util.ThemeOverlayEnforcement
 
 @SuppressLint("Registered")
@@ -31,7 +31,7 @@ open class BpkBaseActivity : AppCompatActivity() {
   }
 
   override fun attachBaseContext(newBase: Context) {
-    super.attachBaseContext(ThemeOverlayEnforcement(ViewPumpContextWrapper.wrap(newBase)))
+    super.attachBaseContext(ThemeOverlayEnforcement(BpkViewPumpContextWrapper.wrap(newBase)))
   }
 
   override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
Disable `ViewPump` on Android-Q for now. This means the highlights can still be used on emulators and devices running a stable version of Android upto API-28

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
