### PR TITLE
Rename spinner sizes to match Figma and other platforms

### DIFF
--- a/app/src/androidTest/java/net/skyscanner/backpack/compose/spinner/BpkSpinnerTest.kt
+++ b/app/src/androidTest/java/net/skyscanner/backpack/compose/spinner/BpkSpinnerTest.kt
@@ -38,7 +38,7 @@ class BpkSpinnerTest : BpkSnapshotTest() {
 
   @Test
   fun default() = composed {
-    BpkSpinner(size = BpkSpinnerSize.Medium)
+    BpkSpinner(size = BpkSpinnerSize.Large)
   }
 
   @Test
@@ -53,7 +53,7 @@ class BpkSpinnerTest : BpkSnapshotTest() {
   fun textPrimary() {
     assumeVariant(BpkTestVariant.Default, BpkTestVariant.DarkMode)
     composed {
-      BpkSpinner(size = BpkSpinnerSize.Medium, style = BpkSpinnerStyle.TextPrimary)
+      BpkSpinner(size = BpkSpinnerSize.Large, style = BpkSpinnerStyle.TextPrimary)
     }
   }
 
@@ -61,7 +61,7 @@ class BpkSpinnerTest : BpkSnapshotTest() {
   fun disabled() {
     assumeVariant(BpkTestVariant.Default, BpkTestVariant.DarkMode)
     composed {
-      BpkSpinner(size = BpkSpinnerSize.Medium, style = BpkSpinnerStyle.Disabled)
+      BpkSpinner(size = BpkSpinnerSize.Large, style = BpkSpinnerStyle.Disabled)
     }
   }
 
@@ -69,7 +69,7 @@ class BpkSpinnerTest : BpkSnapshotTest() {
   fun onDarkSurface() {
     assumeVariant(BpkTestVariant.Default, BpkTestVariant.DarkMode)
     composed(background = BpkColor.Black) {
-      BpkSpinner(size = BpkSpinnerSize.Medium, style = BpkSpinnerStyle.OnDarkSurface)
+      BpkSpinner(size = BpkSpinnerSize.Large, style = BpkSpinnerStyle.OnDarkSurface)
     }
   }
 
@@ -78,7 +78,7 @@ class BpkSpinnerTest : BpkSnapshotTest() {
     assumeVariant(BpkTestVariant.Default)
     composed(background = BpkColor.Black) {
       CompositionLocalProvider(LocalContentColor provides BpkColor.White) {
-        BpkSpinner(size = BpkSpinnerSize.Medium)
+        BpkSpinner(size = BpkSpinnerSize.Large)
       }
     }
   }
@@ -88,7 +88,7 @@ class BpkSpinnerTest : BpkSnapshotTest() {
     assumeVariant(BpkTestVariant.Default)
     composed(background = BpkColor.White) {
       CompositionLocalProvider(LocalContentColor provides BpkColor.Black) {
-        BpkSpinner(size = BpkSpinnerSize.Medium)
+        BpkSpinner(size = BpkSpinnerSize.Large)
       }
     }
   }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/button/internal/BpkButtonImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/button/internal/BpkButtonImpl.kt
@@ -92,7 +92,7 @@ internal fun BpkButtonImpl(
                 style = BpkSpinnerStyle.Disabled,
                 size = when (size) {
                   BpkButtonSize.Default -> BpkSpinnerSize.Small
-                  BpkButtonSize.Large -> BpkSpinnerSize.Medium
+                  BpkButtonSize.Large -> BpkSpinnerSize.Large
                 },
               )
             }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/spinner/BpkSpinner.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/spinner/BpkSpinner.kt
@@ -34,8 +34,8 @@ import net.skyscanner.backpack.compose.utils.dynamicColorOf
 
 enum class BpkSpinnerSize {
   Small,
-  Medium,
   Large,
+  XLarge,
 }
 
 enum class BpkSpinnerStyle {
@@ -64,8 +64,8 @@ fun BpkSpinner(
 private val BpkSpinnerSize.dp: Dp
   get() = when (this) {
     BpkSpinnerSize.Small -> BpkSpacing.Base
-    BpkSpinnerSize.Medium -> BpkSpacing.Lg
-    BpkSpinnerSize.Large -> BpkSpacing.Xl
+    BpkSpinnerSize.Large -> BpkSpacing.Lg
+    BpkSpinnerSize.XLarge -> BpkSpacing.Xl
   }
 
 private fun findBestSpinnerStyleFor(contentColor: Color, lightMode: Boolean): BpkSpinnerStyle =

--- a/docs/compose/Spinner/README.md
+++ b/docs/compose/Spinner/README.md
@@ -13,7 +13,7 @@ import net.skyscanner.backpack.compose.spinner.BpkSpinner
 import net.skyscanner.backpack.compose.spinner.BpkSpinnerSize
 
 BpkSpinner(
-  size = BpkSpinnerSize.Medium,
+  size = BpkSpinnerSize.Large,
 )
 ```
 
@@ -25,7 +25,7 @@ import net.skyscanner.backpack.compose.spinner.BpkSpinnerSize
 import net.skyscanner.backpack.compose.spinner.BpkSpinnerStype
 
 BpkSpinner(
-  size = BpkSpinnerSize.Medium,
+  size = BpkSpinnerSize.Large,
   style = BpkSpinnerStyle.OnDarkSurface,
 )
 ```


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Figma & other platforms use small, large & xl spinner sizes - to ensure there's no confusion and sizes match across platforms rename them before people adopt the new spinner.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] Component `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
