### PR TITLE
Switch githooks to standard git hook path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -86,14 +86,10 @@ tasks.dokkaHtmlMultiModule.configure {
     }
 }
 
-task installGitHooks() {
-    def command = Runtime.getRuntime().exec("git config core.hooksPath")
-    def currentGitHookDir = command.inputStream.text.trim()
-    def hooksPath = "hooks"
-    if (currentGitHookDir != hooksPath) {
-        Runtime.getRuntime().exec("git config --local core.hooksPath ${hooksPath}")
-        Runtime.getRuntime().exec("chmod -R +x ${hooksPath}")
-    }
+task installGitHooks(type: Copy) {
+    from new File(rootProject.rootDir, 'hooks/pre-commit')
+    into { new File(rootProject.rootDir, '.git/hooks') }
+    fileMode 0775
 }
 
 tasks.getByPath(':app:preBuild').dependsOn installGitHooks


### PR DESCRIPTION
Changing the githooks path sometimes broke the path for the app, meaning that the githooks for the main app weren't run anymore. This changes the githooks to just copy the file and use the standard folder, rather than changing the hookspath.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
