### PR TITLE
KOA-4581 Remove dcendents plugin

### DIFF
--- a/Backpack/build.gradle
+++ b/Backpack/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 apply plugin: 'org.jetbrains.dokka-android'
-apply plugin: 'com.github.dcendents.android-maven'
 
 apply from: 'gradle-maven-push.gradle'
 

--- a/Backpack/gradle-maven-push.gradle
+++ b/Backpack/gradle-maven-push.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'maven-publish'
 
 def artifactoryURL = "https://artifactory.skyscannertools.net/artifactory/infrastructure-maven"

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,6 @@ buildscript {
   dependencies {
     classpath 'com.android.tools.build:gradle:4.1.3'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-    classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:$dokka_version"
     classpath 'com.facebook.testing.screenshot:plugin:0.14.0'
     classpath "org.jlleitschuh.gradle:ktlint-gradle:10.0.0"


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

This is abandoned and no longer maintained, therefore removing it. We already contain all the maven publish plugins for publishing instead. Confirmed publishing still works both locally and internally.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
