### PR TITLE
RALP-4865 Use ubuntu-22.04 instead of ubuntu-latest

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -17,7 +17,7 @@ jobs:
 
   Build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
     permissions:
       statuses: write
@@ -99,7 +99,7 @@ jobs:
 
   Android:
     name: Android tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
 
     steps:
@@ -163,7 +163,7 @@ jobs:
 
   Screenshots:
     name: Screenshots tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   label-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: docker://agilepathway/pull-request-label-checker:latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
     uses: ./.github/workflows/_build.yml
 
   ReleaseDraft:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -23,7 +23,7 @@ jobs:
     uses: ./.github/workflows/_build.yml
 
   Dependabot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       pull-requests: write
     if: ${{ github.actor == 'dependabot[bot]' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
   Deploy:
     name: Deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: Publishing
     needs: [Build]
     timeout-minutes: 30
@@ -94,7 +94,7 @@ jobs:
           releaseNotes: Version ${{github.event.release.tag_name}}
 
   SupernovaPublish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: Publishing
     steps:
       - name: Update Supernova docs


### PR DESCRIPTION
Using the latest ubuntu image for the github runners but using the specific YAML label instead of `latest`

All available images: https://github.com/actions/runner-images?tab=readme-ov-file#available-images