### PR TITLE
Fix dokka generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,9 @@ jobs:
           KEYSTORE_DECRYPT_KEY: ${{ secrets.KEYSTORE_DECRYPT_KEY }}
           KEYSTORE_DECRYPT_IV: ${{ secrets.KEYSTORE_DECRYPT_IV }}
 
+      - name: Build Dokka docs
+        run: ./gradlew dokkaHtmlMultiModule
+        
       - name: Publish artifacts
         run: >
           ./gradlew checkMavenCredentials
@@ -70,9 +73,6 @@ jobs:
 
       - name: Remove Sonatype key
         run: rm -rf sonatype.gpg
-
-      - name: Build Dokka docs
-        run: ./gradlew dokkaHtmlMultiModule
 
       - name: Deploy Dokka docs
         uses: peaceiris/actions-gh-pages@v3

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 
 dependencies {
   implementation(gradleApi())
+  implementation("org.jetbrains.dokka:dokka-core:1.7.0") // this can be removed when updating to build tools 7.3
   implementation("com.android.tools.build:gradle:7.2.2")
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.0")
   implementation("com.squareup:kotlinpoet:1.11.0")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-all.zip


### PR DESCRIPTION
An upgrade of Kotlin broke dokka generation. This required an upgrade of the gradle wrapper and an explicit dependency onto dokka to avoid a version clash

Also moved the dokka build before the publish step, so we can avoid a half released state in the future

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] Component `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
