### PR TITLE
KOA-4927 Use correct selectable modifier for BpkRadioButton

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/radiobutton/BpkRadioButton.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/radiobutton/BpkRadioButton.kt
@@ -18,11 +18,11 @@
 
 package net.skyscanner.backpack.compose.radiobutton
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.LocalContentColor
 import androidx.compose.material.LocalMinimumTouchTargetEnforcement
@@ -74,7 +74,13 @@ fun BpkRadioButton(
   content: @Composable RowScope.(Boolean) -> Unit,
 ) {
   val rowModifier = if (onClick != null) {
-    modifier.clickable(interactionSource = interactionSource, indication = null, role = Role.RadioButton, onClick = onClick)
+    modifier.selectable(
+      selected = selected,
+      interactionSource = interactionSource,
+      indication = null,
+      role = Role.RadioButton,
+      onClick = onClick,
+    )
   } else {
     modifier
   }


### PR DESCRIPTION
Selectable is the better usage for a RadioButton and will provide a better experience for accessibility

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] Component `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
