### PR TITLE
Add accessibility label

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="11" />
   </component>
 </project>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -3,6 +3,7 @@
   <component name="RunConfigurationProducerService">
     <option name="ignoredProducers">
       <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.AllInPackageGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestClassGradleConfigurationProducer" />
         <option value="org.jetbrains.plugins.gradle.execution.test.runner.TestMethodGradleConfigurationProducer" />

--- a/Backpack/src/androidTest/java/net/skyscanner/backpack/nudger/BpkNudgerTest.kt
+++ b/Backpack/src/androidTest/java/net/skyscanner/backpack/nudger/BpkNudgerTest.kt
@@ -88,8 +88,10 @@ class BpkNudgerTest {
       invocationsCount++
       lastCurrent = current
     }
-    subject.value = 2
-    subject.onChangeListener = listener
+    activityRule.scenario.onActivity {
+      subject.value = 2
+      subject.onChangeListener = listener
+    }
     onView(withId(R.id.bpk_nudger_decrement)).perform(click())
     assertEquals(1, lastCurrent)
     assertEquals(1, invocationsCount)

--- a/app/src/main/res/menu/settings.xml
+++ b/app/src/main/res/menu/settings.xml
@@ -2,7 +2,7 @@
   xmlns:app="http://schemas.android.com/apk/res-auto">
   <item
     android:id="@+id/settings_button"
-    android:title=""
+    android:title="Settings"
     app:showAsAction="always"
     android:icon="@drawable/bpk_settings"
     />


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Small thing I've noticed while testing accessibility - the settings option didn't have a label.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
