### PR TITLE
KOA-4630 Expand lint check to support all components

### DIFF
--- a/backpack-lint/src/main/java/net/skyscanner/backpack/lint/check/BpkComponentUsageDetector.kt
+++ b/backpack-lint/src/main/java/net/skyscanner/backpack/lint/check/BpkComponentUsageDetector.kt
@@ -102,10 +102,113 @@ class BpkComponentUsageDetector : Detector(), SourceCodeScanner, XmlScanner {
   }
 
   private enum class Component(val fullName: String, val webName: String, val componentsToReplace: Set<String>) {
+    BOTTOM_NAV(
+      fullName = "net.skyscanner.backpack.bottomnav.BpkBottomNav",
+      webName = "bottom-nav",
+      componentsToReplace = setOf("com.google.android.material.bottomnavigation.BottomNavigationView")
+    ),
+    BOTTOM_SHEET(
+      fullName = "net.skyscanner.backpack.bottomsheet.BpkBottomSheetBehaviour",
+      webName = "bottom-sheet",
+      componentsToReplace = setOf("com.google.android.material.bottomsheet.BottomSheetBehaviour")
+    ),
     BUTTON(
-      fullName = "net.skyscanner.backpack.BpkButton",
+      fullName = "net.skyscanner.backpack.button.BpkButton",
       webName = "button",
       componentsToReplace = setOf("android.widget.Button", "Button", "androidx.appcompat.widget.AppCompatButton")
+    ),
+    CALENDAR(
+      fullName = "net.skyscanner.backpack.calendar.BpkCalendar",
+      webName = "calendar",
+      componentsToReplace = setOf("java.util.Calendar", "com.google.android.material.datepicker.MaterialDatePicker")
+    ),
+    CARD(
+      fullName = "net.skyscanner.backpack.card.BpkCardView",
+      webName = "card",
+      componentsToReplace = setOf("androidx.cardview.widget.CardView")
+    ),
+    CHECKBOX(
+      fullName = "net.skyscanner.backpack.checkbox.BpkCheckbox",
+      webName = "checkbox",
+      componentsToReplace = setOf("android.widget.Checkbox", "Checkbox", "androidx.appcompat.widget.AppCompatCheckBox")
+    ),
+    CHIP(
+      fullName = "net.skyscanner.backpack.chip.BpkChip",
+      webName = "chip",
+      componentsToReplace = setOf("com.google.android.material.chip.Chip")
+    ),
+    DIALOG(
+      fullName = "net.skyscanner.backpack.dialog.BpkDialog",
+      webName = "dialog",
+      componentsToReplace = setOf("android.app.Dialog")
+    ),
+    FAB(
+      fullName = "net.skyscanner.backpack.fab.BpkFab",
+      webName = "floating-action-button",
+      componentsToReplace = setOf("com.google.android.material.floatingactionbutton.FloatingActionButton")
+    ),
+    HORIZONTAL_NAV(
+      fullName = "net.skyscanner.backpack.horisontalnav.BpkHorizontalNav",
+      webName = "horizontal-nav",
+      componentsToReplace = setOf("com.google.android.material.tabs.TabLayout")
+    ),
+    NAV_BAR(
+      fullName = "net.skyscanner.backpack.navbar.BpkNavBar",
+      webName = "navigation-bar",
+      componentsToReplace = setOf(
+        "com.google.android.material.appbar.AppBarLayout",
+        "com.google.android.material.appbar.CollapsingToolbarLayout"
+      )
+    ),
+    RADIO_BUTTON(
+      fullName = "net.skyscanner.backpack.radiobutton.BpkRadioButton",
+      webName = "radiobutton",
+      componentsToReplace = setOf(
+        "android.widget.RadioButton",
+        "RadioButton",
+        "androidx.appcompat.widget.AppCompatRadioButton"
+      )
+    ),
+    SLIDER(
+      fullName = "net.skyscanner.backpack.slider.BpkSlider",
+      webName = "slider",
+      componentsToReplace = setOf(
+        "com.google.android.material.slider.RangeSlider",
+        "com.google.android.material.slider.Slider",
+        "android.widget.SeekBar",
+        "SeekBar",
+        "androidx.appcompat.widget.AppCompatSeekBar"
+      )
+    ),
+    SNACKBAR(
+      fullName = "net.skyscanner.backpack.snackbar.BpkSnackbar",
+      webName = "snackbar",
+      componentsToReplace = setOf("com.google.android.material.snackbar.Snackbar")
+    ),
+    SPINNER(
+      fullName = "net.skyscanner.backpack.spinner.BpkSpinner",
+      webName = "spinner",
+      componentsToReplace = setOf("android.widget.ProgressBar", "ProgressBar")
+    ),
+    SWITCH(
+      fullName = "net.skyscanner.backpack.toggle.BpkSwitch",
+      webName = "switch",
+      componentsToReplace = setOf(
+        "android.widget.Switch",
+        "Switch",
+        "androidx.appcompat.widget.SwitchCompat",
+        "com.google.android.material.switchmaterial.SwitchMaterial"
+      )
+    ),
+    TEXT(
+      fullName = "net.skyscanner.backpack.text.BpkText",
+      webName = "text",
+      componentsToReplace = setOf("android.widget.TextView", "TextView", "androidx.appcompat.widget.AppCompatTextView")
+    ),
+    TOAST(
+      fullName = "net.skyscanner.backpack.toast.BpkToast",
+      webName = "toast",
+      componentsToReplace = setOf("android.widget.Toast")
     ),
     ;
 

--- a/backpack-lint/src/main/java/net/skyscanner/backpack/lint/check/BpkComponentUsageDetector.kt
+++ b/backpack-lint/src/main/java/net/skyscanner/backpack/lint/check/BpkComponentUsageDetector.kt
@@ -172,10 +172,7 @@ class BpkComponentUsageDetector : Detector(), SourceCodeScanner, XmlScanner {
     NAV_BAR(
       fullName = "net.skyscanner.backpack.navbar.BpkNavBar",
       webName = "navigation-bar",
-      componentsToReplace = setOf(
-        "com.google.android.material.appbar.AppBarLayout",
-        "com.google.android.material.appbar.CollapsingToolbarLayout"
-      )
+      componentsToReplace = setOf("com.google.android.material.appbar.CollapsingToolbarLayout")
     ),
     RADIO_BUTTON(
       fullName = "net.skyscanner.backpack.radiobutton.BpkRadioButton",

--- a/backpack-lint/src/main/java/net/skyscanner/backpack/lint/check/BpkComponentUsageDetector.kt
+++ b/backpack-lint/src/main/java/net/skyscanner/backpack/lint/check/BpkComponentUsageDetector.kt
@@ -97,6 +97,9 @@ class BpkComponentUsageDetector : Detector(), SourceCodeScanner, XmlScanner {
   }
 
   override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
+    if (!context.evaluator.isStatic(method)) {
+      return
+    }
     val className = method.containingClass?.qualifiedName ?: return
     val component = Component.findMethod(method.name, className)
     if (component != null) {

--- a/backpack-lint/src/test/java/net/skyscanner/backpack/lint/check/BpkComponentUsageDetectorTest.kt
+++ b/backpack-lint/src/test/java/net/skyscanner/backpack/lint/check/BpkComponentUsageDetectorTest.kt
@@ -42,7 +42,7 @@ class CustomButton(context: Context) : Button(context)"""
       .expectWarningCount(1)
       .expect(
         """
-src/CustomButton.kt:4: Warning: Backpack component available for android.widget.Button. Use net.skyscanner.backpack.BpkButton instead. More info at https://backpack.github.io/components/button [BpkComponentUsage]
+src/CustomButton.kt:4: Warning: Backpack component available for android.widget.Button. Use net.skyscanner.backpack.button.BpkButton instead. More info at https://backpack.github.io/components/button [BpkComponentUsage]
 class CustomButton(context: Context) : Button(context)
       ~~~~~~~~~~~~
 0 errors, 1 warnings
@@ -67,7 +67,7 @@ class View(context: Context) {
       .expectWarningCount(1)
       .expect(
         """
-src/View.kt:4: Warning: Backpack component available for android.widget.Button. Use net.skyscanner.backpack.BpkButton instead. More info at https://backpack.github.io/components/button [BpkComponentUsage]
+src/View.kt:4: Warning: Backpack component available for android.widget.Button. Use net.skyscanner.backpack.button.BpkButton instead. More info at https://backpack.github.io/components/button [BpkComponentUsage]
   private val button = Button(context)
                        ~~~~~~~~~~~~~~~
 0 errors, 1 warnings
@@ -92,7 +92,7 @@ src/View.kt:4: Warning: Backpack component available for android.widget.Button. 
       .expectWarningCount(1)
       .expect(
         """
-res/layout/native_button.xml:2: Warning: Backpack component available for Button. Use net.skyscanner.backpack.BpkButton instead. More info at https://backpack.github.io/components/button [BpkComponentUsage]
+res/layout/native_button.xml:2: Warning: Backpack component available for Button. Use net.skyscanner.backpack.button.BpkButton instead. More info at https://backpack.github.io/components/button [BpkComponentUsage]
 <Button xmlns:android="http://schemas.android.com/apk/res/android"
 ^
 0 errors, 1 warnings

--- a/backpack-lint/src/test/java/net/skyscanner/backpack/lint/check/BpkComponentUsageDetectorTest.kt
+++ b/backpack-lint/src/test/java/net/skyscanner/backpack/lint/check/BpkComponentUsageDetectorTest.kt
@@ -101,11 +101,39 @@ res/layout/native_button.xml:2: Warning: Backpack component available for Button
   }
 
   @Test
+  fun `warning when using static method of native component`() {
+    lint()
+      .files(
+        kotlin(
+          """import android.widget.Toast
+import android.content.Context
+
+class View(private val context: Context) {
+  fun showToast() {
+    Toast.makeText(context, "Toast!", Toast.LENGTH_SHORT)
+  }
+}"""
+        )
+      )
+      .issues(BpkComponentUsageDetector.ISSUE)
+      .run()
+      .expectWarningCount(1)
+      .expect(
+        """
+src/View.kt:6: Warning: Backpack component available for android.widget.Toast. Use net.skyscanner.backpack.toast.BpkToast instead. More info at https://backpack.github.io/components/toast [BpkComponentUsage]
+    Toast.makeText(context, "Toast!", Toast.LENGTH_SHORT)
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+0 errors, 1 warnings
+      """
+      )
+  }
+
+  @Test
   fun `clean when extending bpk component`() {
     lint()
       .files(
         kotlin(
-          """import net.skyscanner.backpack.BpkButton
+          """import net.skyscanner.backpack.button.BpkButton
 import android.content.Context
 
 class CustomButton(context: Context) : BpkButton(context)"""
@@ -121,7 +149,7 @@ class CustomButton(context: Context) : BpkButton(context)"""
     lint()
       .files(
         kotlin(
-          """import net.skyscanner.backpack.BpkButton
+          """import net.skyscanner.backpack.button.BpkButton
 
 class View(context: Context) {
 private val button = BpkButton(context)
@@ -143,6 +171,26 @@ private val button = BpkButton(context)
 <net.skyscanner.backpack.BpkButton xmlns:android="http://schemas.android.com/apk/res/android"
   android:layout_width="wrap_content"
   android:layout_height="wrap_content" />"""
+        )
+      )
+      .issues(BpkComponentUsageDetector.ISSUE)
+      .run()
+      .expectClean()
+  }
+
+  @Test
+  fun `clean when using static method of bpk component`() {
+    lint()
+      .files(
+        kotlin(
+          """import net.skyscanner.backpack.toast.BpkToast
+import android.content.Context
+
+class View(private val context: Context) {
+  fun showToast() {
+    BpkToast.makeText(context, "Toast!", BpkToast.LENGTH_SHORT)
+  }
+}"""
         )
       )
       .issues(BpkComponentUsageDetector.ISSUE)

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -38,6 +38,16 @@ if (packagesModified && !unreleasedModified && !declaredTrivial) {
   warn("One or more packages have changed, but `UNRELEASED.md` wasn't updated.");
 }
 
+// If any files were created, the BpkComponentUsageDetector should have been updated.
+const usageDetector = includes(
+  modifiedFiles,
+  'backpack-lint/src/main/java/net/skyscanner/backpack/lint/check/BpkComponentUsageDetector.kt',
+);
+const packageFilesCreated = createdFiles.some(filePath => filePath.startsWith('Backpack/src/main/java'));
+if (packageFilesCreated && !usageDetector && !declaredTrivial) {
+  warn("One or more package files were created, but `BpkComponentUsageDetector.kt` wasn't updated.");
+}
+
 // Ensure package-lock changes are intentional.
 const lockFileUpdated = includes(modifiedFiles, 'package-lock.json');
 if (lockFileUpdated) {


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

The lint check now supports all other components where there is a platform/material equivalent

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
