### PR TITLE
[NO-JIRA] Change switch theming approach

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/toggle/BpkSwitch.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/toggle/BpkSwitch.kt
@@ -9,6 +9,11 @@ import net.skyscanner.backpack.util.BpkTheme
 import net.skyscanner.backpack.util.createContextThemeWrapper
 import net.skyscanner.backpack.util.getColor
 
+private fun wrapContext(context: Context, attrs: AttributeSet?): Context {
+  val withBaseStyle = createContextThemeWrapper(context, attrs, androidx.appcompat.R.attr.switchStyle)
+  return createContextThemeWrapper(withBaseStyle, attrs, R.attr.bpkSwitchStyle)
+}
+
 /**
  * BpkSwitch allow users to toggle between two states, on or off.
  *
@@ -21,17 +26,17 @@ import net.skyscanner.backpack.util.getColor
 open class BpkSwitch @JvmOverloads constructor(
   context: Context,
   attrs: AttributeSet? = null,
-  defStyleAttr: Int = R.attr.bpkSwitchStyle
-) : SwitchCompat(createContextThemeWrapper(context, attrs, androidx.appcompat.R.attr.switchStyle), attrs, defStyleAttr) {
+  defStyleAttr: Int = 0
+) : SwitchCompat(wrapContext(context, attrs), attrs, defStyleAttr) {
 
   init {
     initialize(attrs, defStyleAttr)
   }
 
   fun initialize(attrs: AttributeSet?, defStyleAttr: Int) {
-    val a = context.theme.obtainStyledAttributes(attrs, R.styleable.BpkSwitch, defStyleAttr, 0)
-    val primaryColor = a.getColor(R.styleable.BpkSwitch_switchPrimaryColor, getColor(R.color.bpkBlue500))
-    a.recycle()
+    val styledAttrs = context.theme.obtainStyledAttributes(attrs, R.styleable.BpkSwitch, defStyleAttr, 0)
+    val primaryColor = styledAttrs.getColor(R.styleable.BpkSwitch_switchPrimaryColor, getColor(R.color.bpkBlue500))
+    styledAttrs.recycle()
 
     trackTintList = ColorStateList.valueOf(BpkTheme.getColor(context, R.color.bpkGray100))
     thumbTintList = ColorStateList(

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,11 @@
 
 > Place your changes below this line.
 
+**Changed:**
+
+- `BpkSwitch`
+  - Changed theming approach to not rely on constructor's default arguments.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).


### PR DESCRIPTION
Previous approach causes problems/confusion when our components are extended and we have moved away from it in other components. Switch was the only component still using this approach.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
