### PR TITLE
KOA-5679 Include kotlin sourceset when publishing

### DIFF
--- a/gradle-maven-push.gradle
+++ b/gradle-maven-push.gradle
@@ -3,6 +3,7 @@ apply plugin: 'signing'
 
 task sourceJar(type: Jar) {
   from android.sourceSets.main.java.srcDirs
+  from android.sourceSets.main.kotlin.srcDirs
   classifier "source"
 }
 


### PR DESCRIPTION
The compose module was in the kotlin sourceset, rather than java which meant we didn't include the sources when publishing

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] Component `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
