### PR TITLE
Fix danger check for compose components

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -44,7 +44,7 @@ const composeUsageDetector = includes(
   modifiedFiles,
   'backpack-lint/src/main/java/net/skyscanner/backpack/lint/check/BpkComposeComponentUsageDetector.kt',
 );
-const composePackageFilesCreated = createdFiles.some(filePath => filePath.startsWith('backpack-compose/src/main/java'));
+const composePackageFilesCreated = createdFiles.some(filePath => filePath.startsWith('backpack-compose/src/main/kotlin'));
 if (composePackageFilesCreated && !composeUsageDetector && !declaredTrivial) {
   warn("One or more package files were created, but `BpkComposeComponentUsageDetector.kt` wasn't updated.");
 }


### PR DESCRIPTION
The compose module code lives in the kotlin folder, rather than java

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] Component `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
