### PR TITLE
KOA-5874 Fix chip crash when using theming

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/chip/internal/BpkChipAppearances.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/chip/internal/BpkChipAppearances.kt
@@ -56,12 +56,14 @@ internal sealed class BpkChipAppearances : BpkChipAppearance {
         disabled = context.getColor(R.color.bpkTextDisabled),
       )
 
-    internal class Default(context: Context, typedArray: TypedArray?) : Solid(context) {
+    internal class Default(context: Context, private val typedArray: TypedArray?) : Solid(context) {
       constructor(
         context: Context,
         attrs: AttributeSet?,
         defStyleAttr: Int,
-      ) : this(context, context.theme.obtainStyledAttributes(attrs, R.styleable.BpkChip, defStyleAttr, 0))
+      ) : this(context, context.theme.obtainStyledAttributes(attrs, R.styleable.BpkChip, defStyleAttr, 0)) {
+        typedArray?.recycle()
+      }
 
       override var selectedBackgroundColor: Int = context.getColor(R.color.__privateChipDefaultOnBackground)
       override var backgroundColor: Int = context.getColor(R.color.__privateChipDefaultNormalBackground)
@@ -80,17 +82,18 @@ internal sealed class BpkChipAppearances : BpkChipAppearance {
           disabledBackgroundColor =
             typedArray.getColor(R.styleable.BpkChip_chipDisabledBackgroundColor, disabledBackgroundColor)
           textColor = typedArray.getColor(R.styleable.BpkChip_chipTextColor, textColor)
-          typedArray.recycle()
         }
       }
     }
 
-    internal class OnDark(context: Context, typedArray: TypedArray?) : Solid(context) {
+    internal class OnDark(context: Context, private val typedArray: TypedArray?) : Solid(context) {
       constructor(
         context: Context,
         attrs: AttributeSet?,
         defStyleAttr: Int,
-      ) : this(context, context.theme.obtainStyledAttributes(attrs, R.styleable.BpkChip, defStyleAttr, 0))
+      ) : this(context, context.theme.obtainStyledAttributes(attrs, R.styleable.BpkChip, defStyleAttr, 0)) {
+        typedArray?.recycle()
+      }
 
       override var selectedBackgroundColor: Int = context.getColor(R.color.__privateChipOnDarkOnBackground)
       override var backgroundColor: Int = context.getColor(R.color.__privateChipOnDarkNormalBackground)
@@ -109,7 +112,6 @@ internal sealed class BpkChipAppearances : BpkChipAppearance {
           disabledBackgroundColor =
             typedArray.getColor(R.styleable.BpkChip_chipDisabledBackgroundColor, disabledBackgroundColor)
           textColor = typedArray.getColor(R.styleable.BpkChip_chipTextColor, textColor)
-          typedArray.recycle()
         }
       }
     }

--- a/app/src/androidTest/java/net/skyscanner/backpack/chip/BpkChipTest.kt
+++ b/app/src/androidTest/java/net/skyscanner/backpack/chip/BpkChipTest.kt
@@ -65,7 +65,7 @@ class BpkChipTest : BpkSnapshotTest() {
   }
 
   @Test
-  @Variants(BpkTestVariant.Default, BpkTestVariant.DarkMode) // TODO: add themed once KOA-5874 is done
+  @Variants(BpkTestVariant.Default, BpkTestVariant.DarkMode, BpkTestVariant.Themed)
   fun notSelected_OnDark() {
     val view = BpkChip(testContext)
     view.text = "Chip"
@@ -75,7 +75,7 @@ class BpkChipTest : BpkSnapshotTest() {
   }
 
   @Test
-  @Variants(BpkTestVariant.Default, BpkTestVariant.DarkMode) // TODO: add themed once KOA-5874 is done
+  @Variants(BpkTestVariant.Default, BpkTestVariant.DarkMode, BpkTestVariant.Themed)
   fun selected_OnDark() {
     val view = BpkChip(testContext)
     view.text = "Chip"
@@ -85,7 +85,7 @@ class BpkChipTest : BpkSnapshotTest() {
   }
 
   @Test
-  @Variants(BpkTestVariant.Default, BpkTestVariant.DarkMode) // TODO: add themed once KOA-5874 is done
+  @Variants(BpkTestVariant.Default, BpkTestVariant.DarkMode, BpkTestVariant.Themed)
   fun disabled_OnDark() {
     val view = BpkChip(testContext)
     view.text = "Chip"


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

This crash happened when programmatically setting a style + using theming due to recycling the `TypedArray` twice.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] Component `README.md`
+ [x] Tests
+ [x] Docs (either update [backpack-docs](https://github.com/Skyscanner/backpack-docs) now, or create a follow up ticket)

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
