### PR TITLE
Group kotlin and AGP dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,18 @@ updates:
     interval: daily
     time: "10:00"
   open-pull-requests-limit: 10
+  groups:
+    kotlin-ksp-compose:
+      patterns:
+      - "org.jetbrains.kotlin:*"
+      - "org.jetbrains.kotlin.*"
+      - "com.google.devtools.ksp"
+      - "androidx.compose.compiler:compiler"
+    android-gradle-plugin:
+      patterns:
+      - "com.android.tools:*"
+      - "com.android.tools.*"
+
 - package-ecosystem: npm
   directory: "/"
   schedule:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -80,6 +80,7 @@ kotlin-compilerTestingKsp = { module = "com.github.tschuchortdev:kotlin-compile-
 lint-lint = { module = "com.android.tools.lint:lint", version.ref = "lint" }
 lint-api = { module = "com.android.tools.lint:lint-api", version.ref = "lint" }
 
+compose-compiler = { module = "androidx.compose.compiler:compiler", version.ref = "composeCompiler" } # dummy library reference for dependabot updates
 compose-bom = { group = "androidx.compose", name = "compose-bom", version = "2024.03.00" }
 compose-ui = { group = "androidx.compose.ui", name = "ui" }
 compose-foundation = { group = "androidx.compose.foundation", name = "foundation" }


### PR DESCRIPTION
Updating the dependabot configuration so it will group all the Android Gradle Plugin updates together and also the Kotlin/Compose Compiler/KSP updates together as well, given usually they need to be updated together.

Also adding a dummy compose compiler library reference so dependabot is able to fetch the new versions.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
