### PR TITLE
KOA-5024 Fix loading button crash

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/button/BpkButton.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/button/BpkButton.kt
@@ -95,7 +95,6 @@ open class BpkButton(
       setStyle(CircularProgressDrawable.DEFAULT)
       strokeWidth = resources.getDimension(R.dimen.bpkSpacingSm) * 0.5f
       callback = this@BpkButton
-      setColorSchemeColors(context.getColor(R.color.__buttonDisabledText))
     }
   }
 
@@ -157,6 +156,7 @@ open class BpkButton(
     this.minHeight = resources.getDimensionPixelSize(size.minHeight)
     this.iconSize = resources.getDimensionPixelSize(size.iconSize)
     this.progress.centerRadius = iconSize / 2f - this.progress.strokeWidth
+    this.progress.setColorSchemeColors(context.getColor(R.color.__buttonDisabledText))
     BpkText.getFont(context, size.textStyle).applyTo(this)
     applyStyle(style)
   }

--- a/UNRELEASED.md
+++ b/UNRELEASED.md
@@ -1,6 +1,11 @@
 # Unreleased
 > Place your changes below this line.
 
+**Fixed:**
+- backpack-android
+  - Fixed crash for loading button
+
+
 ## How to write a good changelog entry
 
 1. Add 'Breaking', 'Added' or 'Fixed' in bold depending on if the change will be major, minor or patch according to [semver](semver.org).


### PR DESCRIPTION
When using a button with the loading property set in xml the button was crashing due to a stackoverflow exception. Ensure we set the button colour in the constructor instead of the button lazy initialisation

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] `UNRELEASED.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_
