### PR TITLE
[BPK-3760] Avoided dismissing the dialog when setCanceledOnTouchOutside is false

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/dialog/BpkDialog.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/dialog/BpkDialog.kt
@@ -50,4 +50,9 @@ open class BpkDialog(
   fun addActionButton(view: View) {
     impl.addActionButton(view)
   }
+
+  override fun setCanceledOnTouchOutside(cancel: Boolean) {
+    super.setCanceledOnTouchOutside(cancel)
+    impl.isCanceledOnTouchOutside = cancel
+  }
 }

--- a/Backpack/src/main/java/net/skyscanner/backpack/dialog/internal/AlertDialogImpl.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/dialog/internal/AlertDialogImpl.kt
@@ -30,7 +30,9 @@ internal class AlertDialogImpl(
         else -> DialogWindowLayout.Gravity.Center
       }
       dismissListener = {
-        dialog.dismiss()
+        if(isCanceledOnTouchOutside) {
+          dialog.dismiss()
+        }
       }
     }
   }

--- a/Backpack/src/main/java/net/skyscanner/backpack/dialog/internal/AlertDialogImpl.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/dialog/internal/AlertDialogImpl.kt
@@ -30,7 +30,7 @@ internal class AlertDialogImpl(
         else -> DialogWindowLayout.Gravity.Center
       }
       dismissListener = {
-        if(isCanceledOnTouchOutside) {
+        if (isCanceledOnTouchOutside) {
           dialog.dismiss()
         }
       }

--- a/Backpack/src/main/java/net/skyscanner/backpack/dialog/internal/BpkDialogImpl.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/dialog/internal/BpkDialogImpl.kt
@@ -19,6 +19,8 @@ internal interface BpkDialogImpl {
 
   var icon: BpkDialog.Icon?
 
+  var isCanceledOnTouchOutside: Boolean
+
   fun addActionButton(view: View)
 
   abstract class Base(
@@ -60,6 +62,8 @@ internal interface BpkDialogImpl {
         field = value
         iconView?.icon = icon
       }
+
+    override var isCanceledOnTouchOutside: Boolean = true
 
     override fun addActionButton(view: View) {
       buttonsRoot?.addView(view, LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -27,3 +27,7 @@ See [`CHANGELOG.md`](CHANGELOG.md) for real-world examples of good changelog ent
 
 - `bpk-component-horcrux`:
   - Fixed issue where `BpkHorcrux` would occasionally possess the living.
+
+- `BpkDialog`
+  - `setCanceledOnTouchOutside()` method to change dialog dismiss behaviour
+

--- a/app/src/main/java/net/skyscanner/backpack/demo/stories/DialogStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/stories/DialogStory.kt
@@ -94,6 +94,7 @@ class DialogStory : Story() {
           R.color.bpkPanjin
         )
         setCancelable(false)
+        setCanceledOnTouchOutside(false)
         setOnCancelListener {
           println("canceled")
         }


### PR DESCRIPTION
Implemented to `setCanceledOnTouchOutside` method in BpkDialog to disabling closing when clicking outside for ALERT type.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
