### PR TITLE
[NO JIRA]: Patch del version bump build issue

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,7 +22,11 @@ const gulp = require('gulp');
 const merge = require('merge-stream');
 const nunjucks = require('gulp-nunjucks');
 const rename = require('gulp-rename');
-const del = require('del');
+// As del is now an ESM module unless/until we migrate this file to ESM this and want to do the major version bump
+// we use the following format to import from CommonJS instead of ESM. See https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c
+const del = async () => {
+  await import('del');
+}
 const tinycolor = require('tinycolor2');
 const _ = require('lodash');
 const through = require('through2');


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

`del` was recently bumped in #1126 - during this major bump `del` had changed how they export modules to be in ESM format instead of CommonJS, for some reason CI didn't fail when this automated PR was raised, even though there was an error which now causes new running of `npm run build` to fail.

This PR solves that issue! For now as migrating the full JS to ESM modules is a big task and we probably want to bump the version for security purposes, I have updated the import to use the CommonJS format as per here https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c 

This will unblock the breakage in `main` for any external users or Skyscanner users contributing to the codebase.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
