### PR TITLE
Skip signing task for snapshot versions

### DIFF
--- a/gradle-maven-push.gradle
+++ b/gradle-maven-push.gradle
@@ -67,3 +67,6 @@ signing {
   sign publishing.publications
 }
 
+tasks.withType(Sign) {
+  onlyIf { !project.version.endsWith("SNAPSHOT") }
+}


### PR DESCRIPTION
Snapshot versions are not published to maven central and therefore don't require the signing configuration. This is useful for publishing locally to test changes in the app

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] Component `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
