### PR TITLE
KOA-4792 Add lint check for compose component usage

### DIFF
--- a/app/src/main/java/net/skyscanner/backpack/demo/compose/ThemeStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/compose/ThemeStory.kt
@@ -26,22 +26,18 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.AlertDialog
 import androidx.compose.material.BottomAppBar
-import androidx.compose.material.Button
-import androidx.compose.material.Card
 import androidx.compose.material.Checkbox
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ExtendedFloatingActionButton
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
 import androidx.compose.material.LinearProgressIndicator
-import androidx.compose.material.OutlinedButton
 import androidx.compose.material.RadioButton
 import androidx.compose.material.Slider
 import androidx.compose.material.Snackbar
 import androidx.compose.material.Switch
 import androidx.compose.material.Tab
 import androidx.compose.material.TabRow
-import androidx.compose.material.TextButton
 import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -54,11 +50,13 @@ import androidx.compose.ui.unit.dp
 import com.google.accompanist.flowlayout.FlowCrossAxisAlignment
 import com.google.accompanist.flowlayout.FlowMainAxisAlignment
 import com.google.accompanist.flowlayout.FlowRow
+import net.skyscanner.backpack.compose.button.BpkButton
+import net.skyscanner.backpack.compose.button.BpkButtonType
+import net.skyscanner.backpack.compose.card.BpkCard
 import net.skyscanner.backpack.compose.icons.BpkIcons
 import net.skyscanner.backpack.compose.icons.lg.Flight
 import net.skyscanner.backpack.compose.text.BpkText
 import net.skyscanner.backpack.compose.theme.BpkTheme
-import net.skyscanner.backpack.compose.tokens.BpkElevation
 import net.skyscanner.backpack.compose.tokens.BpkSpacing
 import net.skyscanner.backpack.demo.R
 
@@ -94,35 +92,21 @@ fun ThemeStory() {
       }
     }
 
-    Button(onClick = { }) {
-      BpkText(text = "Primary button")
-    }
+    BpkButton(text = "Primary button", onClick = { })
 
-    OutlinedButton(onClick = { }) {
-      BpkText(text = "Outlined button")
-    }
-
-    TextButton(onClick = { }) {
-      BpkText(text = "Text button")
-    }
+    BpkButton(text = "Secondary button", type = BpkButtonType.Secondary, onClick = { })
 
     var showAlertDialog by remember { mutableStateOf(false) }
