### PR TITLE
RALP-4859 add heading semantic to snippet heading

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/snippet/internal/BpkSnippetImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/snippet/internal/BpkSnippetImpl.kt
@@ -29,6 +29,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import net.skyscanner.backpack.compose.snippet.ImageOrientation
 import net.skyscanner.backpack.compose.text.BpkText
 import net.skyscanner.backpack.compose.theme.BpkTheme
@@ -69,6 +71,8 @@ internal fun BpkSnippetImpl(
                 text = headline,
                 style = BpkTheme.typography.heading4,
                 color = BpkTheme.colors.textPrimary,
+                modifier = Modifier.semantics { heading() },
+
             )
             Spacer(modifier = Modifier.height(BpkSpacing.Sm))
         }


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

[RALP-4859](https://skyscanner.atlassian.net/browse/RALP-4859)

improves accessiblity by adding heading semantic to snippet heading. This makes the screenreader specify when reading a heading that the heading is a heading

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
