### PR TITLE
Bellagio/non jira remove confirmation

### DIFF
--- a/scripts/generate-component.py
+++ b/scripts/generate-component.py
@@ -31,12 +31,6 @@ else:
     package = sys.argv[2]
 
 print('')
-print(f'Create compose component structure for {package}.Bpk{name}?')
-confirmation = input("[Y/n]: ").lower()
-if confirmation != "" and confirmation != "y" and confirmation != "yes":
-    sys.exit("Component creation cancelled")
-
-print('')
 print('Creating compose component structure...')
 print('')
 

--- a/scripts/generate-component.py
+++ b/scripts/generate-component.py
@@ -31,7 +31,7 @@ else:
     package = sys.argv[2]
 
 print('')
-print('Creating compose component structure...')
+print('Creating component structure...')
 print('')
 
 mapping = {


### PR DESCRIPTION
If you don't enter "yes" the process is cancelled which seems counter intuitive. If all new components are expected to be designed using compose then this shouldn't need to be asked during setup, hence i'm removing it.