### PR TITLE
Exclude js and github actions from changelog

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,21 @@ updates:
   versioning-strategy: increase-if-necessary
   allow:
     - dependency-type: "direct"
+  ignore:
+    - dependency-name: "bpk-*"
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "10:00"
+  open-pull-requests-limit: 10
+  versioning-strategy: increase-if-necessary
+  labels:
+    - "bpk"
+    - "depencdencies"
+  allow:
+    - dependency-type: "direct"
+    - dependency-name: "bpk-*"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,7 +32,7 @@ updates:
   versioning-strategy: increase-if-necessary
   labels:
     - "bpk"
-    - "depencdencies"
+    - "dependencies"
   allow:
     - dependency-type: "direct"
     - dependency-name: "bpk-*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,21 +21,6 @@ updates:
   versioning-strategy: increase-if-necessary
   allow:
     - dependency-type: "direct"
-  ignore:
-    - dependency-name: "bpk-*"
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "10:00"
-  open-pull-requests-limit: 10
-  versioning-strategy: increase-if-necessary
-  labels:
-    - "bpk"
-    - "dependencies"
-  allow:
-    - dependency-type: "direct"
-    - dependency-name: "bpk-*"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,6 +11,8 @@ categories:
     label: 'dependencies'
 exclude-labels:
   - 'skip-changelog'
+  - 'javascript'
+  - 'github-actions'
 version-resolver:
   major:
     labels:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,3 +17,18 @@ jobs:
   Build:
     name: Build
     uses: ./.github/workflows/_build.yml
+
+  Dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.3.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Add bpk label
+        if: contains(steps.dependabot-metadata.outputs.dependency-names[0], 'bpk-')
+        run: gh pr edit "$PR_URL" --add-label "bpk" --remove-label "javascript"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
JS & github actions dependencies generally don't affect anything for the consumers, so we shouldn't include them in the changelog. The only exception to this is backpack dependencies which include token changes. these should be part of the changelog, so creating a separate config for them.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] Component `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
