### PR TITLE
Set TopNavBar zIndex to 1

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/navigationbar/internal/BpkTopNavBarImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/navigationbar/internal/BpkTopNavBarImpl.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import net.skyscanner.backpack.compose.icon.BpkIcon
 import net.skyscanner.backpack.compose.icon.BpkIconSize
 import net.skyscanner.backpack.compose.navigationbar.Action
@@ -83,6 +84,11 @@ internal fun BpkTopNavBarImpl(
         else -> 0.dp
     }
 
+    val zIndex = when {
+        fraction <= 0f -> 1f
+        else -> 0f
+    }
+
     TwoRowsTopAppBar(
         backgroundColor = backgroundColor,
         contentColor = contentColor,
@@ -103,7 +109,8 @@ internal fun BpkTopNavBarImpl(
                 overflow = TextOverflow.Ellipsis,
             )
         },
-        modifier = modifier,
+        modifier = modifier
+            .zIndex(zIndex),
         navigationIcon = {
             if (navIcon != null) {
                 IconAction(action = navIcon)


### PR DESCRIPTION
Fixes a UI issue where the content is drawn on top of the toolbar instead of behind it, this prevents the shadow from being displayed when the content has a background. To fix i added a z index of -1f which is less than the default that is applied to the app bar (0f), causing the bar to be drawn over the content.

| Before | After |
| --- | ----------- |
| ![Screenshot_20231002_133455](https://github.com/Skyscanner/backpack-android/assets/26006896/22c8ae83-41ec-4dac-b04c-dc6bd6ae8a27) | ![Screenshot_20231002_133520](https://github.com/Skyscanner/backpack-android/assets/26006896/e9c03d5e-545b-4c8d-8272-74bb5e22338a) |