### PR TITLE
Add missing character

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ implementation 'com.github.<github-username>:backpack-android:<branch-name>'
 Before running the script install and start the docs emulator.
 
 ```
-$ANDROID_HOME/tools/bin/avdmanager --verbose create avd --force --name "bpk-droid-docs-avd" --device "pixel" --package "system-images;android-29;google_apis;x86" --tag "google_apis" --abi "x86
+$ANDROID_HOME/tools/bin/avdmanager --verbose create avd --force --name "bpk-droid-docs-avd" --device "pixel" --package "system-images;android-29;google_apis;x86" --tag "google_apis" --abi "x86"
 $ANDROID_HOME/emulator/emulator -avd bpk-droid-docs-avd
 ```
 


### PR DESCRIPTION
A minor fix for the CONTRIBUTION.md file where there was a missing `"` character - which when used would produce a new line in the terminal