### PR TITLE
Enable uploading all failure artifacts from screenshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,7 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@v2
         with:
-          name: ${{ env.flavour }}${{ env.config }}-screenshot-test-output
+          name: ${{ env.flavour }}${{ env.config }}-${{ matrix.variant }}-screenshot-test-output
           path: app/build/screenshots${{ env.flavour }}${{ env.config }}AndroidTest/
           retention-days: 5
 


### PR DESCRIPTION
Currently when screenshots fail we try to upload an archive containing the results. However, due to running 4 flavours, and defining the same name for the zipped artifact the results get overwriten. 

This PR adds the matrix variant name to the screenshot testing artifact. Which would allow us to upload all falures.


+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] `UNRELEASED.md`
+ [ ] `README.md`
+ [ ] Tests
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
