### PR TITLE
Comment on a PR when screenshot tests fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,7 @@ jobs:
           script: echo "Generated AVD snapshot for caching."
 
       - name: Screenshot Tests
+        id: screenshotTests
         uses: reactivecircus/android-emulator-runner@v2
         with:
           target: google_apis
@@ -199,6 +200,8 @@ jobs:
           script: |
             sudo easy_install Pillow==6.2.2
             ./gradlew :app:record${{ env.flavour }}${{ env.config }}AndroidTestScreenshotTest -Pandroid.testInstrumentationRunnerArguments.variant=${{ matrix.variant }}
+           
+            changedFiles=`git diff --name-only` && echo "::set-output name=CHANGED_FILES::${changedFiles//$'\n'/'%0A'}"
             ./scripts/check-no-changes.sh
 
       - name: Upload Screenshot Tests Artifact
@@ -207,7 +210,22 @@ jobs:
         with:
           name: ${{ env.flavour }}${{ env.config }}-${{ matrix.variant }}-screenshot-test-output
           path: app/build/screenshots${{ env.flavour }}${{ env.config }}AndroidTest/
-          retention-days: 5
+          retention-days: 5 
+
+      - name: Notify PR of screenshots failure
+        if: ${{ failure() }}
+        uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### '${{ matrix.variant }}' files were changed.
+              If these changes are intentional please run \`./scripts/record_screenshot_tests.sh\` locally and commit the changes.
+              
+              >'${{ steps.screenshotTests.outputs.CHANGED_FILES }}'`
+            })
 
   Deploy:
     name: Deploy


### PR DESCRIPTION
This PR enables commenting on a PR if the screenshot tests fail. 
One comment per failing flavour will be posted, specifying the paths to the screenshots that have failed. It does not add protection agains having all screenshots failing. 



+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
