### PR TITLE
LMN-790 Fix modal show/hide duration

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/modal/BpkModalState.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/modal/BpkModalState.kt
@@ -21,7 +21,8 @@ package net.skyscanner.backpack.compose.modal
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import kotlinx.coroutines.delay
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 @Composable
 fun rememberBpkModalState() = remember {
@@ -32,12 +33,22 @@ class BpkModalState internal constructor(
     internal val isVisible: MutableTransitionState<Boolean>,
 ) {
     suspend fun show() {
-        isVisible.targetState = true
-        delay(ModalAnimationDurationMs.toLong())
+        animateState(true)
     }
 
     suspend fun hide() {
-        isVisible.targetState = false
-        delay(ModalAnimationDurationMs.toLong())
+        animateState(false)
+    }
+
+    private suspend fun animateState(newVisibility: Boolean) {
+        isVisible.targetState = newVisibility
+        if (isVisible.currentState == newVisibility) {
+            return
+        }
+        withContext(Dispatchers.IO) {
+            while (!isVisible.isIdle) {
+                // continue until the animation is finished
+            }
+        }
     }
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

The show/hide function was using a fixed delay. This wasn't working correctly when the animation speed is set to a different value/disabled as the animation would finish at a different point as the delay. This resulted in unexpected behaviour when animation speed was different to the default

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
