### PR TITLE
Removing docs site trigger step

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,9 +42,3 @@ jobs:
         with:
           java-version: '11'
           distribution: 'adopt'
-
-      - name: Trigger backpack.github.io CI
-        run: |
-          curl -f -s -X POST -H "Content-Type: application/json" -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $GITHUB_TOKEN" -d "{\"ref\":\"main\",\"inputs\":{\"repo\":\"backpack-android\"}}" https://api.github.com/repos/Skyscanner/backpack-docs/actions/workflows/ci.yml/dispatches
-        env:
-          GITHUB_TOKEN: ${{ secrets.BACKPACK_DOCS_DEPLOY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,12 +56,6 @@ jobs:
           external_repository: backpack/android
           publish_branch: main
 
-      - name: Trigger backpack.github.io CI
-        run: |
-          curl -f -s -X POST -H "Content-Type: application/json" -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $GITHUB_TOKEN" -d "{\"ref\":\"main\",\"inputs\":{\"repo\":\"backpack-android\"}}" https://api.github.com/repos/Skyscanner/backpack-docs/actions/workflows/ci.yml/dispatches
-        env:
-          GITHUB_TOKEN: ${{ secrets.BACKPACK_DOCS_DEPLOY_TOKEN }}
-
       - name: Building release APK
         run: |
           openssl aes-256-cbc -K $KEYSTORE_DECRYPT_KEY -iv $KEYSTORE_DECRYPT_IV -in backpack.android.demo.key.enc -out backpack.android.demo.key -d;


### PR DESCRIPTION
As we are moving towards dependant bumping submodules automatically and we have removed the step in the docs CI to automatically pull latest submodules on main for deployment which can cause unexpected crashes, we are removing the trigger step as this now has no affect on the docs ci