### PR TITLE
Set build timeout on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,7 +215,7 @@ jobs:
   Deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    needs: [Java, Android, Screenshots]
+    needs: [Build, Android, Screenshots]
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   Build:
     name: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -74,7 +74,7 @@ jobs:
   Android:
     name: Android tests
     runs-on: macos-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -134,7 +134,7 @@ jobs:
   Screenshots:
     name: Screenshots tests
     runs-on: macos-latest
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -216,7 +216,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     needs: [Build, Android, Screenshots]
-    timeout-minutes: 45
+    timeout-minutes: 30
 
     steps:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   Java:
     name: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 1
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ env:
 
 jobs:
 
-  Java:
+  Build:
     name: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 1
+    timeout-minutes: 45
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
   Java:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     strategy:
       fail-fast: false
@@ -73,6 +74,7 @@ jobs:
   Android:
     name: Android tests
     runs-on: macos-latest
+    timeout-minutes: 45
 
     strategy:
       fail-fast: false
@@ -132,6 +134,7 @@ jobs:
   Screenshots:
     name: Screenshots tests
     runs-on: macos-latest
+    timeout-minutes: 45
 
     strategy:
       fail-fast: false
@@ -213,6 +216,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     needs: [Java, Android, Screenshots]
+    timeout-minutes: 45
 
     steps:
 


### PR DESCRIPTION
Currently jobs time out after 6 hours. However most jobs finish after 15 minutes with some outliers getting closer to 30 minutes. Setting a default timeout to 45 minutes should be enough to cover some of the longer builds without wasting too much CI time for when CI is hanging.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