-    Button(onClick = { showAlertDialog = true }) {
-      BpkText(text = "Alert dialog")
-    }
+    BpkButton(text = "Alert dialog", onClick = { showAlertDialog = true })
     if (showAlertDialog) {
       AlertDialog(
         onDismissRequest = { showAlertDialog = false },
         title = { BpkText(text = "Alert dialog") },
         confirmButton = {
-          TextButton(onClick = { showAlertDialog = false }) {
-            BpkText(text = "OK")
-          }
+          BpkButton(text = "OK", onClick = { showAlertDialog = false })
         },
         dismissButton = {
-          TextButton(onClick = { showAlertDialog = false }) {
-            BpkText(text = "Cancel")
-          }
+          BpkButton(text = "Cancel", type = BpkButtonType.Secondary, onClick = { showAlertDialog = false })
         },
         text = {
           BpkText(text = stringResource(id = R.string.stub))
@@ -155,7 +139,7 @@ fun ThemeStory() {
       onClick = { },
     )
 
-    Card(elevation = BpkElevation.Lg) {
+    BpkCard(focused = true) {
       BpkText(modifier = Modifier.padding(all = BpkSpacing.Base), text = "Card")
     }
 

--- a/backpack-compose/CHANGELOG.md
+++ b/backpack-compose/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 [Unreleased changes](UNRELEASED.md).
 
+# 0.2.0
+
+**Added:**
+
+- New `BpkButton` component
+- New `focused` property for `BpkCard`
+
 # 0.1.1
 
 **Fixed:**

--- a/backpack-compose/UNRELEASED.md
+++ b/backpack-compose/UNRELEASED.md
@@ -4,8 +4,7 @@
 
 **Added:**
 
-- New `BpkButton` component
-- New `focused` property for `BpkCard`
+- Added lint check for compose component usage
 
 
 ## How to write a good changelog entry

--- a/backpack-lint/src/main/java/net/skyscanner/backpack/lint/IssueRegistry.kt
+++ b/backpack-lint/src/main/java/net/skyscanner/backpack/lint/IssueRegistry.kt
@@ -23,6 +23,7 @@ import com.android.tools.lint.client.api.Vendor
 import com.android.tools.lint.detector.api.CURRENT_API
 import com.android.tools.lint.detector.api.Issue
 import net.skyscanner.backpack.lint.check.BpkComponentUsageDetector
+import net.skyscanner.backpack.lint.check.BpkComposeComponentUsageDetector
 import net.skyscanner.backpack.lint.check.HardcodedColorResourceDetector
 import net.skyscanner.backpack.lint.check.HardcodedColorUsageDetector
 
@@ -32,6 +33,7 @@ class IssueRegistry : IssueRegistry() {
   override val api: Int = CURRENT_API
 
   override val issues: List<Issue> = listOf(
+    BpkComposeComponentUsageDetector.ISSUE,
     BpkComponentUsageDetector.ISSUE,
     HardcodedColorUsageDetector.ISSUE,
     HardcodedColorResourceDetector.ISSUE

--- a/backpack-lint/src/main/java/net/skyscanner/backpack/lint/check/BpkComposeComponentUsageDetector.kt
+++ b/backpack-lint/src/main/java/net/skyscanner/backpack/lint/check/BpkComposeComponentUsageDetector.kt
@@ -1,0 +1,104 @@
+/**
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.skyscanner.backpack.lint.check
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import com.android.tools.lint.detector.api.SourceCodeScanner
+import com.intellij.psi.PsiMethod
+import org.jetbrains.uast.UCallExpression
+
+@Suppress("UnstableApiUsage")
+class BpkComposeComponentUsageDetector : Detector(), SourceCodeScanner {
+
+  companion object {
+    val ISSUE = Issue.create(
+      id = "BpkComposeComponentUsage",
+      briefDescription = "A Backpack version of this component is available",
+      explanation = "Use Backpack components where available to improve consistency, accessibility and dark mode support.",
+      category = Category.CORRECTNESS,
+      severity = Severity.WARNING,
+      implementation = Implementation(
+        BpkComposeComponentUsageDetector::class.java,
+        Scope.JAVA_FILE_SCOPE
+      )
+    )
+
+    private val APPLICABLE_TYPES =
+      Component.values().flatMap { it.componentsToReplace.map { component -> component.substringAfterLast('.') } }
+  }
+
+  override fun getApplicableMethodNames(): List<String> {
+    return APPLICABLE_TYPES
+  }
+
+  override fun visitMethodCall(context: JavaContext, node: UCallExpression, method: PsiMethod) {
+    val methodPackage = context.evaluator.getPackage(method)!!.qualifiedName
+    val qualifiedName = "$methodPackage.${node.methodName}"
+    val component = Component.find(qualifiedName)
+    if (component != null) {
+      context.report(
+        ISSUE,
+        context.getLocation(node),
+        "Backpack component available for $qualifiedName. Use ${component.fullName} instead. More info at ${component.url}"
+      )
+    }
+  }
+
+  private enum class Component(
+    val fullName: String,
+    val webName: String,
+    val componentsToReplace: Set<String>,
+  ) {
+    BUTTON(
+      fullName = "net.skyscanner.backpack.compose.button.BpkButton",
+      webName = "button",
+      componentsToReplace = setOf(
+        "androidx.compose.material.Button",
+        "androidx.compose.material.TextButton",
+        "androidx.compose.material.OutlinedButton"
+      )
+    ),
+    CARD(
+      fullName = "net.skyscanner.backpack.compose.card.BpkCard",
+      webName = "card",
+      componentsToReplace = setOf("androidx.compose.material.Card")
+    ),
+    TEXT(
+      fullName = "net.skyscanner.backpack.compose.text.BpkText",
+      webName = "text",
+      componentsToReplace = setOf("androidx.compose.material.Text")
+    ),
+    ;
+
+    val url: String = "https://backpack.github.io/components/$webName"
+
+    private fun replacesComponent(componentToReplace: String) = componentsToReplace.contains(componentToReplace)
+
+    companion object {
+      internal fun find(componentToReplace: String) =
+        values().firstOrNull { it.replacesComponent(componentToReplace) }
+    }
+  }
+}

--- a/backpack-lint/src/test/java/net/skyscanner/backpack/lint/check/BpkComposeComponentUsageDetectorTest.kt
+++ b/backpack-lint/src/test/java/net/skyscanner/backpack/lint/check/BpkComposeComponentUsageDetectorTest.kt
@@ -1,0 +1,91 @@
+/**
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.skyscanner.backpack.lint.check
+
+import com.android.tools.lint.checks.infrastructure.TestFile
+import com.android.tools.lint.checks.infrastructure.TestFiles.kotlin
+import com.android.tools.lint.checks.infrastructure.TestLintResult
+import com.android.tools.lint.checks.infrastructure.TestLintTask
+import com.android.tools.lint.checks.infrastructure.TestLintTask.lint
+import org.junit.Test
+
+@Suppress("UnstableApiUsage")
+class BpkComposeComponentUsageDetectorTest {
+
+  @Test
+  fun `warning when using component to replace`() {
+    lint()
+      .files(
+        kotlin(
+          """import androidx.compose.material.Button
+
+@Composable
+fun CustomButton() { Button() }"""
+        ),
+        button(),
+      )
+      .runCheck()
+      .expectWarningCount(1)
+      .expect(
+        """
+src/test.kt:4: Warning: Backpack component available for androidx.compose.material.Button. Use net.skyscanner.backpack.compose.button.BpkButton instead. More info at https://backpack.github.io/components/button [BpkComposeComponentUsage]
+fun CustomButton() { Button() }
+                     ~~~~~~~~
+0 errors, 1 warnings
+      """
+      )
+  }
+
+  @Test
+  fun `clean when using backpack component`() {
+    lint()
+      .files(
+        kotlin(
+          """import net.skyscanner.backpack.compose.button.BpkButton
+
+@Composable
+fun CustomButton() { BpkButton() }"""
+        ),
+        bpkButton(),
+      )
+      .runCheck()
+      .expectClean()
+  }
+
+  private fun bpkButton(): TestFile =
+    kotlin(
+      """package net.skyscanner.backpack.compose.button
+
+@Composable
+fun BpkButton() {}"""
+    )
+
+  private fun button(): TestFile =
+    kotlin(
+      """package androidx.compose.material
+
+@Composable
+fun Button() {}"""
+    )
+
+  private fun TestLintTask.runCheck(): TestLintResult =
+    issues(BpkComposeComponentUsageDetector.ISSUE)
+      .allowMissingSdk()
+      .run()
+}

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -35,7 +35,7 @@ const unreleasedModified = includes(modifiedFiles, 'Backpack/UNRELEASED.md') ||
   includes(modifiedFiles, 'backpack-compose/UNRELEASED.md');
 const packagesModified = fileChanges.some(filePath =>
   filePath.startsWith('Backpack/src/main') ||
-  filePath.startsWith('backpack-compose/src/main') || 
+  filePath.startsWith('backpack-compose/src/main') ||
   filePath.startsWith('backpack-common/src/main')
 );
 if (packagesModified && !unreleasedModified && !declaredTrivial) {
@@ -50,6 +50,16 @@ const usageDetector = includes(
 const packageFilesCreated = createdFiles.some(filePath => filePath.startsWith('Backpack/src/main/java'));
 if (packageFilesCreated && !usageDetector && !declaredTrivial) {
   warn("One or more package files were created, but `BpkComponentUsageDetector.kt` wasn't updated.");
+}
+
+// If any files were created, the BpkComposeComponentUsageDetector should have been updated.
+const composeUsageDetector = includes(
+  modifiedFiles,
+  'backpack-lint/src/main/java/net/skyscanner/backpack/lint/check/BpkComposeComponentUsageDetector.kt',
+);
+const composePackageFilesCreated = createdFiles.some(filePath => filePath.startsWith('backpack-compose/src/main/java'));
+if (composePackageFilesCreated && !composeUsageDetector && !declaredTrivial) {
+  warn("One or more package files were created, but `BpkComposeComponentUsageDetector.kt` wasn't updated.");
 }
 
 // Ensure package-lock changes are intentional.


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.
-->

Replicated the lint check we had in place for the existing view system to detect usage of non-compose components

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
