### PR TITLE
Fix for calendar2 not formatting months with less days than the current day

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/calendar2/data/CalendarMonth.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/calendar2/data/CalendarMonth.kt
@@ -81,8 +81,10 @@ internal inline fun CalendarMonth(
 // see https://github.com/ThreeTen/threetenbp/issues/55
 @Suppress("DEPRECATION")
 internal fun MonthTitle(yearMonth: YearMonth, formatter: SimpleDateFormat, locale: Locale): String {
-  val date = Date()
-  date.year = yearMonth.year - 1900
-  date.month = yearMonth.monthValue - 1
+  val date = Date(
+    yearMonth.year - 1900,
+    yearMonth.monthValue - 1,
+    2 // Lock the formatter date to 2nd, so it accounts for -12h tz and the month is predictable
+  )
   return formatter.format(date).capitalize(locale)
 }

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,7 +1,10 @@
 # Unreleased
 
 > Place your changes below this line.
->
+
+**Fixed:**
+
+- Fixed an issue with Calendar2, where current months with less days than the current day were incorrectly formatted to the next month.
 
 ## How to write a good changelog entry
 


### PR DESCRIPTION
Calendar2 was failing to correctly create the label for any month which had less days than the current day. 
For example, if it tried formatting February on 30th of any month then the label would come off as March. This was due to using a `Date()` without resetting the day(date) value, thus the formatter incorrectly interpreting this as the next month. 

The fix is to reset the `Date()` object to a well know day. In order to avoid TZ issues I've set it up as 2.

Adding new automated test cases will require a discussion around the design of the component.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [ ] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
