### PR TITLE
Donburi/don 555 add test tag to nudger

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/nudger/BpkNudger.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/nudger/BpkNudger.kt
@@ -29,11 +29,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.disabled
 import androidx.compose.ui.semantics.invisibleToUser
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.setProgress
 import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.semantics.text
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.style.TextAlign
@@ -61,6 +64,8 @@ fun BpkNudger(
     min: Int,
     max: Int,
     modifier: Modifier = Modifier,
+    testTag: String? = null,
+    allowSemantics: Boolean = true,
     enabled: Boolean = LocalFieldStatus.current != BpkFieldStatus.Disabled,
 ) {
     val range = min..max
@@ -70,7 +75,7 @@ fun BpkNudger(
         onValueChange(value.coerceIn(range))
 
     Row(
-        modifier = modifier.nudgerSemantics(value, ::setValue, range, enabled),
+        modifier = if (allowSemantics) modifier.nudgerSemantics(value, ::setValue, range, enabled) else modifier,
         verticalAlignment = Alignment.CenterVertically,
     ) {
 
@@ -81,6 +86,7 @@ fun BpkNudger(
             size = BpkButtonSize.Default,
             type = BpkButtonType.Secondary,
             onClick = { setValue(coerced - 1) },
+            modifier = Modifier.generateNudgerTestTag(testTag, "Minus"),
         )
 
         BpkText(
@@ -107,8 +113,20 @@ fun BpkNudger(
             size = BpkButtonSize.Default,
             type = BpkButtonType.Secondary,
             onClick = { setValue(coerced + 1) },
+            modifier = Modifier.generateNudgerTestTag(testTag, "Plus"),
         )
     }
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+private fun Modifier.generateNudgerTestTag(testTag: String?, buttonType: String): Modifier {
+    return testTag?.let {
+        semantics {
+            contentDescription = ""
+            stateDescription = ""
+            testTagsAsResourceId = true
+        }.testTag("${testTag}$buttonType")
+    } ?: this
 }
 
 @Composable
@@ -119,6 +137,7 @@ fun BpkNudger(
     max: Int,
     title: String,
     modifier: Modifier = Modifier,
+    testTag: String? = null,
     subtitle: String? = null,
     icon: BpkIcon? = null,
     enabled: Boolean = LocalFieldStatus.current != BpkFieldStatus.Disabled,
@@ -126,7 +145,9 @@ fun BpkNudger(
     Row(
         modifier = modifier
             .semantics {
-                text = listOfNotNull(title, subtitle).joinToString(separator = " ").let(::AnnotatedString)
+                text = listOfNotNull(title, subtitle)
+                    .joinToString(separator = " ")
+                    .let(::AnnotatedString)
             }
             .nudgerSemantics(value, onValueChange, min..max, enabled),
         verticalAlignment = Alignment.CenterVertically,
@@ -171,7 +192,8 @@ fun BpkNudger(
             min = min,
             max = max,
             enabled = enabled,
-            modifier = Modifier.invisibleSemantic(),
+            testTag = testTag,
+            allowSemantics = false,
         )
     }
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/nudger/BpkNudgerImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/nudger/BpkNudgerImpl.kt
@@ -51,7 +51,7 @@ import kotlin.math.roundToInt
 
 @OptIn(ExperimentalComposeUiApi::class)
 @Composable
-fun BpkNudgerImpl(
+internal fun BpkNudgerImpl(
     value: Int,
     onValueChange: (Int) -> Unit,
     min: Int,

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/nudger/BpkNudgerImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/nudger/BpkNudgerImpl.kt
@@ -79,7 +79,7 @@ fun BpkNudgerImpl(
             size = BpkButtonSize.Default,
             type = BpkButtonType.Secondary,
             onClick = { setValue(coerced - 1) },
-            modifier = Modifier.generateNudgerTestTag(testTag, "Minus"),
+            modifier = Modifier.generateNudgerTestTag(testTag, "Decrement"),
         )
 
         BpkText(
@@ -106,7 +106,7 @@ fun BpkNudgerImpl(
             size = BpkButtonSize.Default,
             type = BpkButtonType.Secondary,
             onClick = { setValue(coerced + 1) },
-            modifier = Modifier.generateNudgerTestTag(testTag, "Plus"),
+            modifier = Modifier.generateNudgerTestTag(testTag, "Increment"),
         )
     }
 }
@@ -146,12 +146,12 @@ internal fun Modifier.nudgerSemantics(
         )
 
 @OptIn(ExperimentalComposeUiApi::class)
-private fun Modifier.generateNudgerTestTag(testTag: String?, buttonType: String): Modifier {
+private fun Modifier.generateNudgerTestTag(testTag: String?, action: String): Modifier {
     return testTag?.let {
         semantics {
             contentDescription = ""
             stateDescription = ""
             testTagsAsResourceId = true
-        }.testTag("${testTag}$buttonType")
+        }.testTag("${testTag}$action")
     } ?: this
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/nudger/BpkNudgerImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/nudger/BpkNudgerImpl.kt
@@ -149,8 +149,8 @@ internal fun Modifier.nudgerSemantics(
 private fun Modifier.generateNudgerTestTag(testTag: String?, action: String): Modifier {
     return testTag?.let {
         semantics {
-            contentDescription = ""
-            stateDescription = ""
+            contentDescription = "" // handled by semantics modifier
+            stateDescription = "" // handled by semantics modifier
             testTagsAsResourceId = true
         }.testTag("${testTag}$action")
     } ?: this

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/nudger/BpkNudgerImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/nudger/BpkNudgerImpl.kt
@@ -1,0 +1,157 @@
+/*
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.skyscanner.backpack.compose.nudger
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.progressSemantics
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.invisibleToUser
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.setProgress
+import androidx.compose.ui.semantics.stateDescription
+import androidx.compose.ui.semantics.testTagsAsResourceId
+import androidx.compose.ui.text.style.TextAlign
+import net.skyscanner.backpack.compose.button.BpkButton
+import net.skyscanner.backpack.compose.button.BpkButtonSize
+import net.skyscanner.backpack.compose.button.BpkButtonType
+import net.skyscanner.backpack.compose.fieldset.BpkFieldStatus
+import net.skyscanner.backpack.compose.fieldset.LocalFieldStatus
+import net.skyscanner.backpack.compose.icon.BpkIcon
+import net.skyscanner.backpack.compose.text.BpkText
+import net.skyscanner.backpack.compose.theme.BpkTheme
+import net.skyscanner.backpack.compose.tokens.BpkSpacing
+import net.skyscanner.backpack.compose.tokens.Minus
+import net.skyscanner.backpack.compose.tokens.Plus
+import kotlin.math.roundToInt
+
+@OptIn(ExperimentalComposeUiApi::class)
+@Composable
+fun BpkNudgerImpl(
+    value: Int,
+    onValueChange: (Int) -> Unit,
+    min: Int,
+    max: Int,
+    modifier: Modifier = Modifier,
+    testTag: String? = null,
+    allowSemantics: Boolean = true,
+    enabled: Boolean = LocalFieldStatus.current != BpkFieldStatus.Disabled,
+) {
+    val range = min..max
+    val coerced = value.coerceIn(range)
+
+    fun setValue(value: Int) =
+        onValueChange(value.coerceIn(range))
+
+    Row(
+        modifier = if (allowSemantics) modifier.nudgerSemantics(value, ::setValue, range, enabled) else modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+
+        BpkButton(
+            icon = BpkIcon.Minus,
+            contentDescription = "", // handled by semantics modifier
+            enabled = enabled && coerced > range.first,
+            size = BpkButtonSize.Default,
+            type = BpkButtonType.Secondary,
+            onClick = { setValue(coerced - 1) },
+            modifier = Modifier.generateNudgerTestTag(testTag, "Minus"),
+        )
+
+        BpkText(
+            text = coerced.toString(),
+            style = BpkTheme.typography.heading5,
+            maxLines = 1,
+            textAlign = TextAlign.Center,
+            modifier = Modifier
+                .semantics { invisibleToUser() }
+                .padding(horizontal = BpkSpacing.Md)
+                .widthIn(min = BpkSpacing.Lg),
+            color = animateColorAsState(
+                when {
+                    enabled -> BpkTheme.colors.textPrimary
+                    else -> BpkTheme.colors.textDisabled
+                },
+            ).value,
+        )
+
+        BpkButton(
+            icon = BpkIcon.Plus,
+            contentDescription = "", // handled by semantics modifier
+            enabled = enabled && coerced < range.last,
+            size = BpkButtonSize.Default,
+            type = BpkButtonType.Secondary,
+            onClick = { setValue(coerced + 1) },
+            modifier = Modifier.generateNudgerTestTag(testTag, "Plus"),
+        )
+    }
+}
+
+internal fun Modifier.nudgerSemantics(
+    value: Int,
+    onValueChange: (Int) -> Unit,
+    range: IntRange,
+    enabled: Boolean,
+): Modifier =
+    semantics(mergeDescendants = true) {
+
+        // this is needed to use volume keys
+        setProgress { targetValue ->
+            // without this rounding the values will only decrease
+            val newValue = targetValue
+                .roundToInt()
+                .coerceIn(range)
+            if (newValue != value) {
+                onValueChange(newValue)
+                true
+            } else {
+                false
+            }
+        }
+
+        // override describing percents
+        stateDescription = value.toString()
+
+        if (!enabled) disabled()
+    }
+        .progressSemantics(
+            // this is needed to use volume keys
+            value = value.toFloat(),
+            valueRange = range.first.toFloat()..range.last.toFloat(),
+            steps = range.last - range.first,
+        )
+
+@OptIn(ExperimentalComposeUiApi::class)
+private fun Modifier.generateNudgerTestTag(testTag: String?, buttonType: String): Modifier {
+    return testTag?.let {
+        semantics {
+            contentDescription = ""
+            stateDescription = ""
+            testTagsAsResourceId = true
+        }.testTag("${testTag}$buttonType")
+    } ?: this
+}

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/select/internal/BpkSelectImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/select/internal/BpkSelectImpl.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
 import net.skyscanner.backpack.compose.fieldset.BpkFieldStatus
@@ -56,7 +57,7 @@ internal fun BpkSelectImpl(
 ) {
     var expanded by remember { mutableStateOf(false) }
     val selectText = selectedIndex?.let { options.getOrNull(selectedIndex) } ?: ""
-
+    val focusManager = LocalFocusManager.current
     ExposedDropdownMenuBox(
         expanded = expanded,
         onExpandedChange = { expanded = !expanded },
@@ -75,7 +76,10 @@ internal fun BpkSelectImpl(
             modifier = Modifier
                 .background(BpkTheme.colors.surfaceDefault)
                 .fillMaxWidth(),
-            onDismissRequest = { expanded = false },
+            onDismissRequest = {
+                expanded = false
+                focusManager.clearFocus()
+            },
         ) {
             options.forEachIndexed { index, option ->
                 val itemBackgroundColor =
@@ -95,6 +99,7 @@ internal fun BpkSelectImpl(
                     },
                     onClick = {
                         expanded = false
+                        focusManager.clearFocus()
                         if (index != selectedIndex) {
                             onSelectionChange?.let { it(index) }
                         }


### PR DESCRIPTION
Currently we are facing issues on how to write a smoke test and interact with nudger buttons, so I have made these changes to expose `BpkNudger` buttons `testTags` as `resourceId` without affecting our existing `semantics`, please make sure to test the semantics while reviewing. thank you

Thanks @henrik-sky for recording this
<img src="https://github.com/Skyscanner/backpack-android/assets/19841948/bdfa117e-3570-4dbf-abbd-ec7dbb981b27" width=300 height=600/>




Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
