### PR TITLE
Set fixed screenshot size

### DIFF
--- a/docs/compose/Badge/README.md
+++ b/docs/compose/Badge/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![Badge component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Badge/screenshots/default.png) |![Badge component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Badge/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Badge/screenshots/default.png" alt="Badge component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Badge/screenshots/default_dm.png" alt="Badge component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/compose/Button/README.md
+++ b/docs/compose/Button/README.md
@@ -8,19 +8,19 @@
 
 | Day | Night |
 | --- | --- |
-| ![Button component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Button/screenshots/default.png) |![Button component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Button/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Button/screenshots/default.png" alt="Button component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Button/screenshots/default_dm.png" alt="Button component - dark mode" width="375" /> |
 
 ## Large
 
 | Day | Night |
 | --- | --- |
-| ![Large Button component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Button/screenshots/large.png) |![Large Button component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Button/screenshots/large_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Button/screenshots/large.png" alt="Large Button component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Button/screenshots/large_dm.png" alt="Large Button component - dark mode" width="375" /> |
 
 ## Link
 
 | Day | Night |
 | --- | --- |
-| ![Link Button component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Button/screenshots/link.png) |![Link Button component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Button/screenshots/link_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Button/screenshots/link.png" alt="Link Button component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Button/screenshots/link_dm.png" alt="Link Button component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/compose/Card/README.md
+++ b/docs/compose/Card/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![Card component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Card/screenshots/default.png) |![Card component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Card/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Card/screenshots/default.png" alt="Card component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Card/screenshots/default_dm.png" alt="Card component - dark mode" width="375" /> |
 
 
 ## Installation

--- a/docs/compose/Checkbox/README.md
+++ b/docs/compose/Checkbox/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![Checkbox component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Checkbox/screenshots/default.png) |![Checkbox component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Checkbox/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Checkbox/screenshots/default.png" alt="Checkbox component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Checkbox/screenshots/default_dm.png" alt="Checkbox component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/compose/Chip/README.md
+++ b/docs/compose/Chip/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![Chip component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Chip/screenshots/default.png) |![Chip component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Chip/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Chip/screenshots/default.png" alt="Chip component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Chip/screenshots/default_dm.png" alt="Chip component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/compose/Dialog/README.md
+++ b/docs/compose/Dialog/README.md
@@ -8,25 +8,25 @@
 
 | Day | Night |
 | --- | --- |
-| ![Success Dialog component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Dialog/screenshots/success.png) |![Success Dialog component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Dialog/screenshots/success_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Dialog/screenshots/success.png" alt="Success Dialog component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Dialog/screenshots/success_dm.png" alt="Success Dialog component - dark mode" width="375" /> |
 
 ## Warning
 
 | Day | Night |
 | --- | --- |
-| ![Warning Dialog component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Dialog/screenshots/warning.png) |![Warning Dialog component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Dialog/screenshots/warning_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Dialog/screenshots/warning.png" alt="Warning Dialog component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Dialog/screenshots/warning_dm.png" alt="Warning Dialog component - dark mode" width="375" /> |
 
 ## Destructive
 
 | Day | Night |
 | --- | --- |
-| ![Destructive Dialog component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Dialog/screenshots/destructive.png) |![Destructive Dialog component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Dialog/screenshots/destructive_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Dialog/screenshots/destructive.png" alt="Destructive Dialog component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Dialog/screenshots/destructive_dm.png" alt="Destructive Dialog component - dark mode" width="375" /> |
 
 ## Flare
 
 | Day | Night |
 | --- | --- |
-| ![Flare Dialog component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Dialog/screenshots/flare.png) |![Flare Dialog component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Dialog/screenshots/flare_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Dialog/screenshots/flare.png" alt="Flare Dialog component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Dialog/screenshots/flare_dm.png" alt="Flare Dialog component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/compose/FieldSet/README.md
+++ b/docs/compose/FieldSet/README.md
@@ -8,25 +8,25 @@
 
 | Day | Night |
 | --- | --- |
-| ![FieldSet component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/FieldSet/screenshots/default.png) |![FieldSet component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/FieldSet/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/FieldSet/screenshots/default.png" alt="FieldSet component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/FieldSet/screenshots/default_dm.png" alt="FieldSet component - dark mode" width="375" /> |
 
 ## Error
 
 | Day | Night |
 | --- | --- |
-| ![Error FieldSet component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/FieldSet/screenshots/error.png) |![Error FieldSet component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/FieldSet/screenshots/error_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/FieldSet/screenshots/error.png" alt="Error FieldSet component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/FieldSet/screenshots/error_dm.png" alt="Error FieldSet component - dark mode" width="375" /> |
 
 ## Validated
 
 | Day | Night |
 | --- | --- |
-| ![Validated FieldSet component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/FieldSet/screenshots/validated.png) |![Validated FieldSet component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/FieldSet/screenshots/validated_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/FieldSet/screenshots/validated.png" alt="Validated FieldSet component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/FieldSet/screenshots/validated_dm.png" alt="Validated FieldSet component - dark mode" width="375" /> |
 
 ## Disabled
 
 | Day | Night |
 | --- | --- |
-| ![Disabled FieldSet component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/FieldSet/screenshots/disabled.png) |![Disabled FieldSet component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/FieldSet/screenshots/disabled_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/FieldSet/screenshots/disabled.png" alt="Disabled FieldSet component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/FieldSet/screenshots/disabled_dm.png" alt="Disabled FieldSet component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/compose/Flare/README.md
+++ b/docs/compose/Flare/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![Flare component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Flare/screenshots/default.png) |![Flare component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Flare/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Flare/screenshots/default.png" alt="Flare component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Flare/screenshots/default_dm.png" alt="Flare component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/compose/FloatingActionButton/README.md
+++ b/docs/compose/FloatingActionButton/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![FloatingActionButton component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/FloatingActionButton/screenshots/default.png) |![FloatingActionButton component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/FloatingActionButton/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/FloatingActionButton/screenshots/default.png" alt="FloatingActionButton component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/FloatingActionButton/screenshots/default_dm.png" alt="FloatingActionButton component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/compose/HorizontalNav/README.md
+++ b/docs/compose/HorizontalNav/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![HorizontalNav component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/HorizontalNav/screenshots/default.png) |![HorizontalNav component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/HorizontalNav/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/HorizontalNav/screenshots/default.png" alt="HorizontalNav component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/HorizontalNav/screenshots/default_dm.png" alt="HorizontalNav component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/compose/Icon/README.md
+++ b/docs/compose/Icon/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![Icon component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/AllIcons/screenshots/default.png) |![Icon component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/AllIcons/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/AllIcons/screenshots/default.png" alt="Icon component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/AllIcons/screenshots/default_dm.png" alt="Icon component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/compose/NavBar/README.md
+++ b/docs/compose/NavBar/README.md
@@ -8,13 +8,13 @@
 
 | Day | Night |
 | --- | --- |
-| ![NavBar component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/NavBar/screenshots/default.png) |![NavBar component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/NavBar/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/NavBar/screenshots/default.png" alt="NavBar component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/NavBar/screenshots/default_dm.png" alt="NavBar component - dark mode" width="375" /> |
 
 ## Collapsible
 
 | Day | Night |
 | --- | --- |
-| ![Collapsible NavBar component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/NavBar/screenshots/collapsible.png) |![Collapsible NavBar component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/NavBar/screenshots/collapsible_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/NavBar/screenshots/collapsible.png" alt="Collapsible NavBar component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/NavBar/screenshots/collapsible_dm.png" alt="Collapsible NavBar component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/compose/Panel/README.md
+++ b/docs/compose/Panel/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![Panel component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Panel/screenshots/all.png) |![Panel component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Panel/screenshots/all_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Panel/screenshots/all.png" alt="Panel component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Panel/screenshots/all_dm.png" alt="Panel component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/compose/RadioButton/README.md
+++ b/docs/compose/RadioButton/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![RadioButton component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/RadioButton/screenshots/default.png) |![RadioButton component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/RadioButton/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/RadioButton/screenshots/default.png" alt="RadioButton component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/RadioButton/screenshots/default_dm.png" alt="RadioButton component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/compose/Skeleton/README.md
+++ b/docs/compose/Skeleton/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![Skeleton component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Skeleton/screenshots/default.png) |![Skeleton component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Skeleton/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Skeleton/screenshots/default.png" alt="Skeleton component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Skeleton/screenshots/default_dm.png" alt="Skeleton component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/compose/Spinner/README.md
+++ b/docs/compose/Spinner/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![Spinner component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Spinner/screenshots/default.png) |![Spinner component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Spinner/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Spinner/screenshots/default.png" alt="Spinner component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Spinner/screenshots/default_dm.png" alt="Spinner component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/compose/Switch/README.md
+++ b/docs/compose/Switch/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![Switch component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Switch/screenshots/default.png) |![Switch component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Switch/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Switch/screenshots/default.png" alt="Switch component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Switch/screenshots/default_dm.png" alt="Switch component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/compose/Text/README.md
+++ b/docs/compose/Text/README.md
@@ -8,19 +8,19 @@
 
 | Day | Night |
 | --- | --- |
-| ![Body Text component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Text/screenshots/body.png) |![Body Text component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Text/screenshots/body_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Text/screenshots/body.png" alt="Body Text component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Text/screenshots/body_dm.png" alt="Body Text component - dark mode" width="375" /> |
 
 ## Heading
 
 | Day | Night |
 | --- | --- |
-| ![Heading Text component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Text/screenshots/heading.png) |![Heading Text component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Text/screenshots/heading_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Text/screenshots/heading.png" alt="Heading Text component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Text/screenshots/heading_dm.png" alt="Heading Text component - dark mode" width="375" /> |
 
 ## Hero
 
 | Day | Night |
 | --- | --- |
-| ![Hero Text component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Text/screenshots/hero.png) |![Hero Text component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Text/screenshots/hero_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Text/screenshots/hero.png" alt="Hero Text component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Text/screenshots/hero_dm.png" alt="Hero Text component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/compose/TextField/README.md
+++ b/docs/compose/TextField/README.md
@@ -8,25 +8,25 @@
 
 | Day | Night |
 | --- | --- |
-| ![TextField component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/TextField/screenshots/default.png) |![TextField component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/TextField/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/TextField/screenshots/default.png" alt="TextField component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/TextField/screenshots/default_dm.png" alt="TextField component - dark mode" width="375" /> |
 
 ## Error
 
 | Day | Night |
 | --- | --- |
-| ![Error TextField component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/TextField/screenshots/error.png) |![Error TextField component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/TextField/screenshots/error_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/TextField/screenshots/error.png" alt="Error TextField component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/TextField/screenshots/error_dm.png" alt="Error TextField component - dark mode" width="375" /> |
 
 ## Validated
 
 | Day | Night |
 | --- | --- |
-| ![Validated TextField component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/TextField/screenshots/validated.png) |![Validated TextField component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/TextField/screenshots/validated_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/TextField/screenshots/validated.png" alt="Validated TextField component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/TextField/screenshots/validated_dm.png" alt="Validated TextField component - dark mode" width="375" /> |
 
 ## Disabled
 
 | Day | Night |
 | --- | --- |
-| ![Disabled TextField component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/TextField/screenshots/disabled.png) |![Disabled TextField component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/TextField/screenshots/disabled_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/TextField/screenshots/disabled.png" alt="Disabled TextField component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/TextField/screenshots/disabled_dm.png" alt="Disabled TextField component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Badge/README.md
+++ b/docs/view/Badge/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![Badge component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Badge/screenshots/all.png) |![Badge component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Badge/screenshots/all_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Badge/screenshots/all.png" alt="Badge component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Badge/screenshots/all_dm.png" alt="Badge component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/BarChart/README.md
+++ b/docs/view/BarChart/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![BarChart component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/BarChart/screenshots/default.png) |![BarChart component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/BarChart/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/BarChart/screenshots/default.png" alt="BarChart component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/BarChart/screenshots/default_dm.png" alt="BarChart component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/BottomNav/README.md
+++ b/docs/view/BottomNav/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![BottomNav component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/BottomNav/screenshots/default.png) |![BottomNav component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/BottomNav/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/BottomNav/screenshots/default.png" alt="BottomNav component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/BottomNav/screenshots/default_dm.png" alt="BottomNav component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/BottomSheet/README.md
+++ b/docs/view/BottomSheet/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![BottomSheet component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/BottomSheet/screenshots/default.png) |![BottomSheet component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/BottomSheet/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/BottomSheet/screenshots/default.png" alt="BottomSheet component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/BottomSheet/screenshots/default_dm.png" alt="BottomSheet component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Button/README.md
+++ b/docs/view/Button/README.md
@@ -8,19 +8,19 @@
 
 | Day | Night |
 | --- | --- |
-| ![Standard Button component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Button/screenshots/standard.png) |![Standard Button component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Button/screenshots/standard_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Button/screenshots/standard.png" alt="Standard Button component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Button/screenshots/standard_dm.png" alt="Standard Button component - dark mode" width="375" /> |
 
 ## Large
 
 | Day | Night |
 | --- | --- |
-| ![Large Button component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Button/screenshots/large.png) |![Large Button component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Button/screenshots/large_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Button/screenshots/large.png" alt="Large Button component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Button/screenshots/large_dm.png" alt="Large Button component - dark mode" width="375" /> |
 
 ## Link
 
 | Day | Night |
 | --- | --- |
-| ![Link Button component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Button/screenshots/link.png) |![Link Button component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Button/screenshots/link_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Button/screenshots/link.png" alt="Link Button component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Button/screenshots/link_dm.png" alt="Link Button component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Calendar/README.md
+++ b/docs/view/Calendar/README.md
@@ -8,19 +8,19 @@
 
 | Day | Night |
 | --- | --- |
-| ![Colored Calendar component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar/screenshots/colored.png) |![Colored Calendar component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar/screenshots/colored_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar/screenshots/colored.png" alt="Colored Calendar component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar/screenshots/colored_dm.png" alt="Colored Calendar component - dark mode" width="375" /> |
 
 ## Labeled
 
 | Day | Night |
 | --- | --- |
-| ![Labeled Calendar component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar/screenshots/labeled.png) |![Labeled Calendar component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar/screenshots/labeled_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar/screenshots/labeled.png" alt="Labeled Calendar component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar/screenshots/labeled_dm.png" alt="Labeled Calendar component - dark mode" width="375" /> |
 
 ## Range
 
 | Day | Night |
 | --- | --- |
-| ![Range Calendar component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar/screenshots/range.png) |![Range Calendar component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar/screenshots/range_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar/screenshots/range.png" alt="Range Calendar component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar/screenshots/range_dm.png" alt="Range Calendar component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Calendar2/README.md
+++ b/docs/view/Calendar2/README.md
@@ -8,25 +8,25 @@
 
 | Day | Night |
 | --- | --- |
-| ![Colored Calendar2 component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar2/screenshots/colored.png) |![Colored Calendar2 component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar2/screenshots/colored_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar2/screenshots/colored.png" alt="Colored Calendar2 component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar2/screenshots/colored_dm.png" alt="Colored Calendar2 component - dark mode" width="375" /> |
 
 ## Labeled
 
 | Day | Night |
 | --- | --- |
-| ![Labeled Calendar2 component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar2/screenshots/labeled.png) |![Labeled Calendar2 component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar2/screenshots/labeled_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar2/screenshots/labeled.png" alt="Labeled Calendar2 component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar2/screenshots/labeled_dm.png" alt="Labeled Calendar2 component - dark mode" width="375" /> |
 
 ## Month
 
 | Day | Night |
 | --- | --- |
-| ![Month Calendar2 component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar2/screenshots/month.png) |![Month Calendar2 component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar2/screenshots/month_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar2/screenshots/month.png" alt="Month Calendar2 component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar2/screenshots/month_dm.png" alt="Month Calendar2 component - dark mode" width="375" /> |
 
 ## Range
 
 | Day | Night |
 | --- | --- |
-| ![Range Calendar2 component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar2/screenshots/range.png) |![Range Calendar2 component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar2/screenshots/range_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar2/screenshots/range.png" alt="Range Calendar2 component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Calendar2/screenshots/range_dm.png" alt="Range Calendar2 component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Card/README.md
+++ b/docs/view/Card/README.md
@@ -8,49 +8,49 @@
 
 | Day | Night |
 | --- | --- |
-| ![Card component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/default.png) |![Card component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/default.png" alt="Card component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/default_dm.png" alt="Card component - dark mode" width="375" /> |
 
 ## Corner style large
 
 | Day | Night |
 | --- | --- |
-| ![Corner style large Card component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/corner-style-large.png) |![Corner style large Card component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/corner-style-large_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/corner-style-large.png" alt="Corner style large Card component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/corner-style-large_dm.png" alt="Corner style large Card component - dark mode" width="375" /> |
 
 ## Selected
 
 | Day | Night |
 | --- | --- |
-| ![Selected Card component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/selected.png) |![Selected Card component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/selected_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/selected.png" alt="Selected Card component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/selected_dm.png" alt="Selected Card component - dark mode" width="375" /> |
 
 ## With divider and corner style large
 
 | Day | Night |
 | --- | --- |
-| ![With divider and corner style large Card component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/with-divider-and-corner-style-large.png) |![With divider and corner style large Card component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/with-divider-and-corner-style-large_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/with-divider-and-corner-style-large.png" alt="With divider and corner style large Card component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/with-divider-and-corner-style-large_dm.png" alt="With divider and corner style large Card component - dark mode" width="375" /> |
 
 ## With divider arranged vertically
 
 | Day | Night |
 | --- | --- |
-| ![With divider arranged verticy Card component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/with-divider-arranged-vertically.png) |![With divider arranged verticy Card component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/with-divider-arranged-vertically_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/with-divider-arranged-vertically.png" alt="With divider arranged verticy Card component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/with-divider-arranged-vertically_dm.png" alt="With divider arranged verticy Card component - dark mode" width="375" /> |
 
 ## With divider without padding
 
 | Day | Night |
 | --- | --- |
-| ![With divider without padding Card component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/with-divider-without-padding.png) |![With divider without padding Card component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/with-divider-without-padding_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/with-divider-without-padding.png" alt="With divider without padding Card component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/with-divider-without-padding_dm.png" alt="With divider without padding Card component - dark mode" width="375" /> |
 
 ## With divider
 
 | Day | Night |
 | --- | --- |
-| ![With divider Card component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/with-divider.png) |![With divider Card component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/with-divider_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/with-divider.png" alt="With divider Card component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/with-divider_dm.png" alt="With divider Card component - dark mode" width="375" /> |
 
 ## Without padding
 
 | Day | Night |
 | --- | --- |
-| ![Without padding Card component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/without-padding.png) |![Without padding Card component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/without-padding_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/without-padding.png" alt="Without padding Card component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Card/screenshots/without-padding_dm.png" alt="Without padding Card component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Checkbox/README.md
+++ b/docs/view/Checkbox/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![Checkbox component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Checkbox/screenshots/default.png) |![Checkbox component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Checkbox/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Checkbox/screenshots/default.png" alt="Checkbox component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Checkbox/screenshots/default_dm.png" alt="Checkbox component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Chip/README.md
+++ b/docs/view/Chip/README.md
@@ -8,19 +8,19 @@
 
 | Day | Night |
 | --- | --- |
-| ![Chip component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Chip/screenshots/all.png) |![Chip component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Chip/screenshots/all_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Chip/screenshots/all.png" alt="Chip component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Chip/screenshots/all_dm.png" alt="Chip component - dark mode" width="375" /> |
 
 ## On dark
 
 | Day | Night |
 | --- | --- |
-| ![On dark Chip component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Chip/screenshots/on-dark.png) |![On dark Chip component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Chip/screenshots/on-dark_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Chip/screenshots/on-dark.png" alt="On dark Chip component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Chip/screenshots/on-dark_dm.png" alt="On dark Chip component - dark mode" width="375" /> |
 
 ## With icon
 
 | Day | Night |
 | --- | --- |
-| ![With icon Chip component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Chip/screenshots/with-icon.png) |![With icon Chip component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Chip/screenshots/with-icon_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Chip/screenshots/with-icon.png" alt="With icon Chip component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Chip/screenshots/with-icon_dm.png" alt="With icon Chip component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Dialog/README.md
+++ b/docs/view/Dialog/README.md
@@ -8,19 +8,19 @@
 
 | Day | Night |
 | --- | --- |
-| ![Delete confirmation Dialog component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Dialog/screenshots/delete-confirmation.png) |![Delete confirmation Dialog component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Dialog/screenshots/delete-confirmation_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Dialog/screenshots/delete-confirmation.png" alt="Delete confirmation Dialog component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Dialog/screenshots/delete-confirmation_dm.png" alt="Delete confirmation Dialog component - dark mode" width="375" /> |
 
 ## With CTA
 
 | Day | Night |
 | --- | --- |
-| ![With cta Dialog component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Dialog/screenshots/with-cta.png) |![With cta Dialog component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Dialog/screenshots/with-cta_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Dialog/screenshots/with-cta.png" alt="With cta Dialog component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Dialog/screenshots/with-cta_dm.png" alt="With cta Dialog component - dark mode" width="375" /> |
 
 ## With flare
 
 | Day | Night |
 | --- | --- |
-| ![With flare Dialog component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Dialog/screenshots/with-flare.png) |![With flare Dialog component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Dialog/screenshots/with-flare_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Dialog/screenshots/with-flare.png" alt="With flare Dialog component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Dialog/screenshots/with-flare_dm.png" alt="With flare Dialog component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Flare/README.md
+++ b/docs/view/Flare/README.md
@@ -6,31 +6,31 @@
 
 | Day | Night |
 | --- | --- |
-| ![Flare component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Flare/screenshots/default.png) |![Flare component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Flare/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Flare/screenshots/default.png" alt="Flare component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Flare/screenshots/default_dm.png" alt="Flare component - dark mode" width="375" /> |
 
 ## Inset padding
 
 | Day | Night |
 | --- | --- |
-| ![Inset padding Flare component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Flare/screenshots/inset-padding.png) |![Inset padding Flare component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Flare/screenshots/inset-padding_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Flare/screenshots/inset-padding.png" alt="Inset padding Flare component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Flare/screenshots/inset-padding_dm.png" alt="Inset padding Flare component - dark mode" width="375" /> |
 
 ## Pointer offset
 
 | Day | Night |
 | --- | --- |
-| ![Pointer offset Flare component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Flare/screenshots/pointer-offset.png) |![Pointer offset Flare component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Flare/screenshots/pointer-offset_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Flare/screenshots/pointer-offset.png" alt="Pointer offset Flare component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Flare/screenshots/pointer-offset_dm.png" alt="Pointer offset Flare component - dark mode" width="375" /> |
 
 ## Pointing up
 
 | Day | Night |
 | --- | --- |
-| ![Pointing up Flare component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Flare/screenshots/pointing-up.png) |![Pointing up Flare component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Flare/screenshots/pointing-up_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Flare/screenshots/pointing-up.png" alt="Pointing up Flare component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Flare/screenshots/pointing-up_dm.png" alt="Pointing up Flare component - dark mode" width="375" /> |
 
 ## Rounded
 
 | Day | Night |
 | --- | --- |
-| ![Rounded Flare component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Flare/screenshots/rounded.png) |![Rounded Flare component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Flare/screenshots/rounded_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Flare/screenshots/rounded.png" alt="Rounded Flare component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Flare/screenshots/rounded_dm.png" alt="Rounded Flare component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/FloatingActionButton/README.md
+++ b/docs/view/FloatingActionButton/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![FloatingActionButton component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/FloatingActionButton/screenshots/default.png) |![FloatingActionButton component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/FloatingActionButton/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/FloatingActionButton/screenshots/default.png" alt="FloatingActionButton component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/FloatingActionButton/screenshots/default_dm.png" alt="FloatingActionButton component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/HorizontalNav/README.md
+++ b/docs/view/HorizontalNav/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![HorizontalNav component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/HorizontalNav/screenshots/default.png) |![HorizontalNav component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/HorizontalNav/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/HorizontalNav/screenshots/default.png" alt="HorizontalNav component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/HorizontalNav/screenshots/default_dm.png" alt="HorizontalNav component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Icon/README.md
+++ b/docs/view/Icon/README.md
@@ -6,13 +6,13 @@
 
 | Day | Night |
 | --- | --- |
-| ![Icon component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Icon/screenshots/all.png) |![Icon component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Icon/screenshots/all_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Icon/screenshots/all.png" alt="Icon component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Icon/screenshots/all_dm.png" alt="Icon component - dark mode" width="375" /> |
 
 ## Small
 
 | Day | Night |
 | --- | --- |
-| ![Sm Icon component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Icon/screenshots/small.png) |![Sm Icon component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Icon/screenshots/small_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Icon/screenshots/small.png" alt="Sm Icon component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Icon/screenshots/small_dm.png" alt="Sm Icon component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Maps/README.md
+++ b/docs/view/Maps/README.md
@@ -8,19 +8,19 @@
 
 | Day | Night |
 | --- | --- |
-| ![Badges Maps component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Maps/screenshots/badges.png) |![Badges Maps component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Maps/screenshots/badges_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Maps/screenshots/badges.png" alt="Badges Maps component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Maps/screenshots/badges_dm.png" alt="Badges Maps component - dark mode" width="375" /> |
 
 ## Pointers
 
 | Day | Night |
 | --- | --- |
-| ![Pointers Maps component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Maps/screenshots/pointers.png) |![Pointers Maps component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Maps/screenshots/pointers_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Maps/screenshots/pointers.png" alt="Pointers Maps component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Maps/screenshots/pointers_dm.png" alt="Pointers Maps component - dark mode" width="375" /> |
 
 ## With Icons
 
 | Day | Night |
 | --- | --- |
-| ![With Icons Maps component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Maps/screenshots/with_icons) |![With Icons Maps component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Maps/screenshots/with_icons_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Maps/screenshots/with_icons" alt="With Icons Maps component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Maps/screenshots/with_icons_dm.png" alt="With Icons Maps component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/NavBar/README.md
+++ b/docs/view/NavBar/README.md
@@ -8,19 +8,19 @@
 
 | Day | Night |
 | --- | --- |
-| ![Collapsed NavBar component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/NavBar/screenshots/collapsed.png) |![Collapsed NavBar component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/NavBar/screenshots/collapsed_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/NavBar/screenshots/collapsed.png" alt="Collapsed NavBar component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/NavBar/screenshots/collapsed_dm.png" alt="Collapsed NavBar component - dark mode" width="375" /> |
 
 ## Expanded
 
 | Day | Night |
 | --- | --- |
-| ![Expanded NavBar component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/NavBar/screenshots/expanded.png) |![Expanded NavBar component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/NavBar/screenshots/expanded_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/NavBar/screenshots/expanded.png" alt="Expanded NavBar component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/NavBar/screenshots/expanded_dm.png" alt="Expanded NavBar component - dark mode" width="375" /> |
 
 ## Navigation
 
 | Day | Night |
 | --- | --- |
-| ![Navigation NavBar component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/NavBar/screenshots/navigation.png) |![Navigation NavBar component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/NavBar/screenshots/navigation_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/NavBar/screenshots/navigation.png" alt="Navigation NavBar component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/NavBar/screenshots/navigation_dm.png" alt="Navigation NavBar component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Nudger/README.md
+++ b/docs/view/Nudger/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![Nudger component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Nudger/screenshots/all.png) |![Nudger component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Nudger/screenshots/all_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Nudger/screenshots/all.png" alt="Nudger component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Nudger/screenshots/all_dm.png" alt="Nudger component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Overlay/README.md
+++ b/docs/view/Overlay/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![Overlay component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Overlay/screenshots/all.png) |![Overlay component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Overlay/screenshots/all_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Overlay/screenshots/all.png" alt="Overlay component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Overlay/screenshots/all_dm.png" alt="Overlay component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Panel/README.md
+++ b/docs/view/Panel/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![Panel component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Panel/screenshots/all.png) |![Panel component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Panel/screenshots/all_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Panel/screenshots/all.png" alt="Panel component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Panel/screenshots/all_dm.png" alt="Panel component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/RadioButton/README.md
+++ b/docs/view/RadioButton/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![RadioButton component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/RadioButton/screenshots/default.png) |![RadioButton component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/RadioButton/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/RadioButton/screenshots/default.png" alt="RadioButton component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/RadioButton/screenshots/default_dm.png" alt="RadioButton component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Rating/README.md
+++ b/docs/view/Rating/README.md
@@ -8,25 +8,25 @@
 
 | Day | Night |
 | --- | --- |
-| ![Rating component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Rating/screenshots/default.png) |![Rating component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Rating/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Rating/screenshots/default.png" alt="Rating component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Rating/screenshots/default_dm.png" alt="Rating component - dark mode" width="375" /> |
 
 ## Pill
 
 | Day | Night |
 | --- | --- |
-| ![Pill Rating component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Rating/screenshots/pill.png) |![Pill Rating component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Rating/screenshots/pill_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Rating/screenshots/pill.png" alt="Pill Rating component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Rating/screenshots/pill_dm.png" alt="Pill Rating component - dark mode" width="375" /> |
 
 ## Sizes
 
 | Day | Night |
 | --- | --- |
-| ![Sizes Rating component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Rating/screenshots/sizes.png) |![Sizes Rating component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Rating/screenshots/sizes_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Rating/screenshots/sizes.png" alt="Sizes Rating component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Rating/screenshots/sizes_dm.png" alt="Sizes Rating component - dark mode" width="375" /> |
 
 ## Vertical
 
 | Day | Night |
 | --- | --- |
-| ![Vertical Rating component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Rating/screenshots/vertical.png) |![Vertical Rating component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Rating/screenshots/vertical_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Rating/screenshots/vertical.png" alt="Vertical Rating component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Rating/screenshots/vertical_dm.png" alt="Vertical Rating component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Skeleton/README.md
+++ b/docs/view/Skeleton/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![Skeleton component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Skeleton/screenshots/default.png) |![Skeleton component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Skeleton/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Skeleton/screenshots/default.png" alt="Skeleton component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Skeleton/screenshots/default_dm.png" alt="Skeleton component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Slider/README.md
+++ b/docs/view/Slider/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![Slider component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Slider/screenshots/all.png) |![Slider component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Slider/screenshots/all_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Slider/screenshots/all.png" alt="Slider component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Slider/screenshots/all_dm.png" alt="Slider component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Snackbar/README.md
+++ b/docs/view/Snackbar/README.md
@@ -8,13 +8,13 @@
 
 | Day | Night |
 | --- | --- |
-| ![Snackbar component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Snackbar/screenshots/default.png) |![Snackbar component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Snackbar/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Snackbar/screenshots/default.png" alt="Snackbar component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Snackbar/screenshots/default_dm.png" alt="Snackbar component - dark mode" width="375" /> |
 
 ## Icon
 
 | Day | Night |
 | --- | --- |
-| ![Icon Snackbar component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Snackbar/screenshots/icon.png) |![Icon Snackbar component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Snackbar/screenshots/icon_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Snackbar/screenshots/icon.png" alt="Icon Snackbar component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Snackbar/screenshots/icon_dm.png" alt="Icon Snackbar component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Spinner/README.md
+++ b/docs/view/Spinner/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![Spinner component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Spinner/screenshots/default.png) |![Spinner component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Spinner/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Spinner/screenshots/default.png" alt="Spinner component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Spinner/screenshots/default_dm.png" alt="Spinner component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/StarRating/README.md
+++ b/docs/view/StarRating/README.md
@@ -8,13 +8,13 @@
 
 | Day | Night |
 | --- | --- |
-| ![StarRating component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/StarRating/screenshots/default.png) |![StarRating component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/StarRating/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/StarRating/screenshots/default.png" alt="StarRating component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/StarRating/screenshots/default_dm.png" alt="StarRating component - dark mode" width="375" /> |
 
 ## Interactive
 
 | Day | Night |
 | --- | --- |
-| ![StarRating component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/StarRatingInteractive/screenshots/default.png) |![StarRating component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/StarRatingInteractive/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/StarRatingInteractive/screenshots/default.png" alt="StarRating component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/StarRatingInteractive/screenshots/default_dm.png" alt="StarRating component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Switch/README.md
+++ b/docs/view/Switch/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![Switch component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Switch/screenshots/default.png) |![Switch component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Switch/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Switch/screenshots/default.png" alt="Switch component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Switch/screenshots/default_dm.png" alt="Switch component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Text/README.md
+++ b/docs/view/Text/README.md
@@ -8,19 +8,19 @@
 
 | Day | Night |
 | --- | --- |
-| ![Body Text component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Text/screenshots/body.png) |![Body Text component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Text/screenshots/body_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Text/screenshots/body.png" alt="Body Text component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Text/screenshots/body_dm.png" alt="Body Text component - dark mode" width="375" /> |
 
 ## Heading
 
 | Day | Night |
 | --- | --- |
-| ![Heading Text component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Text/screenshots/heading.png) |![Heading Text component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Text/screenshots/heading_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Text/screenshots/heading.png" alt="Heading Text component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Text/screenshots/heading_dm.png" alt="Heading Text component - dark mode" width="375" /> |
 
 ## Hero
 
 | Day | Night |
 | --- | --- |
-| ![Hero Text component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Text/screenshots/hero.png) |![Hero Text component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Text/screenshots/hero_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Text/screenshots/hero.png" alt="Hero Text component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Text/screenshots/hero_dm.png" alt="Hero Text component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/TextField/README.md
+++ b/docs/view/TextField/README.md
@@ -8,13 +8,13 @@
 
 | Day | Night |
 | --- | --- |
-| ![TextField component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/TextField/screenshots/default.png) |![TextField component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/TextField/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/TextField/screenshots/default.png" alt="TextField component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/TextField/screenshots/default_dm.png" alt="TextField component - dark mode" width="375" /> |
 
 ## Labels
 
 | Day | Night |
 | --- | --- |
-| ![Labels TextField component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/TextField/screenshots/labels.png) |![Labels TextField component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/TextField/screenshots/labels_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/TextField/screenshots/labels.png" alt="Labels TextField component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/TextField/screenshots/labels_dm.png" alt="Labels TextField component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/TextSpans/README.md
+++ b/docs/view/TextSpans/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![TextSpans component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/TextSpans/screenshots/default.png) |![TextSpans component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/TextSpans/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/TextSpans/screenshots/default.png" alt="TextSpans component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/TextSpans/screenshots/default_dm.png" alt="TextSpans component - dark mode" width="375" /> |
 
 ## Installation
 

--- a/docs/view/Toast/README.md
+++ b/docs/view/Toast/README.md
@@ -8,7 +8,7 @@
 
 | Day | Night |
 | --- | --- |
-| ![Toast component](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Toast/screenshots/default.png) |![Toast component - dark mode](https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Toast/screenshots/default_dm.png) |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Toast/screenshots/default.png" alt="Toast component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Toast/screenshots/default_dm.png" alt="Toast component - dark mode" width="375" /> |
 
 ## Installation
 


### PR DESCRIPTION
Supernova renders them full sized. We need to limit the size on our end.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] Component `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
