### PR TITLE
RALP-4860 add heading semantic to section header heading

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/sectionheader/internal/BpkSectionHeaderImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/sectionheader/internal/BpkSectionHeaderImpl.kt
@@ -26,6 +26,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import net.skyscanner.backpack.compose.button.BpkButton
 import net.skyscanner.backpack.compose.button.BpkButtonType
 import net.skyscanner.backpack.compose.icon.BpkIcon
@@ -66,6 +68,7 @@ internal fun BpkSectionHeaderImpl(
                     BpkTheme.typography.heading3
                 },
                 color = getTextColor(type),
+                modifier = Modifier.semantics { heading() },
             )
             if (!description.isNullOrBlank()) {
                 BpkText(


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
[RALP-4860](https://skyscanner.atlassian.net/browse/RALP-4860)

improves accessiblity by adding heading semantic to section header heading. This makes the screenreader specify when reading a heading that the heading is a heading

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
