### PR TITLE
[NO-JIRA] Theme status bar

### DIFF
--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -5,6 +5,7 @@
   <style name="LondonTheme">
     <item name="bpkPrimaryColor">#013A76</item>
     <item name="colorPrimary">?bpkPrimaryColor</item>
+    <item name="colorPrimaryDark">#00254B</item>
 
     <item name="bpkGray50Color">#F1F3F3</item>
     <item name="bpkGray100Color">#DCDFE0</item>
@@ -87,6 +88,8 @@
   <style name="DohaTheme" parent="">
     <item name="bpkPrimaryColor">#ffb300</item>
     <item name="colorPrimary">?bpkPrimaryColor</item>
+    <item name="colorPrimaryDark">#ffa000</item>
+
     <item name="bpkGray50Color">#F1F3F3</item>
     <item name="bpkGray100Color">#DCDFE0</item>
     <item name="bpkGray300Color">#B3BABD</item>


### PR DESCRIPTION
Status bar colour is based on `colorPrimaryDark` which we were not setting.

![Screenshot_1558964468](https://user-images.githubusercontent.com/1457263/58423775-d42d6680-808d-11e9-86c2-b0d1c11304a1.png)
![Screenshot_1558964459](https://user-images.githubusercontent.com/1457263/58423776-d42d6680-808d-11e9-80bf-363a8928f43f.png)


+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/master/CONTRIBUTING.md)


_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
