### PR TITLE
Add `heading` property for AppSearchModal and TopNavBar

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/appsearchmodal/internal/BpkSection.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/appsearchmodal/internal/BpkSection.kt
@@ -25,6 +25,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import net.skyscanner.backpack.compose.appsearchmodal.BpkItem
 import net.skyscanner.backpack.compose.appsearchmodal.BpkSectionHeading
 import net.skyscanner.backpack.compose.button.BpkButton
@@ -49,6 +51,7 @@ internal fun BpkSectionHeading(
         BpkText(
             text = sectionHeading.title,
             style = BpkTheme.typography.label1,
+            modifier = Modifier.semantics { heading() },
         )
         sectionHeading.action?.let {
             BpkButton(

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/navigationbar/internal/BpkTopNavBarImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/navigationbar/internal/BpkTopNavBarImpl.kt
@@ -30,6 +30,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
@@ -99,6 +101,7 @@ internal fun BpkTopNavBarImpl(
                 maxLines = 1,
                 style = BpkTheme.typography.heading2,
                 overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.semantics { heading() },
             )
         },
         smallTitle = {
@@ -107,6 +110,7 @@ internal fun BpkTopNavBarImpl(
                 maxLines = 1,
                 style = BpkTheme.typography.heading4,
                 overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.semantics { heading() },
             )
         },
         modifier = modifier


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Add `heading` property for the BpkText instance inside the `BpkSectionHeading` and `BpkTopNavBar`, for better screen reader experience

Note: The heading property is intended for screen readers and is not visible to the user.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] Component `README.md`
+ [x] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
