### PR TITLE
add a11y labels to calendar header

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/calendar/view/MonthView.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/calendar/view/MonthView.kt
@@ -186,6 +186,7 @@ internal class MonthView @JvmOverloads constructor(
     controller?.let {
       drawMonthTitle(canvas)
       drawDaysInMonth(it, canvas)
+      contentDescription = monthHeaderString
     }
   }
 

--- a/Backpack/src/main/java/net/skyscanner/backpack/calendar/view/WeekdayHeaderView.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/calendar/view/WeekdayHeaderView.kt
@@ -47,6 +47,8 @@ internal class WeekdayHeaderView @JvmOverloads constructor(
 
   internal fun initializeWithLocale(locale: Locale) {
     val formatter = DateTimeFormatter.ofPattern("ccc", locale)
+    val descriptionFormatter = DateTimeFormatter.ofPattern("cccc", locale)
+
 
     firstWeekdayView.text = dayOfWeek(locale, formatter, 1)
     secondWeekdayView.text = dayOfWeek(locale, formatter, 2)
@@ -55,6 +57,14 @@ internal class WeekdayHeaderView @JvmOverloads constructor(
     fifthWeekdayView.text = dayOfWeek(locale, formatter, 5)
     sixthWeekdayView.text = dayOfWeek(locale, formatter, 6)
     seventhWeekdayView.text = dayOfWeek(locale, formatter, 7)
+
+    firstWeekdayView.contentDescription = dayOfWeek(locale, descriptionFormatter, 1)
+    secondWeekdayView.contentDescription = dayOfWeek(locale, descriptionFormatter, 2)
+    thirdWeekdayView.contentDescription = dayOfWeek(locale, descriptionFormatter, 3)
+    fourthWeekdayView.contentDescription = dayOfWeek(locale, descriptionFormatter, 4)
+    fifthWeekdayView.contentDescription = dayOfWeek(locale, descriptionFormatter, 5)
+    sixthWeekdayView.contentDescription = dayOfWeek(locale, descriptionFormatter, 6)
+    seventhWeekdayView.contentDescription = dayOfWeek(locale, descriptionFormatter, 7)
   }
 
   private fun dayOfWeek(locale: Locale, formatter: DateTimeFormatter, dayOfWeekIndex: Long): String {

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 > Place your changes below this line.
+- Added acessibility labels to `WeekDay` and `Month` views in `BpkCalendar`
 
 ## How to write a good changelog entry
 


### PR DESCRIPTION
Adding acessibility lables to weekday header view. Will fix the date views in a seprate PR

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/master/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/master/CODE_REVIEW_GUIDELINES.md)_
