### PR TITLE
DON-388  Fix BpkSectionItem clickable area

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/appsearchmodal/internal/BpkSearchModalContent.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/appsearchmodal/internal/BpkSearchModalContent.kt
@@ -54,14 +54,12 @@ internal fun BpkSearchModalContent(
                     behaviouralEventWrapper(it, Modifier) {
                         BpkSectionItem(
                             item = it,
-                            modifier = Modifier.padding(BpkSpacing.Base),
                             clickHandleScope = this,
                         )
                     }
                 } else {
                     BpkSectionItem(
                         item = it,
-                        modifier = Modifier.padding(BpkSpacing.Base),
                     )
                 }
             }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/appsearchmodal/internal/BpkSection.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/appsearchmodal/internal/BpkSection.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -72,7 +73,8 @@ internal fun BpkSectionItem(item: BpkItem, modifier: Modifier = Modifier, clickH
                 item.onItemSelected()
                 clickHandleScope?.notifyClick()
             }
-            .fillMaxWidth(),
+            .fillMaxWidth()
+            .padding(BpkSpacing.Base),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(BpkSpacing.Base),
     ) {


### PR DESCRIPTION
Change modifier order so the clickable area extends to the full size of the item.
This now matches the previous place selector / other lists (including the sample app one).

| Before | After |
| ---- | ---- |
| ![item_before](https://github.com/Skyscanner/backpack-android/assets/141921186/e6508be7-d063-4755-a0bd-d5007d69077a) | ![item_after](https://github.com/Skyscanner/backpack-android/assets/141921186/9020348d-e11a-4318-abb3-709af0db999a) |

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
