### PR TITLE
Add alternative to mksdcard instructions for OSX

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,13 +43,13 @@ Create an AVD using the following command
 $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd --name "bpk-droid-avd" --force --package "system-images;android-24;google_apis;x86" --device "Nexus 4" && cp bpk-droid-local.ini ~/.android/avd/bpk-droid-avd.avd/config.ini
 ```
 
-Create an SDCard for the screenshot tests (Linux)
+Create an SD card for the screenshot tests (Linux)
 
 ```
 $ANDROID_HOME/tools/mksdcard -l e 512M sd.img
 ```
 
-Create an SDCard for the screenshot tests (OSX)
+Create an SD card for the screenshot tests (OSX)
 
 ```
 hdiutil create -megabytes 512 -fs MS-DOS -layout NONE -o sd && mv sd.dmg sd.img

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,11 +37,22 @@ Given that you have a compatible environment as stated above you can now set up 
 ## Testing
 
 #### Snapshot testing
-Create an AVD using the following commands
+Create an AVD using the following command
 
 ```
 $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd --name "bpk-droid-avd" --force --package "system-images;android-24;google_apis;x86" --device "Nexus 4" && cp bpk-droid-local.ini ~/.android/avd/bpk-droid-avd.avd/config.ini
+```
+
+Create an SDCard for the screenshot tests (Linux)
+
+```
 $ANDROID_HOME/tools/mksdcard -l e 512M sd.img
+```
+
+Create an SDCard for the screenshot tests (OSX)
+
+```
+hdiutil create -megabytes 512 -fs MS-DOS -layout NONE -o sd && mv sd.dmg sd.img
 ```
 
 Snapshot testing depends on a python package which can be installed as:


### PR DESCRIPTION
Added instructions on how to create an SDCard on OSX. This was preventing contributors from running the screenshot tests. 
The change is basically an instruction on how to run `hdiutil` which would create an sdcard image which is usable by android.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
