### PR TITLE
KOA-4749 Add compose tab

### DIFF
--- a/app/src/main/java/net/skyscanner/backpack/demo/data/ComponentRegistry.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/data/ComponentRegistry.kt
@@ -18,8 +18,13 @@
 
 package net.skyscanner.backpack.demo.data
 
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import net.skyscanner.backpack.demo.R
 import net.skyscanner.backpack.demo.stories.BarChartStory
 import net.skyscanner.backpack.demo.stories.BottomNavStory
@@ -127,6 +132,9 @@ private infix fun String.story(story: NodeData): Pair<String, NodeItem> {
  * Helper class to register the fragments for components
  */
 object ComponentRegistry {
+
+  private val TAB_TITLE_COMPOSE = "Compose"
+  private val TAB_TITLE_VIEW = "View"
 
   private val COMPONENTS_TREE = mapOf(
     "Badge" story NodeData { Story of R.layout.fragment_badge },
@@ -304,8 +312,15 @@ object ComponentRegistry {
     "Sneak peek" story NodeData(
       { children -> TabStory of children },
       mapOf(
-        "Compose" composeStory { Text(text = ("Hello!")) },
-        "View" story NodeData { Story of R.layout.fragment_icons },
+        TAB_TITLE_COMPOSE composeStory {
+          Text(
+            text = "Coming soon",
+            modifier = Modifier.padding(16.dp),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.h5
+          )
+        },
+        TAB_TITLE_VIEW story NodeData { Story of R.layout.component_list },
       )
     ),
   )

--- a/app/src/main/java/net/skyscanner/backpack/demo/data/ComponentRegistry.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/data/ComponentRegistry.kt
@@ -51,6 +51,7 @@ import net.skyscanner.backpack.demo.stories.Story.Companion.scrollable
 import net.skyscanner.backpack.demo.stories.Story.Companion.with
 import net.skyscanner.backpack.demo.stories.StyleableButtonStory
 import net.skyscanner.backpack.demo.stories.SubStory
+import net.skyscanner.backpack.demo.stories.TabStory
 import net.skyscanner.backpack.demo.stories.TextSpansStory
 import net.skyscanner.backpack.demo.stories.ToastStory
 
@@ -86,7 +87,7 @@ class NodeItem(
     var fullName = this.name
 
     while (parent != null) {
-      fullName = "${parent.name} - $name"
+      fullName = "${parent.name} - $fullName"
       parent = parent.getParent()
     }
 
@@ -284,6 +285,19 @@ object ComponentRegistry {
     "Text Field" story NodeData { Story of R.layout.fragment_text_fields },
     "Text Spans" story NodeData { TextSpansStory of R.layout.fragment_text_spans },
     "Toast" story NodeData { ToastStory of R.layout.fragment_toasts },
+    "Sneak peek" story NodeData(
+      { children -> TabStory of children },
+      mapOf(
+        "Compose" story NodeData(
+          { children -> SubStory of children },
+          mapOf(
+            "Very" story NodeData { Story of R.layout.fragment_text },
+            "Exciting" story NodeData { Story of R.layout.fragment_text_emphasized },
+          )
+        ),
+        "View" story NodeData { Story of R.layout.fragment_icons },
+      )
+    ),
   )
 
   private val TOKENS_MAP = mapOf(
@@ -324,7 +338,7 @@ object ComponentRegistry {
     story ?: throw IllegalArgumentException("Invalid story name - $fullyQualifiedName")
 
     return rest.fold(story) { result, item ->
-      return result.subItems[item]
+      result.subItems[item] as? NodeItem
         ?: throw IllegalArgumentException("Invalid story name - $fullyQualifiedName")
     }
   }

--- a/app/src/main/java/net/skyscanner/backpack/demo/data/ComponentRegistry.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/data/ComponentRegistry.kt
@@ -18,6 +18,8 @@
 
 package net.skyscanner.backpack.demo.data
 
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
 import net.skyscanner.backpack.demo.R
 import net.skyscanner.backpack.demo.stories.BarChartStory
 import net.skyscanner.backpack.demo.stories.BottomNavStory
@@ -26,6 +28,7 @@ import net.skyscanner.backpack.demo.stories.ChangeableButtonsStory
 import net.skyscanner.backpack.demo.stories.ChipStory
 import net.skyscanner.backpack.demo.stories.ColorStory
 import net.skyscanner.backpack.demo.stories.ColoredCalendarStory
+import net.skyscanner.backpack.demo.stories.ComposeStory
 import net.skyscanner.backpack.demo.stories.DefaultCalendarStory
 import net.skyscanner.backpack.demo.stories.DialogStory
 import net.skyscanner.backpack.demo.stories.DisabledCalendarStory
@@ -63,7 +66,7 @@ interface RegistryItem {
   fun getFullyQualifiedName(): String
 }
 
-class NodeItem(
+open class NodeItem(
   override val name: String,
   private val creator: (items: Array<String>) -> Story,
   items: Map<String, RegistryItem> = emptyMap(),
@@ -95,12 +98,25 @@ class NodeItem(
   }
 }
 
+class ComposeNode(
+  name: String,
+  val composable: @Composable () -> Unit
+) : NodeItem(name, { Story() }) {
+  override fun createStory(): Story {
+    return ComposeStory of getFullyQualifiedName()
+  }
+}
+
 private class NodeData(
   val creator: (items: Array<String>) -> Story,
   val items: Map<String, RegistryItem> = emptyMap(),
 ) {
 
   constructor(creator: () -> Story) : this({ _ -> creator() })
+}
+
+private infix fun String.composeStory(composable: @Composable () -> Unit): Pair<String, NodeItem> {
+  return Pair(this, ComposeNode(this, composable))
 }
 
 private infix fun String.story(story: NodeData): Pair<String, NodeItem> {
@@ -288,13 +304,7 @@ object ComponentRegistry {
     "Sneak peek" story NodeData(
       { children -> TabStory of children },
       mapOf(
-        "Compose" story NodeData(
-          { children -> SubStory of children },
-          mapOf(
-            "Very" story NodeData { Story of R.layout.fragment_text },
-            "Exciting" story NodeData { Story of R.layout.fragment_text_emphasized },
-          )
-        ),
+        "Compose" composeStory { Text(text = ("Hello!")) },
         "View" story NodeData { Story of R.layout.fragment_icons },
       )
     ),

--- a/app/src/main/java/net/skyscanner/backpack/demo/stories/ComposeStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/stories/ComposeStory.kt
@@ -1,0 +1,56 @@
+/**
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018-2021 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.skyscanner.backpack.demo.stories
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import net.skyscanner.backpack.demo.data.ComponentRegistry
+import net.skyscanner.backpack.demo.data.ComposeNode
+
+open class ComposeStory : Story() {
+
+  override fun onCreateView(
+    inflater: LayoutInflater,
+    container: ViewGroup?,
+    savedInstanceState: Bundle?
+  ): View? {
+    val composable = arguments?.getString(ID) ?: savedInstanceState?.getString(ID)
+    if (composable != null) {
+      return ComposeView(requireContext()).apply {
+        setContent {
+          (ComponentRegistry.getStoryCreator(composable) as ComposeNode).composable()
+        }
+      }
+    } else {
+      throw IllegalStateException("Story has not been property initialized")
+    }
+  }
+
+  companion object {
+    const val ID = "id"
+
+    infix fun of(id: String) = ComposeStory().apply {
+      arguments = Bundle()
+      arguments?.putString(ID, id)
+    }
+  }
+}

--- a/app/src/main/java/net/skyscanner/backpack/demo/stories/TabStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/stories/TabStory.kt
@@ -1,0 +1,71 @@
+/**
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018-2021 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.skyscanner.backpack.demo.stories
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import androidx.viewpager2.widget.ViewPager2
+import com.google.android.material.tabs.TabLayoutMediator
+import net.skyscanner.backpack.demo.R
+import net.skyscanner.backpack.demo.data.ComponentRegistry
+import net.skyscanner.backpack.horisontalnav.BpkHorizontalNav
+
+open class TabStory : Story() {
+
+  override fun onCreateView(
+    inflater: LayoutInflater,
+    container: ViewGroup?,
+    savedInstanceState: Bundle?
+  ): View? {
+    val stories = arguments?.getStringArray(STORIES) ?: savedInstanceState?.getStringArray(STORIES)
+    if (stories != null) {
+      val view = inflater.inflate(R.layout.fragment_tabs, container, false)
+      val tabBar = view.findViewById<BpkHorizontalNav>(R.id.tab_bar)
+      val viewPager = view.findViewById<ViewPager2>(R.id.view_pager)
+
+      viewPager.adapter = object : FragmentStateAdapter(this) {
+        override fun getItemCount(): Int = stories.size
+
+        override fun createFragment(position: Int): Fragment =
+          ComponentRegistry.getStoryCreator(stories[position]).createStory()
+      }
+
+      TabLayoutMediator(tabBar, viewPager) { tab, position ->
+        tab.text = ComponentRegistry.getStoryCreator(stories[position]).name
+      }.attach()
+
+      return view
+    } else {
+      throw IllegalStateException("Story has not been property initialized")
+    }
+  }
+
+  companion object {
+    const val STORIES = "stories"
+
+    infix fun of(stories: Array<String>) = TabStory().apply {
+      arguments = Bundle()
+      arguments?.putStringArray(STORIES, stories)
+    }
+  }
+}

--- a/app/src/main/res/layout/fragment_tabs.xml
+++ b/app/src/main/res/layout/fragment_tabs.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:app="http://schemas.android.com/apk/res-auto"
+  android:layout_width="match_parent"
+  android:layout_height="match_parent">
+
+  <net.skyscanner.backpack.horisontalnav.BpkHorizontalNav
+    android:id="@+id/tab_bar"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    app:layout_constraintTop_toTopOf="parent"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    />
+
+  <androidx.viewpager2.widget.ViewPager2
+    android:id="@+id/view_pager"
+    android:layout_width="match_parent"
+    android:layout_height="0dp"
+    app:layout_constraintTop_toBottomOf="@id/tab_bar"
+    app:layout_constraintStart_toStartOf="parent"
+    app:layout_constraintEnd_toEndOf="parent"
+    app:layout_constraintBottom_toBottomOf="parent"/>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Added a new `TabStory` which allows having tabs for entries. Also added the option to add a compose story without much boilerplate.
![device-2021-09-28-115521](https://user-images.githubusercontent.com/1529791/135074258-0d8edb38-df93-462d-9439-ac294faa600d.png)


+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
