### PR TITLE
Add tracing library as a workaround for failing docs screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ captures/
 .idea/markdown-navigator-*.xml
 .idea/deploymentTargetDropDown.xml
 .idea/deploymentTargetSelector.xml
+.idea/other.xml
 /.idea/ktfmt.xml
 .kotlin/*
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -110,6 +110,8 @@ dependencies {
     implementation libs.compose.activity
     implementation libs.kotlin.reflection
     implementation libs.destinations.core
+    implementation libs.androidx.tracing
+
     testImplementation libs.test.junit
     testImplementation libs.roborazzi.compose
     testImplementation libs.roborazzi.core
@@ -128,9 +130,11 @@ dependencies {
     androidTestImplementation libs.test.compose
     androidTestImplementation libs.ktor.clientCore
     androidTestImplementation libs.ktor.clientCio
+
     implementation project(':Backpack')
     implementation project(':backpack-compose')
     implementation project(":meta:annotations")
+
     ksp project(":meta:processor")
     ksp libs.destinations.ksp
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,7 @@ androidx-lifecycleKtx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", v
 androidx-lifecycleViewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel", version.ref = "lifecycle" }
 androidx-lifecycleViewmodelKtx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "lifecycle" }
 androidx-lifecycleRuntimeCompose = { module = "androidx.lifecycle:lifecycle-runtime-compose", version.ref = "lifecycle" }
+androidx-tracing = "androidx.tracing:tracing:1.1.0" # workaround for https://github.com/android/android-test/issues/2246
 
 test-junitKtx = { module = "androidx.test.ext:junit-ktx", version.ref = "androidXJunit" }
 test-junitAndroid = { module = "androidx.test.ext:junit", version.ref = "androidXJunit" }


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
Docs screenshot generation was broken after the espresso upgrade

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
