### PR TITLE
[BPK-2749] Bump appcompat to 1.0.2

### DIFF
--- a/Backpack/build.gradle
+++ b/Backpack/build.gradle
@@ -27,9 +27,9 @@ dependencies {
   implementation "androidx.annotation:annotation:$rootProject.ext.androidx"
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "androidx.appcompat:appcompat:$rootProject.ext.androidx"
-  implementation "com.google.android.material:material:$rootProject.ext.androidx"
+  implementation "com.google.android.material:material:$rootProject.ext.androidMaterial"
   implementation "androidx.constraintlayout:constraintlayout:$rootProject.ext.constraintLayout"
-  implementation "androidx.cardview:cardview:$rootProject.ext.androidx"
+  implementation "androidx.cardview:cardview:$rootProject.ext.cardView"
   implementation "com.jakewharton.threetenabp:threetenabp:$rootProject.ext.threeTenAbp"
   androidTestImplementation "androidx.test.ext:junit:1.0.0"
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -2,6 +2,10 @@
 
 > Place your changes below this line.
 
+**Fixed:**
+
+- Bumped `androidx.appcompat:appcompat` to `1.0.2`
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,9 +41,10 @@ dependencies {
   implementation fileTree(include: ['*.jar'], dir: 'libs')
   implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
   implementation "androidx.appcompat:appcompat:$rootProject.ext.androidx"
-  implementation "androidx.legacy:legacy-support-v4:$rootProject.ext.androidx"
+  implementation "androidx.annotation:annotation:$rootProject.ext.androidx"
+  implementation "androidx.legacy:legacy-support-v4:$rootProject.ext.androidXLegacy"
   implementation "androidx.constraintlayout:constraintlayout:$rootProject.ext.constraintLayout"
-  implementation "com.google.android.material:material:$rootProject.ext.androidx"
+  implementation "com.google.android.material:material:$rootProject.ext.androidMaterial"
   implementation "com.jakewharton.threetenabp:threetenabp:1.1.2"
   testImplementation 'junit:junit:4.12'
   implementation 'com.facebook.stetho:stetho:1.5.0'

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,10 @@ ext {
   supportLibVersion = "27.1.1"
   googlePlayServicesVersion = "15.0.1"
   androidMapsUtilsVersion = "0.5+"
-  androidx = "1.0.0"
+  androidx = "1.0.2"
+  androidXLegacy = "1.0.0"
+  androidMaterial = "1.0.0"
+  cardView = "1.0.0"
   constraintLayout = "1.1.3"
   threeTenAbp = "1.1.2"
 }


### PR DESCRIPTION
This is required to update the react native version of `backpack-react-native` to 0.60.4

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
