### PR TITLE
[NO-JIRA] Automate screenshots

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/calendar/BpkCalendar.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/calendar/BpkCalendar.kt
@@ -27,6 +27,9 @@ open class BpkCalendar @JvmOverloads constructor(
   private val weekdayHeaderView by unsafeLazy { findViewById<WeekdayHeaderView>(R.id.weekday_header_view) }
   private val yearPillView by unsafeLazy { findViewById<BpkBadge>(R.id.year_pill_view) }
 
+  val controller: BpkCalendarController?
+    get() = calendarView.controller
+
   fun setController(controller: BpkCalendarController) {
     weekdayHeaderView.initializeWithLocale(controller.locale)
     calendarView.controller = controller

--- a/Backpack/src/main/java/net/skyscanner/backpack/spinner/BpkSpinner.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/spinner/BpkSpinner.kt
@@ -2,6 +2,7 @@ package net.skyscanner.backpack.spinner
 
 import android.content.Context
 import android.graphics.PorterDuff
+import android.os.Build
 import android.provider.Settings.Global
 import android.util.AttributeSet
 import android.view.ViewGroup
@@ -102,7 +103,7 @@ open class BpkSpinner @JvmOverloads constructor(
     //
     // Since this component only makes sense with animations we simple don't add the progress bar when animations are disabled.
 
-    if (animationsEnabled) {
+    if (animationsEnabled || Build.VERSION.SDK_INT >= 29) {
       val style = if (small) android.R.attr.progressBarStyleSmall else android.R.attr.progressBarStyle
       progressBar = ProgressBar(context, null, style)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ source ~/.bash_profile
 Install system images
 ```
 $ANDROID_HOME/tools/bin/sdkmanager "system-images;android-21;google_apis;x86"
+$ANDROID_HOME/tools/bin/sdkmanager "system-images;android-29;google_apis;x86"
 ```
 
 ## Setup
@@ -78,6 +79,23 @@ To test your branch in a codebase, use the dependency in the below format.
 ```
 implementation 'com.github.<github-username>:backpack-android:<branch-name>'
 ```
+
+## Taking screenshots
+
+Before running the script install and start the docs emulator.
+
+```
+$ANDROID_HOME/tools/bin/avdmanager --verbose create avd --force --name "pixel_9.0" --device "pixel" --package "system-images;android-29;google_apis;x86" --tag "google_apis" --abi "x86
+$ANDROID_HOME/emulator/emulator -avd bpk-droid-docs-avd
+```
+
+Run `./scripts/generate_screenshots.sh` to capture all screenshots. Files will be saved in the correct directory.
+
+> Note: Python is required.
+
+### Adding new screenshots
+
+To add new screenshots, add a new entry to `net/skyscanner/backpack/docs/DocsRegistry.kt`
 
 ## Demo app shortcuts
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,7 +20,9 @@ android {
     versionName rootProject.ext.version
 
     testInstrumentationRunner "net.skyscanner.backpack.BpkTestRunner"
+    testInstrumentationRunnerArgument "notClass", "net.skyscanner.backpack.docs.GenerateScreenshots"
   }
+
   signingConfigs {
     if (travis) {
       release {
@@ -75,6 +77,7 @@ dependencies {
   implementation 'com.facebook.stetho:stetho:1.5.1'
   androidTestImplementation "androidx.test.ext:junit:1.1.1"
   androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+  androidTestImplementation 'com.android.support.test.espresso:espresso-contrib:2.0'
   androidTestImplementation 'androidx.test:rules:1.2.0'
   api project(':Backpack')
   // NOTE: This is here and not in the root file because snyk is not ignoring it otherwise.

--- a/app/src/androidTest/java/net/skyscanner/backpack/docs/DocsRegistry.kt
+++ b/app/src/androidTest/java/net/skyscanner/backpack/docs/DocsRegistry.kt
@@ -1,0 +1,109 @@
+package net.skyscanner.backpack.docs
+
+import androidx.test.espresso.Espresso
+import androidx.test.espresso.action.ViewActions
+import androidx.test.espresso.matcher.ViewMatchers
+import net.skyscanner.backpack.calendar.BpkCalendar
+import net.skyscanner.backpack.calendar.model.CalendarRange
+import net.skyscanner.backpack.demo.R
+import org.threeten.bp.LocalDate
+
+object DocsRegistry {
+  val screenshots = listOf(
+    Screenshot("Badge", "all"),
+    Screenshot("Button - Primary", "primary"),
+    Screenshot("Button - Secondary", "secondary"),
+    Screenshot("Button - Featured", "featured"),
+    Screenshot("Button - Destructive", "destructive"),
+    Screenshot("Button - Outline", "outline"),
+    Screenshot("ButtonLink - Default", "default"),
+    Screenshot("Calendar - Default", "range", ::setupCalendar),
+    Screenshot("Card - Default", "default"),
+    Screenshot("Card - Without padding", "without-padding"),
+    Screenshot("Card - Selected", "selected"),
+    Screenshot("Card - Corner style large", "corner-style-large"),
+    Screenshot("Card - With divider", "with-divider"),
+    Screenshot("Card - With divider arranged vertically", "with-divider-arranged-vertically"),
+    Screenshot("Card - With divider without padding", "with-divider-without-padding"),
+    Screenshot("Card - With divider and corner style large", "with-divider-and-corner-style-large"),
+    Screenshot("Chip", "all"),
+    Screenshot("Checkbox", "default"),
+    Screenshot("Dialog - With call to action", "with-cta", ::setupDialog),
+    Screenshot("Dialog - Delete confirmation", "delete-confirmation", ::setupDialog),
+    Screenshot("Dialog - Flare", "with-flare", ::setupDialog),
+    Screenshot("Flare - Default", "default"),
+    Screenshot("Flare - Pointer offset", "pointer-offset"),
+    Screenshot("Flare - Rounded", "rounded"),
+    Screenshot("Flare - Inset padding mode", "inset-padding"),
+    Screenshot("Horizontal Nav", "default"),
+    Screenshot("Floating Action Button", "default"),
+    Screenshot("Nav Bar - Default", "expanded"),
+    Screenshot("Nav Bar - Default", "collapsed", ::setupNavBarCollapsed),
+    Screenshot("Nav Bar - With Menu", "navigation", ::setupNavBarCollapsed),
+    Screenshot("Panel", "all"),
+    Screenshot("Rating - Default", "default"),
+    Screenshot("Rating - Sizes", "sizes"),
+    Screenshot("Rating - Size Vertical", "vertical"),
+    Screenshot("Snackbar", "default", ::setupSnackbar),
+    Screenshot("Star Rating - Default", "default"),
+    Screenshot("Star Rating Interactive", "default"),
+    Screenshot("Switch", "default"),
+    Screenshot("Text - Default", "default"),
+    Screenshot("Text - Emphasized", "emphasized"),
+    Screenshot("Text - Heavy", "heavy"),
+    Screenshot("Text Field", "default"),
+    Screenshot("Text Spans", "default"),
+    Screenshot("Spinner - Default", "default"),
+    Screenshot("Spinner - Small", "small"),
+    // Leave toast last as it stays visible in the screen for a while
+    Screenshot("Toast", "default", ::setupToast)
+    ).map { it.toArgs() }
+}
+
+data class Screenshot(
+  val name: String,
+  val screenshotName: String,
+  val setup: (() -> Unit)? = null
+) {
+  fun toArgs() = arrayOf(name, screenshotName, setup)
+}
+
+private fun setupCalendar() {
+  Espresso.onView(ViewMatchers.withId(R.id.bpkCalendar))
+    .check { view, _ ->
+      view as BpkCalendar
+      view.controller?.updateSelection(CalendarRange(
+        LocalDate.now().plusDays(5),
+        LocalDate.now().plusDays(10)
+      ))
+      view.controller?.updateContent()
+    }
+}
+
+private fun setupNavBarCollapsed() {
+  Espresso.onView(ViewMatchers.withId(R.id.component_detail_container))
+    .perform(ViewActions.swipeUp())
+
+  Thread.sleep(100)
+}
+
+private fun setupDialog() {
+  Espresso.onView(ViewMatchers.withText("SHOW"))
+    .perform(ViewActions.click())
+
+  Thread.sleep(50)
+}
+
+private fun setupSnackbar() {
+  Espresso.onView(ViewMatchers.withText("INDEFINITE SNACKBAR"))
+    .perform(ViewActions.click())
+
+  Thread.sleep(50)
+}
+
+private fun setupToast() {
+  Espresso.onView(ViewMatchers.withText("SHORT TOAST"))
+    .perform(ViewActions.click())
+
+  Thread.sleep(50)
+}

--- a/app/src/androidTest/java/net/skyscanner/backpack/docs/GenerateScreenshots.kt
+++ b/app/src/androidTest/java/net/skyscanner/backpack/docs/GenerateScreenshots.kt
@@ -1,0 +1,72 @@
+package net.skyscanner.backpack.docs
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import android.content.Intent
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.rule.ActivityTestRule
+import net.skyscanner.backpack.demo.*
+import org.junit.Rule
+
+@RunWith(Parameterized::class)
+open class GenerateScreenshots(
+  private val componentPath: String,
+  private val screenshotName: String,
+  private val setup: (() -> Unit)?
+) {
+
+  companion object {
+    @JvmStatic
+    @Parameterized.Parameters(name = "{0} Screenshot")
+    fun data() = DocsRegistry.screenshots
+  }
+
+  @get:Rule
+  var activityRule = ActivityTestRule(ComponentDetailActivity::class.java, true, false)
+
+  private val screenshotFullName: String
+    get() {
+      val componentName = componentPath.split(" - ").first()
+      return "${componentName.replace(" ", "")}_$screenshotName"
+    }
+
+  private val screenGrab by lazy {
+    val serverIp = InstrumentationRegistry.getArguments().getString("screenshotServer")
+      ?: throw IllegalStateException("screenshotServer argument not provided or null")
+
+    RemoteScreenGrab(serverIp)
+  }
+
+  @Test
+  fun testTakeScreenshot() {
+    AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+    runActivityAndTakeScreenshot()
+  }
+
+  @Test
+  fun testTakeScreenshotDm() {
+    AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES)
+    runActivityAndTakeScreenshot("dm")
+  }
+
+  private fun runActivityAndTakeScreenshot(suffix: String? = null) {
+    val intent = Intent()
+    intent.putExtra(ComponentDetailFragment.ARG_ITEM_ID, componentPath)
+    intent.putExtra(ComponentDetailFragment.AUTOMATION_MODE, true)
+    activityRule.launchActivity(intent)
+    setup?.invoke()
+    takeScreenshot(suffix)
+    activityRule.finishActivity()
+  }
+
+  private fun takeScreenshot(suffix: String? = null) {
+    val name = if (suffix != null) {
+      "${screenshotFullName}_$suffix"
+    } else {
+      screenshotFullName
+    }
+    screenGrab.takeScreenshot(name)
+  }
+}

--- a/app/src/androidTest/java/net/skyscanner/backpack/docs/RemoteScreenGrab.kt
+++ b/app/src/androidTest/java/net/skyscanner/backpack/docs/RemoteScreenGrab.kt
@@ -1,0 +1,27 @@
+package net.skyscanner.backpack.docs
+
+import java.io.BufferedInputStream
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+
+class RemoteScreenGrab(
+  private val serverIp: String
+) {
+  fun takeScreenshot(name: String) {
+    val url = URL("http://$serverIp:8888?name=$name")
+    val con = url.openConnection() as HttpURLConnection
+    con.requestMethod = "POST"
+    try {
+      val inStream = BufferedInputStream(con.inputStream)
+      // Output should to be read
+      BufferedReader(InputStreamReader(inStream)).readText()
+      if (con.responseCode != 200) {
+        throw Exception("Unable to take screenshot for $name. Error code: ${con.responseCode}")
+      }
+    } finally {
+      con.disconnect()
+    }
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,24 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="net.skyscanner.backpack.demo">
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
-    <application
-        android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
-        android:roundIcon="@mipmap/ic_launcher"
-        android:supportsRtl="true"
-        android:name="net.skyscanner.backpack.demo.BackpackDemoApplication"
-        android:theme="@style/AppTheme">
-        <activity android:name=".MainActivity">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.INTERNET" />
 
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
-      <activity android:name=".ComponentDetailActivity" />
-      <activity android:name=".SettingsActivity" />
-      <activity android:name="androidx.appcompat.app.AppCompatActivity" />
-    </application>
+  <application
+      android:icon="@mipmap/ic_launcher"
+      android:label="@string/app_name"
+      android:roundIcon="@mipmap/ic_launcher"
+      android:supportsRtl="true"
+      android:name="net.skyscanner.backpack.demo.BackpackDemoApplication"
+      android:usesCleartextTraffic="true"
+      android:theme="@style/AppTheme">
+      <activity android:name=".MainActivity">
+          <intent-filter>
+              <action android:name="android.intent.action.MAIN" />
+
+              <category android:name="android.intent.category.LAUNCHER" />
+          </intent-filter>
+      </activity>
+    <activity android:name=".ComponentDetailActivity" />
+    <activity android:name=".SettingsActivity" />
+    <activity android:name="androidx.appcompat.app.AppCompatActivity" />
+  </application>
 
 </manifest>

--- a/app/src/main/java/net/skyscanner/backpack/demo/ComponentDetailActivity.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/ComponentDetailActivity.kt
@@ -36,11 +36,14 @@ class ComponentDetailActivity : BpkBaseActivity() {
       val itemId = intent.getStringExtra(ComponentDetailFragment.ARG_ITEM_ID)
       detail_toolbar.title = itemId
 
+      val automationMode = intent.getBooleanExtra(ComponentDetailFragment.AUTOMATION_MODE, false)
+
       val createFragment = ComponentRegistry.getStoryCreator(itemId)
       val fragment = createFragment.createStory()
 
       val arguments = fragment.arguments ?: Bundle()
       arguments.putString(ComponentDetailFragment.ARG_ITEM_ID, itemId)
+      arguments.putBoolean(ComponentDetailFragment.AUTOMATION_MODE, automationMode)
 
       fragment.arguments = arguments
       supportFragmentManager.beginTransaction()
@@ -56,6 +59,14 @@ class ComponentDetailActivity : BpkBaseActivity() {
     return super.onOptionsItemSelected(item)
   }
 
+  fun toggleToolbar() {
+    detail_toolbar.visibility = if (detail_toolbar.visibility == View.VISIBLE) {
+      View.GONE
+    } else {
+      View.VISIBLE
+    }
+  }
+
   /*
    Hide/Un-hide toolbar: Shift + T
    toggle layout direction: Shift + D
@@ -63,11 +74,7 @@ class ComponentDetailActivity : BpkBaseActivity() {
   */
   override fun onKeyUp(keyCode: Int, event: KeyEvent?): Boolean {
     if (keyCode == KeyEvent.KEYCODE_T && event?.isShiftPressed == true) {
-      detail_toolbar.visibility = if (detail_toolbar.visibility == View.VISIBLE) {
-        View.GONE
-      } else {
-        View.VISIBLE
-      }
+      toggleToolbar()
     }
     if (keyCode == KeyEvent.KEYCODE_D && event?.isShiftPressed == true) {
       if (component_detail_container.layoutDirection == View.LAYOUT_DIRECTION_LTR) {

--- a/app/src/main/java/net/skyscanner/backpack/demo/ComponentDetailFragment.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/ComponentDetailFragment.kt
@@ -29,5 +29,12 @@ open class ComponentDetailFragment : Fragment() {
      * represents.
      */
     val ARG_ITEM_ID = "item_id"
+
+    /*
+     * Tells if the fragment running in automation mode.
+     * Use this to avoid showing toast and things designed only for
+     * user feedback
+     */
+    val AUTOMATION_MODE = "automation_mode"
   }
 }

--- a/app/src/main/java/net/skyscanner/backpack/demo/data/ComponentRegistry.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/data/ComponentRegistry.kt
@@ -152,7 +152,7 @@ object ComponentRegistry {
         "Different values" story NodeData { Story of R.layout.fragment_star_rating_values },
         "Custom Max Rating" story NodeData { Story of R.layout.fragment_star_rating_max }
       )),
-    "Star Rating: Interactive" story NodeData { InteractiveStarRatingStory of R.layout.fragment_star_rating_interactive },
+    "Star Rating Interactive" story NodeData { InteractiveStarRatingStory of R.layout.fragment_star_rating_interactive },
     "Switch" story NodeData { Story of R.layout.fragment_switch },
     "Text" story NodeData({ children -> SubStory of children },
       mapOf(

--- a/app/src/main/java/net/skyscanner/backpack/demo/data/ExampleBpkCalendarController.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/data/ExampleBpkCalendarController.kt
@@ -22,9 +22,13 @@ import org.threeten.bp.temporal.ChronoUnit
 class ExampleBpkCalendarController(
   private val context: Context,
   override val selectionType: SelectionType = SelectionType.RANGE,
-  private val disableDates: Boolean = false
+  private val disableDates: Boolean = false,
+  private val automationMode: Boolean = false
 ) : BpkCalendarController(selectionType) {
   override fun onRangeSelected(range: CalendarSelection) {
+    if (automationMode) {
+      return
+    }
     when (range) {
       is SingleDay -> Toast.makeText(context, String.format("%s", range.selectedDay.toString()), Toast.LENGTH_SHORT).show()
       is CalendarRange -> Toast.makeText(context, String.format("%s - %s", range.start.toString(), range.end.toString()), Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/net/skyscanner/backpack/demo/stories/DefaultCalendarStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/stories/DefaultCalendarStory.kt
@@ -19,8 +19,9 @@ class DefaultCalendarStory : Story() {
   override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
     super.onViewCreated(view, savedInstanceState)
 
+    val automationMode = arguments?.getBoolean(AUTOMATION_MODE) ?: false
     val calendar = view.findViewById<BpkCalendar>(R.id.bpkCalendar)
-    controller = ExampleBpkCalendarController(requireContext())
+    controller = ExampleBpkCalendarController(requireContext(), SelectionType.RANGE, false, automationMode)
     calendar.setController(controller)
     initSelectionTypeSwitcher()
   }

--- a/app/src/main/res/layout/fragment_nav_bar.xml
+++ b/app/src/main/res/layout/fragment_nav_bar.xml
@@ -11,6 +11,7 @@
     app:navBarExpandedTextColor="@color/bpkErfoud"/>
 
   <androidx.core.widget.NestedScrollView
+    android:id="@+id/navBarScrollView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:clipToPadding="false"

--- a/scripts/ci-tests.sh
+++ b/scripts/ci-tests.sh
@@ -16,6 +16,7 @@ if [ "$TEST_METHOD" == "screenshot" ]; then
       --app ./app/build/outputs/apk/oss/debug/app-oss-debug.apk \
       --test ./app/build/outputs/apk/androidTest/oss/debug/app-oss-debug-androidTest.apk \
       --device model=Nexus4,version=21 \
+      --environment-variables "notClass=net.skyscanner.backpack.docs.GenerateScreenshots" \
       --results-dir="$dir_name"
 
 

--- a/scripts/generate_screenshots.sh
+++ b/scripts/generate_screenshots.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+
+test_instrumentation_runner='net.skyscanner.backpack.BpkTestRunner'
+tests_apk_path='app/build/outputs/apk/androidTest/internal/debug/app-internal-debug-androidTest.apk'
+app_apk_path='app/build/outputs/apk/internal/debug/app-internal-debug.apk'
+app_package_name='net.skyscanner.backpack'
+
+docs_avd="bpk-droid-docs-avd"
+
+apk=app/build/outputs/apk/base/debug/Go.Android.App-base-debug.apk
+
+function getActiveNetwork() {
+	services=$(networksetup -listnetworkserviceorder | grep 'Hardware Port')
+
+	while read line; do
+    sname=$(echo $line | awk -F  "(, )|(: )|[)]" '{print $2}')
+    sdev=$(echo $line | awk -F  "(, )|(: )|[)]" '{print $4}')
+    #echo "Current service: $sname, $sdev, $currentservice"
+    if [ -n "$sdev" ]; then
+        ifout="$(ifconfig $sdev 2>/dev/null)"
+        echo "$ifout" | grep 'status: active' > /dev/null 2>&1
+        rc="$?"
+        if [ "$rc" -eq 0 ]; then
+            currentservice="$sname"
+            currentdevice="$sdev"
+            currentmac=$(echo "$ifout" | awk '/ether/{print $2}')
+        fi
+    fi
+	done <<< "$(echo "$services")"
+
+	if [ -z "$currentservice" ]; then
+			>&2 echo "Could not find any active network. Are you connected to the internet?"
+			exit 1
+	fi
+
+	ipconfig getifaddr $currentdevice
+}
+
+function checkStatus() {
+	if [ $? -ne 0 ]; then
+		echo "Something wrong :/"
+		exit $?
+	fi
+}
+
+function buildApp() {
+	echo "🏢  Building the app..."
+	./gradlew :app:assembleInternalDebug app:assembleAndroidTest
+	checkStatus
+}
+
+function installApp() {
+	echo "📥  Installing the app"
+	adb install -t -r "$app_apk_path"
+	adb install -t -r "$tests_apk_path"
+	checkStatus
+}
+
+function clearData() {
+	echo "😉  Cleaning up"
+	adb shell pm clear $app_package_name
+	checkStatus
+}
+
+function run() {
+	echo "📸  Taking screenshots..."
+	python ./scripts/screenshot-server.py &
+	echo $! > ss-server.pid
+	ipAddr=$(getActiveNetwork)
+	~/Library/Android/sdk/platform-tools/adb shell am instrument --no-window-animation -w \
+		-e class net.skyscanner.backpack.docs.GenerateScreenshots \
+		-e screenshotServer $ipAddr \
+		net.skyscanner.backpack.test/$test_instrumentation_runner
+
+	cat ss-server.pid | xargs kill -9 2> /dev/null
+	checkStatus
+}
+
+function waitUntil() {
+	echo "🕙  Waiting $1 seconds for $2"
+	sleep $1
+}
+
+function section() {
+	echo ""
+	echo "🎬  $1"
+}
+
+function start() {
+	if [ `ps aux | grep qemu | wc -l` -gt 1 ]; then
+		adb reconnect > /dev/null
+		waitUntil 2 "the emulator to reconnect"
+	else
+		echo "emulator not started, please start 'bpk-droid-docs-avd'"
+		exit 1
+	fi
+	installApp
+	clearData
+	waitUntil 2 "the device after the cleanup"
+}
+
+function finish() {
+	echo "✅  All done. Please review the new screenshots"
+}
+
+function generate() {
+	locale=$1
+
+	echo ""
+	echo "-----------------------"
+	echo "🚩  Taking screenshots "
+	echo "-----------------------"
+	echo ""
+
+	start
+	run
+	finish
+}
+
+buildApp
+generate

--- a/scripts/screenshot-server.py
+++ b/scripts/screenshot-server.py
@@ -1,0 +1,31 @@
+#!/bin/python
+
+from http.server import HTTPServer, BaseHTTPRequestHandler
+from urlparse import parse_qs
+import SocketServer
+import subprocess
+import os
+
+class S(BaseHTTPRequestHandler):
+  def log_message(self, format, *args):
+    # args are in this format ('POST ?name=<name> HTTP', ...)
+    print args[0].split(' ')[1].split('=')[1]
+
+  def do_POST(self):
+    fileName = parse_qs(self.path[2:])["name"][0]
+    (componentName, screenShotName) = fileName.split('_', 1)
+    folderPath = os.path.join('docs', componentName, 'screenshots')
+    screenShotPath = os.path.join(folderPath, screenShotName + '.png')
+
+    if not os.path.exists(folderPath):
+      os.makedirs(folderPath)
+
+    subprocess.call(["adb", "exec-out", "screencap", "-p"], stdout=open(screenShotPath, 'w'))
+    self.send_response(200, "ok\n")
+
+PORT = 8888
+
+httpd = HTTPServer(("", PORT), S)
+
+print "screenshot server running at port", PORT
+httpd.serve_forever()


### PR DESCRIPTION
This is a quick overview of how the script works:

- Builds and install `app-internal` and `app-test-internal`
- Starts a python `http` server listening for screenshot requests
- Runs tests in the emulator specifying that only `GenerateScreenshots` test should run.
- `GenerateScreenshots` runs two tests for every `story`, one for light and one for dark mode.
- Tests will prepare the view for screenshots and call the python server, that will then run adb to take the screenshot and save to the docs folder.

# Todo:

- [x] Component that requires action (e.g. toast)
- [x] Component with animation (e.g. spinner)
- [x] Save files in the correct folder (and without the hash in the name)
- [x] Dark mode
- [x] Docs
- [x] Automate build and execution

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
