### PR TITLE
KOA-3596 Improve accessibility for star rating component

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/starrating/BpkStarRating.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/starrating/BpkStarRating.kt
@@ -20,6 +20,7 @@ package net.skyscanner.backpack.starrating
 
 import android.content.Context
 import android.util.AttributeSet
+import android.view.accessibility.AccessibilityNodeInfo
 import net.skyscanner.backpack.R
 import net.skyscanner.backpack.starrating.internal.BpkStarRatingBase
 import net.skyscanner.backpack.util.createContextThemeWrapper
@@ -27,7 +28,7 @@ import net.skyscanner.backpack.util.createContextThemeWrapper
 open class BpkStarRating @JvmOverloads constructor(
   context: Context,
   attrs: AttributeSet? = null,
-  defStyleAttr: Int = 0
+  defStyleAttr: Int = 0,
 ) : BpkStarRatingBase(
   context = createContextThemeWrapper(context, attrs, R.attr.bpkStarRatingStyle),
   attrs = attrs,
@@ -37,6 +38,18 @@ open class BpkStarRating @JvmOverloads constructor(
   full = R.drawable.bpk_star,
   starSize = context.resources.getDimensionPixelSize(R.dimen.bpkSpacingBase)
 ) {
+
+  override fun onInitializeAccessibilityNodeInfo(info: AccessibilityNodeInfo) {
+    super.onInitializeAccessibilityNodeInfo(info)
+    val text = getAccessibilityText()
+    if (text != null) {
+      if (info.contentDescription != null) {
+        info.contentDescription = "$text ${info.contentDescription}"
+      } else {
+        info.contentDescription = text
+      }
+    }
+  }
 
   final override var rating: Float
     get() = super.rating

--- a/Backpack/src/main/java/net/skyscanner/backpack/starrating/BpkStarRating.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/starrating/BpkStarRating.kt
@@ -44,6 +44,8 @@ open class BpkStarRating @JvmOverloads constructor(
     val text = getAccessibilityText()
     if (text != null) {
       if (info.contentDescription != null) {
+        // append the content description to match other announcements.
+        // Using `announceForAccessibility` or similar methods didn't get announced when focused, so this is a workaround
         info.contentDescription = "$text ${info.contentDescription}"
       } else {
         info.contentDescription = text

--- a/Backpack/src/main/java/net/skyscanner/backpack/starrating/internal/BpkStarRatingBase.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/starrating/internal/BpkStarRatingBase.kt
@@ -39,7 +39,7 @@ open class BpkStarRatingBase internal constructor(
   @DrawableRes empty: Int,
   @DrawableRes half: Int,
   @DrawableRes full: Int,
-  @Px private val starSize: Int
+  @Px private val starSize: Int,
 ) : LinearLayoutCompat(context, attrs, defStyleAttr) {
 
   private val empty: Drawable
@@ -65,6 +65,14 @@ open class BpkStarRatingBase internal constructor(
       update()
     }
 
+  var accessibilityStatusRes: Int? = null
+    set(value) {
+      field = value
+      if (importantForAccessibility == IMPORTANT_FOR_ACCESSIBILITY_AUTO && accessibilityStatusRes != null) {
+        importantForAccessibility = IMPORTANT_FOR_ACCESSIBILITY_YES
+      }
+    }
+
   init {
     orientation = HORIZONTAL
     var starColor = context.getColor(R.color.__starRatingStarColor)
@@ -79,6 +87,7 @@ open class BpkStarRatingBase internal constructor(
       _rating = it.getFloat(R.styleable.BpkStarRating_rating, maxRating / 2f)
       starColor = it.getColor(R.styleable.BpkStarRating_starColor, starColor)
       starFilledColor = it.getColor(R.styleable.BpkStarRating_starFilledColor, starFilledColor)
+      accessibilityStatusRes = it.getResourceId(R.styleable.BpkStarRating_accessibilityStatus, 0).takeIf { it != 0 }
     }
 
     this.empty = getDrawable(empty, starColor)
@@ -91,6 +100,9 @@ open class BpkStarRatingBase internal constructor(
     super.onRtlPropertiesChanged(layoutDirection)
     update()
   }
+
+  protected fun getAccessibilityText(): String? =
+    accessibilityStatusRes?.let { context.resources.getString(it, rating, maxRating) }
 
   private fun update() {
     half.isAutoMirrored = layoutDirection == View.LAYOUT_DIRECTION_RTL

--- a/Backpack/src/main/res/drawable/bpk_star_rating.xml
+++ b/Backpack/src/main/res/drawable/bpk_star_rating.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+  <item android:id="@android:id/background" android:drawable="@drawable/bpk_star_outline" />
+  <item android:id="@android:id/secondaryProgress" android:drawable="@drawable/bpk_star" />
+  <item android:id="@android:id/progress" android:drawable="@drawable/bpk_star_half" />
+</layer-list>

--- a/Backpack/src/main/res/drawable/bpk_star_rating.xml
+++ b/Backpack/src/main/res/drawable/bpk_star_rating.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-
-  <item android:id="@android:id/background" android:drawable="@drawable/bpk_star_outline" />
-  <item android:id="@android:id/secondaryProgress" android:drawable="@drawable/bpk_star" />
-  <item android:id="@android:id/progress" android:drawable="@drawable/bpk_star_half" />
-</layer-list>

--- a/Backpack/src/main/res/values/attrs.xml
+++ b/Backpack/src/main/res/values/attrs.xml
@@ -121,6 +121,7 @@
     <attr name="starFilledColor" format="color" />
     <attr name="rating" format="float" />
     <attr name="maxRating" format="integer" />
+    <attr name="accessibilityStatus" format="reference" />
   </declare-styleable>
 
   <declare-styleable name="BpkHorizontalNav">

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -3,6 +3,9 @@
 > Place your changes below this line.
 >
 
+**Added:**
+- Accessibility support for `BpkStarRating` and `BpkStarRatingInteractive` - set the new `accessibilityStatus` attribute for better announcements.
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).

--- a/app/src/main/res/layout/fragment_star_rating_default.xml
+++ b/app/src/main/res/layout/fragment_star_rating_default.xml
@@ -16,6 +16,8 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginBottom="@dimen/bpkSpacingLg"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:maxRating="5"
     app:rating="0.0" />
 
@@ -29,6 +31,8 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginBottom="@dimen/bpkSpacingLg"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:maxRating="5"
     app:rating="2.5" />
 
@@ -42,6 +46,8 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginBottom="@dimen/bpkSpacingLg"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:maxRating="5"
     app:rating="5" />
 

--- a/app/src/main/res/layout/fragment_star_rating_interactive.xml
+++ b/app/src/main/res/layout/fragment_star_rating_interactive.xml
@@ -17,6 +17,8 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginBottom="@dimen/bpkSpacingLg"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_accessibility_status"
     app:maxRating="5"
     app:rating="0.0" />
 
@@ -30,6 +32,8 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginBottom="@dimen/bpkSpacingLg"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_accessibility_status"
     app:maxRating="5"
     app:rating="3" />
 
@@ -43,6 +47,8 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginBottom="@dimen/bpkSpacingLg"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_accessibility_status"
     app:maxRating="5"
     app:rating="5" />
 
@@ -58,6 +64,8 @@
     android:layout_height="wrap_content"
     android:layout_marginBottom="@dimen/bpkSpacingLg"
     android:layoutDirection="rtl"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_accessibility_status"
     app:maxRating="5"
     app:rating="2" />
 
@@ -71,6 +79,8 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
     android:layout_marginBottom="@dimen/bpkSpacingLg"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_accessibility_status"
     app:maxRating="8"
     app:rating="5" />
 

--- a/app/src/main/res/layout/fragment_star_rating_max.xml
+++ b/app/src/main/res/layout/fragment_star_rating_max.xml
@@ -9,59 +9,79 @@
   <net.skyscanner.backpack.starrating.BpkStarRating
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:maxRating="10"
     app:rating="-0.5" />
 
   <net.skyscanner.backpack.starrating.BpkStarRating
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:maxRating="10"
     app:rating="0.0" />
 
   <net.skyscanner.backpack.starrating.BpkStarRating
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:maxRating="10"
     app:rating="0.49" />
 
   <net.skyscanner.backpack.starrating.BpkStarRating
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:maxRating="10"
     app:rating="0.5" />
 
   <net.skyscanner.backpack.starrating.BpkStarRating
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:maxRating="10"
     app:rating="0.99" />
 
   <net.skyscanner.backpack.starrating.BpkStarRating
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:maxRating="10"
     app:rating="1.0" />
 
   <net.skyscanner.backpack.starrating.BpkStarRating
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:maxRating="10" />
 
   <net.skyscanner.backpack.starrating.BpkStarRating
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:maxRating="10"
     app:rating="9.5" />
 
   <net.skyscanner.backpack.starrating.BpkStarRating
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:maxRating="10"
     app:rating="10.0" />
 
   <net.skyscanner.backpack.starrating.BpkStarRating
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:maxRating="10"
     app:rating="10.5" />
 

--- a/app/src/main/res/layout/fragment_star_rating_values.xml
+++ b/app/src/main/res/layout/fragment_star_rating_values.xml
@@ -1,58 +1,78 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
   xmlns:app="http://schemas.android.com/apk/res-auto"
+  style="@style/App.Story"
   android:layout_width="match_parent"
   android:layout_height="match_parent"
-  android:orientation="vertical"
-  style="@style/App.Story">
+  android:orientation="vertical">
 
   <net.skyscanner.backpack.starrating.BpkStarRating
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:rating="-0.5" />
 
   <net.skyscanner.backpack.starrating.BpkStarRating
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:rating="0.0" />
 
   <net.skyscanner.backpack.starrating.BpkStarRating
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:rating="0.49" />
 
   <net.skyscanner.backpack.starrating.BpkStarRating
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:rating="0.5" />
 
   <net.skyscanner.backpack.starrating.BpkStarRating
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:rating="0.99" />
 
   <net.skyscanner.backpack.starrating.BpkStarRating
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:rating="1.0" />
 
   <net.skyscanner.backpack.starrating.BpkStarRating
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content" />
+    android:layout_height="wrap_content"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status" />
 
   <net.skyscanner.backpack.starrating.BpkStarRating
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:rating="4.5" />
 
   <net.skyscanner.backpack.starrating.BpkStarRating
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:rating="5.0" />
 
   <net.skyscanner.backpack.starrating.BpkStarRating
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
+    android:contentDescription="Rating"
+    app:accessibilityStatus="@string/star_rating_decimal_accessibility_status"
     app:rating="5.5" />
 
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -38,6 +38,9 @@
     <item>High Subtitle</item>
   </string-array>
 
+  <string name="star_rating_accessibility_status">%.0f out of %d</string>
+  <string name="star_rating_decimal_accessibility_status">%.1f out of %d</string>
+
   <string name="bottom_nav_home">Home</string>
   <string name="bottom_nav_explore">Explore</string>
   <string name="bottom_nav_trips">Trips</string>

--- a/docs/InteractiveStarRating/README.md
+++ b/docs/InteractiveStarRating/README.md
@@ -37,3 +37,15 @@ BpkInteractiveStarRating(context).apply {
 - `starFilledColor`
 
 Styles can be changed globally through `bpkInteractiveStarRatingStyle`. Check [theming](https://github.com/Skyscanner/backpack-android/blob/main/docs/THEMING.md) for more information.
+
+
+## Accessibility
+
+To ensure this component is accessible set a `contentDescription` for the component.
+To improve status announcements you can set `accessibilityStatusRes` in both XML and Kotlin/Java to announce `x out of y` instead of `x% out of 100%`.
+
+The string resource needs to contain a `%f` and `%d` placeholder:
+
+```xml
+<string name="star_rating_accessibility_status">%.0f out of %d</string>
+```

--- a/docs/StarRating/README.md
+++ b/docs/StarRating/README.md
@@ -35,3 +35,16 @@ BpkStarRating(context).apply {
 - `starFilledColor`
 
 Styles can be changed globally through `bpkStarRatingStyle`. Check [theming](https://github.com/Skyscanner/backpack-android/blob/main/docs/THEMING.md) for more information.
+
+## Accessibility
+
+To ensure this component is accessible set a `contentDescription` for the component, unless there is a label indicating the rating available.
+For simpler logic you can also set `accessibilityStatusRes` in both XML and Kotlin/Java to announce `x out of y`.
+
+The string resource needs to contain a `%f` and `%d` placeholder:
+
+```xml
+<string name="star_rating_accessibility_status">%.0f out of %d</string>
+```
+
+If both `contentDescription` and `accessibilityStatusRes` are set the `contentDescription` will be appended to the accessibility status to match status description behaviour.


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

The star rating component was lacking accessibility - the interactive component was not possible to be controlled while using talkback. This adds accessibility support to both the static and interactive rating control by adding a new `accessibilityStatus` attribute to be set by consumers. For the interactive component there is a big difference between Android 11/sdk version 30 and below as a new API was added to improve announcements for controls.

(sorry the video + audio is massively out of sync - thank Android Studio for that)

https://user-images.githubusercontent.com/1529791/122533410-72941800-d019-11eb-9c34-23c2fc5e6f97.mp4

https://user-images.githubusercontent.com/1529791/122533402-7031be00-d019-11eb-8606-3d9934aa61ec.mp4

https://user-images.githubusercontent.com/1529791/122533413-732cae80-d019-11eb-8e2b-120b1d612cf8.mp4

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
