### PR TITLE
Add bpkbutton content description

### DIFF
--- a/app/src/main/java/net/skyscanner/backpack/demo/compose/ButtonsStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/compose/ButtonsStory.kt
@@ -222,6 +222,7 @@ private fun ButtonsRow(
                 enabled = enabled,
                 loading = loading,
                 onClick = ::load,
+                contentDescription = stringResource(R.string.button_custom_content_description),
             )
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,6 +115,7 @@
     <string name="button_increased">%s increased</string>
     <string name="button_short_text">Short Text</string>
     <string name="button_long_text">Long Text Long Text Long Text Long Text Long</string>
+    <string name="button_custom_content_description">Custom Content Description</string>
 
     <string name="toggle_default">Default</string>
     <string name="toggle_indeterminate">Indeterminate</string>

--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/button/internal/BpkButtonImplTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/button/internal/BpkButtonImplTest.kt
@@ -1,0 +1,61 @@
+/**
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.skyscanner.backpack.compose.button.internal
+
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import net.skyscanner.backpack.compose.theme.BpkTheme
+import org.junit.Rule
+import org.junit.Test
+
+class BpkButtonImplTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun givenContentDescriptionNotNull_whenBpkButton_thenSemanticsSet() {
+        composeTestRule.setContent {
+            BpkTheme {
+                BpkButtonImpl(
+                    enabled = true,
+                    loading = false,
+                    contentDescription = "Custom content description",
+                    onClick = { },
+                    content = { },
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("Custom content description")
+            .assertExists()
+
+        composeTestRule
+            .onNode(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button))
+            .assertIsEnabled()
+            .assertHasClickAction()
+            .assertExists()
+    }
+}

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/button/BpkButton.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/button/BpkButton.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.semantics.contentDescription
 import net.skyscanner.backpack.compose.button.internal.BpkButtonImpl
 import net.skyscanner.backpack.compose.button.internal.ButtonDrawable
 import net.skyscanner.backpack.compose.button.internal.ButtonIcon
@@ -105,13 +106,14 @@ fun BpkButton(
     text: String,
     icon: BpkIcon,
     position: BpkButtonIconPosition,
+    onClick: () -> Unit,
     modifier: Modifier = Modifier,
     size: BpkButtonSize = DefaultSize,
     type: BpkButtonType = DefaultType,
     enabled: Boolean = DefaultEnabled,
     loading: Boolean = DefaultLoading,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
-    onClick: () -> Unit,
+    contentDescription: String? = null,
 ) {
     BpkButtonImpl(
         size = size,
@@ -121,6 +123,7 @@ fun BpkButton(
         interactionSource = interactionSource,
         modifier = modifier,
         onClick = onClick,
+        contentDescription = contentDescription,
     ) {
         when (position) {
             BpkButtonIconPosition.Start -> {

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/button/internal/BpkButtonImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/button/internal/BpkButtonImpl.kt
@@ -19,6 +19,7 @@
 package net.skyscanner.backpack.compose.button.internal
 
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -40,6 +41,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.style.TextOverflow
 import net.skyscanner.backpack.compose.LocalContentColor
 import net.skyscanner.backpack.compose.LocalTextStyle
@@ -52,6 +56,7 @@ import net.skyscanner.backpack.compose.spinner.BpkSpinnerSize
 import net.skyscanner.backpack.compose.text.BpkText
 import net.skyscanner.backpack.compose.tokens.BpkBorderRadius
 import net.skyscanner.backpack.compose.tokens.BpkSpacing
+import net.skyscanner.backpack.compose.utils.applyIf
 import net.skyscanner.backpack.compose.utils.hideContentIf
 
 @Composable
@@ -63,15 +68,31 @@ internal fun BpkButtonImpl(
     enabled: Boolean = true,
     loading: Boolean = false,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    contentDescription: String? = null,
     content: @Composable RowScope.() -> Unit,
 ) {
+    val clickable = enabled && !loading
+
     CompositionLocalProvider(LocalRippleTheme provides ButtonRippleTheme(type.rippleColor())) {
         Button(
             onClick = onClick,
-            enabled = enabled && !loading,
+            enabled = clickable,
             modifier = modifier
                 .defaultMinSize(BpkSpacing.Sm, size.minHeight)
-                .requiredHeight(size.minHeight),
+                .requiredHeight(size.minHeight)
+                .applyIf(contentDescription != null) {
+                    then(
+                        Modifier
+                            .clickable(
+                                enabled = clickable,
+                                onClick = onClick,
+                                role = Role.Button,
+                            )
+                            .clearAndSetSemantics {
+                                this.contentDescription = contentDescription!!
+                            },
+                    )
+                },
             interactionSource = interactionSource,
             colors = ButtonDefaults.buttonColors(
                 containerColor = type.backgroundColor(interactionSource),


### PR DESCRIPTION
Add BpkButton constructor with image, text and content description. Requirement identified [here](https://skyscanner.slack.com/archives/C01V743QEM7/p1690377143020019).