### PR TITLE
Add @ColorInt annotation to getPrimaryColor

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/util/BpkTheme.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/util/BpkTheme.kt
@@ -36,6 +36,7 @@ class BpkTheme {
      * @return a color integer
      */
     @JvmStatic
+    @ColorInt
     fun getPrimaryColor(context: Context) =
       resolveThemeColorWithDefault(context, R.attr.bpkPrimaryColor)
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

This annotation can assist when using the getPrimaryColor method so users know what int they get in return.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
