### PR TITLE
[NO-JIRA] Fix calendar background

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/calendar/view/CalendarView.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/calendar/view/CalendarView.kt
@@ -17,12 +17,11 @@
 package net.skyscanner.backpack.calendar.view
 
 import android.content.Context
+import android.graphics.Color
 import android.util.AttributeSet
 import android.view.ViewConfiguration
 import android.widget.AbsListView
 import android.widget.ListView
-import androidx.core.content.ContextCompat
-import net.skyscanner.backpack.R
 import net.skyscanner.backpack.calendar.presenter.BpkCalendarController
 import net.skyscanner.backpack.calendar.presenter.MonthAdapter
 
@@ -83,7 +82,7 @@ internal class CalendarView constructor(
     setOnScrollListener(this)
     setFadingEdgeLength(0)
     setFriction(ViewConfiguration.getScrollFriction() * scrollFriction)
-    setBackgroundColor(ContextCompat.getColor(context, R.color.bpkWhite))
+    setBackgroundColor(Color.TRANSPARENT)
   }
 
   // TODO: Updates the title and selected month if the view has moved to a new month.

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,1 +1,6 @@
 # Unreleased
+
+**Fixed:**
+
+- BpkCalendar
+  - Changed changed background color to transparent.


### PR DESCRIPTION
The MonthHeader views is already transparent but the calendar was setting the background to `white` making it impossible to use in a view with a different background colour

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
