### PR TITLE
OGM-1968 Update month selection to only select days in calendar range

### DIFF
--- a/backpack-common/src/androidTest/java/net/skyscanner/backpack/calendar2/data/CalendarRangeSelectionTests.kt
+++ b/backpack-common/src/androidTest/java/net/skyscanner/backpack/calendar2/data/CalendarRangeSelectionTests.kt
@@ -32,6 +32,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.threeten.bp.LocalDate
+import org.threeten.bp.Month
 
 class CalendarRangeSelectionTests {
 
@@ -193,6 +195,27 @@ class CalendarRangeSelectionTests {
 
             verify {
                 assertEquals(CalendarSelection.Dates(firstDay.date, lastDay.date), state.selection)
+            }
+        }
+    }
+
+    @Test
+    fun given_whole_month_is_selected_and_month_is_partly_in_range_only_in_range_selected() {
+        val mSelection = monthSelection.copy(
+            range = LocalDate.of(2000, Month.JANUARY, 15)..LocalDate.of(2001, Month.JANUARY, 14),
+        )
+        testCalendarWith(mSelection) {
+            stateMachine.onClick(CalendarInteraction.SelectMonthClicked(header))
+
+            verify {
+                assertEquals(
+                    CalendarSelection.Month(
+                        month = header.yearMonth,
+                        start = mSelection.range.start,
+                        end = LocalDate.of(2000, monthSelection.range.start.month, 31),
+                    ),
+                    state.selection,
+                )
             }
         }
     }

--- a/backpack-common/src/main/java/net/skyscanner/backpack/calendar2/CalendarSelection.kt
+++ b/backpack-common/src/main/java/net/skyscanner/backpack/calendar2/CalendarSelection.kt
@@ -76,10 +76,11 @@ sealed class CalendarSelection : Serializable {
      * A whole [month] is selected.
      */
     @Immutable
-    data class Month(val month: YearMonth) : Range() {
-        override val start: LocalDate = month.firstDay()
-        override val end: LocalDate = month.lastDay()
-    }
+    data class Month(
+        val month: YearMonth,
+        override val start: LocalDate = month.firstDay(),
+        override val end: LocalDate = month.lastDay(),
+    ) : Range()
 
     /**
      * A range of dates is selected.

--- a/backpack-common/src/main/java/net/skyscanner/backpack/calendar2/data/CalendarStateMachine.kt
+++ b/backpack-common/src/main/java/net/skyscanner/backpack/calendar2/data/CalendarStateMachine.kt
@@ -25,6 +25,8 @@ import net.skyscanner.backpack.calendar2.CalendarParams
 import net.skyscanner.backpack.calendar2.CalendarParams.SelectionMode
 import net.skyscanner.backpack.calendar2.CalendarSelection
 import net.skyscanner.backpack.calendar2.CalendarState
+import net.skyscanner.backpack.calendar2.extension.firstDay
+import net.skyscanner.backpack.calendar2.extension.lastDay
 import net.skyscanner.backpack.util.InternalBackpackApi
 import net.skyscanner.backpack.util.MutableStateMachine
 import net.skyscanner.backpack.util.StateMachine
@@ -144,7 +146,11 @@ internal fun CalendarState.dispatchClick(data: CalendarCell.Header): CalendarSta
     if (data.monthSelectionMode is CalendarParams.MonthSelectionMode.Disabled) return this
     val selection = when (params.selectionMode) {
         SelectionMode.Disabled -> selection
-        else -> CalendarSelection.Month(month = data.yearMonth)
+        else -> CalendarSelection.Month(
+            month = data.yearMonth,
+            start = maxOf(data.yearMonth.firstDay(), params.range.start),
+            end = minOf(data.yearMonth.lastDay(), params.range.endInclusive),
+        )
     }
 
     return copy(


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

When selecting the whole month for a month that is only partially in the range of selectable dates, the entire month is selected.
This means that changing the selection to a range of dates is more difficult as the selectable dates aren't obvious.

Now with this change only the months that are selectable in the month are selected.

| Calendar | Current selection | New selection |
| -------- | -------- | -------- |
| ![calendar](https://github.com/Skyscanner/backpack-android/assets/141921186/d8aafcd7-bede-40a8-9501-05ab1859aefe) | ![old_month_selection](https://github.com/Skyscanner/backpack-android/assets/141921186/eaae3899-4f3f-423d-a687-49ddc6006ea3) | ![new_month_selection](https://github.com/Skyscanner/backpack-android/assets/141921186/ba098220-0104-4ba6-a79f-f0a2525746e6) |

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [x] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
