### PR TITLE
Remove autofix behaviour from ktlint git prehook

### DIFF
--- a/scripts/lint-staged-ktlint.sh
+++ b/scripts/lint-staged-ktlint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Backpack for Android - Skyscanner's Design System
 #
-# Copyright 2018-2021 Skyscanner Ltd
+# Copyright 2018-2022 Skyscanner Ltd
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,5 +20,10 @@
 
 ALL_FILES=$*
 
-./gradlew ktlintFormat -Pfiles="$ALL_FILES"
-git add .
+./gradlew ktlintCheck -Pfiles="$ALL_FILES"
+
+if [ $? -ne 0 ]; then
+  echo "Run './gradlew ktlintFormat' to fix issues"
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Fixing issues on the fly means there might be unintended changes. It also meant that splitting up changes into various commits was impossible as all files were added to the commit. Only check for ktlint errors and throw an error instead.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
