### PR TITLE
RALP-4861 make page indicator invisible to screenreader

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/imagegallery/BpkImageGalleryCarousel.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/imagegallery/BpkImageGalleryCarousel.kt
@@ -27,7 +27,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.invisibleToUser
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import net.skyscanner.backpack.compose.badge.BpkBadge
 import net.skyscanner.backpack.compose.badge.BpkBadgeType
@@ -35,6 +38,7 @@ import net.skyscanner.backpack.compose.carousel.BpkCarousel
 import net.skyscanner.backpack.compose.carousel.BpkCarouselState
 import net.skyscanner.backpack.compose.tokens.BpkSpacing
 
+@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun BpkImageGalleryCarousel(
     state: BpkCarouselState,
@@ -65,9 +69,10 @@ fun BpkImageGalleryCarousel(
                 pageIndicator?.invoke()
                 BpkBadge(
                     modifier = Modifier
-                        .align(Alignment.BottomEnd),
+                        .align(Alignment.BottomEnd).semantics { this.invisibleToUser() },
                     text = "${state.currentPage + 1}/${state.pageCount}",
                     type = BpkBadgeType.Inverse,
+
                 )
             }
         },

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/imagegallery/BpkImageGalleryCarousel.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/imagegallery/BpkImageGalleryCarousel.kt
@@ -29,14 +29,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.invisibleToUser
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import net.skyscanner.backpack.compose.badge.BpkBadge
 import net.skyscanner.backpack.compose.badge.BpkBadgeType
 import net.skyscanner.backpack.compose.carousel.BpkCarousel
 import net.skyscanner.backpack.compose.carousel.BpkCarouselState
 import net.skyscanner.backpack.compose.tokens.BpkSpacing
+import net.skyscanner.backpack.compose.utils.invisibleSemantic
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
@@ -69,7 +68,7 @@ fun BpkImageGalleryCarousel(
                 pageIndicator?.invoke()
                 BpkBadge(
                     modifier = Modifier
-                        .align(Alignment.BottomEnd).semantics { this.invisibleToUser() },
+                        .align(Alignment.BottomEnd).invisibleSemantic(),
                     text = "${state.currentPage + 1}/${state.pageCount}",
                     type = BpkBadgeType.Inverse,
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

[RALP-4861](https://skyscanner.atlassian.net/browse/RALP-4861)

Previously the screenreader could move focus from the image to the page indicator element, this caused repeated information to be read out to the user which is potentially confusing. The page indicator gives no additional info on top of what is already provided by the narration from the image so best approach is to make the indicator invisible to the user

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
