### PR TITLE
Add check on minValue and maxValue in BpkNudger

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/nudger/BpkNudger.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/nudger/BpkNudger.kt
@@ -53,6 +53,7 @@ open class BpkNudger @JvmOverloads constructor(
       if (field != value) {
         field = value.coerceIn(minValue, maxValue)
         update()
+        updateEnabledFields()
       }
     }
 
@@ -66,6 +67,7 @@ open class BpkNudger @JvmOverloads constructor(
         this.value = max(this.value, value)
         update()
       }
+      updateEnabledFields()
     }
 
   var maxValue: Int = 100
@@ -78,6 +80,7 @@ open class BpkNudger @JvmOverloads constructor(
         this.value = min(this.value, value)
         update()
       }
+      updateEnabledFields()
     }
 
   var onChangeListener: ((Int) -> Unit)? = null
@@ -105,8 +108,11 @@ open class BpkNudger @JvmOverloads constructor(
   }
 
   private fun update() {
+    label.text = value.toString()
+  }
+
+  private fun updateEnabledFields() {
     decrementButton.isEnabled = value > minValue
     incrementButton.isEnabled = value < maxValue
-    label.text = value.toString()
   }
 }

--- a/Backpack/src/main/java/net/skyscanner/backpack/nudger/BpkNudger.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/nudger/BpkNudger.kt
@@ -58,22 +58,26 @@ open class BpkNudger @JvmOverloads constructor(
 
   var minValue: Int = 0
     set(value) {
-      if (value > maxValue) {
-        throw IllegalArgumentException("Cannot set minValue $value when maxValue is $maxValue")
+      if (field != value) {
+        if (value > maxValue) {
+          throw IllegalArgumentException("Cannot set minValue $value when maxValue is $maxValue")
+        }
+        field = value
+        this.value = max(this.value, value)
+        update()
       }
-      field = value
-      this.value = max(this.value, value)
-      update()
     }
 
   var maxValue: Int = 100
     set(value) {
-      if (value < minValue) {
-        throw IllegalArgumentException("Cannot set maxValue $value when minValue is $minValue")
+      if (field != value) {
+        if (value < minValue) {
+          throw IllegalArgumentException("Cannot set maxValue $value when minValue is $minValue")
+        }
+        field = value
+        this.value = min(this.value, value)
+        update()
       }
-      field = value
-      this.value = min(this.value, value)
-      update()
     }
 
   var onChangeListener: ((Int) -> Unit)? = null

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,10 @@
 # Unreleased
 
 > Place your changes below this line.
+**Fixed:**
+
+- `net.skyscanner.backpack.nudger`:
+  - Added extra check on BpkNudger to improve its use with screen readers.
 
 ## How to write a good changelog entry
 


### PR DESCRIPTION
When using more than one `BpkNudger` in a screen, if we need to re-create them and set the value of `minValue` and `maxValue`, the update() method is called even if the field value has not changed.
This causes screen readers to read the values again, even if there was no change.
By adding an extra check we enable apps with this scenario to re-create `BpkNudgers` and only have one value (the one that was updated) to be read by the screen reader. 

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
