### PR TITLE
SONIC - Make BpkImageDialog secondaryButton optional

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/dialog/BpkDialog.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/dialog/BpkDialog.kt
@@ -202,6 +202,31 @@ fun BpkImageDialog(
   title: String,
   text: String,
   confirmButton: DialogButton,
+  secondaryButton: DialogButton? = null,
+  textAlign: TextAlign = TextAlign.Center,
+  properties: DialogProperties = DialogProperties(),
+  content: @Composable BoxScope.() -> Unit,
+) {
+  BpkImageDialogImpl(
+    title = title,
+    text = text,
+    buttons = listOfNotNull(
+      Dialog.Button(BpkButtonType.Featured, confirmButton),
+      secondaryButton?.let { Dialog.Button(BpkButtonType.Secondary, secondaryButton) },
+    ),
+    onDismissRequest = onDismissRequest,
+    properties = properties,
+    textAlign = textAlign,
+    content = content,
+  )
+}
+
+@Composable
+fun BpkImageDialog(
+  onDismissRequest: () -> Unit,
+  title: String,
+  text: String,
+  confirmButton: DialogButton,
   secondaryButton: DialogButton,
   linkButton: DialogButton? = null,
   textAlign: TextAlign = TextAlign.Center,


### PR DESCRIPTION
Added an overload of BpkImageDialog to make secondaryButton optional

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests
+ [ ] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
