### PR TITLE
RALP-3221: improve accessibility by changing unselected color of text in navigation bar

### DIFF
--- a/Backpack/src/main/res/values/internal.semantic.color.xml
+++ b/Backpack/src/main/res/values/internal.semantic.color.xml
@@ -31,7 +31,7 @@
   <color name="__textFieldIcon">@color/bpkSkyGrayTint02</color>
   <color name="__textFieldBorder">@color/bpkSkyGrayTint04</color>
   <color name="__textFieldBorderDisabled">@color/bpkSkyGrayTint06</color>
-  <color name="__bottomNavUnselected">@color/bpkSkyGrayTint04</color>
+  <color name="__bottomNavUnselected">@color/bpkSkyGrayTint03</color>
 
   <color name="__barChartInactivatedColor">@color/bpkSkyGrayTint03</color>
   <color name="__barChartActivatedColor">@color/bpkMonteverde</color>


### PR DESCRIPTION
Improve accessibility by changing unselected color of text in navigation bar

Before
<img src="https://user-images.githubusercontent.com/92928366/138284685-90096702-1274-4baa-9005-9379cc9434fe.png" width="340" height="680">

After
<img src="https://user-images.githubusercontent.com/92928366/138284696-1bae4be0-d3e4-473e-be6a-ef9adff0747a.png" width="340" height="680">


<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->
+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
