### PR TITLE
Revert - BpkAppSearchModal execute hide animation 

### DIFF
--- a/app/src/main/java/net/skyscanner/backpack/demo/compose/AppSearchModalStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/compose/AppSearchModalStory.kt
@@ -58,28 +58,28 @@ import net.skyscanner.backpack.meta.StoryKind
 @AppSearchModalComponent
 @ComposeStory("Content")
 fun AppSearchModalStoryContent(modifier: Modifier = Modifier) {
-    AppSearchModalStory(result = { contentResult(it) })
+    AppSearchModalStory(result = contentResult())
 }
 
 @Composable
 @AppSearchModalComponent
 @ComposeStory("Content-InputText", kind = StoryKind.DemoOnly)
 fun AppSearchModalStoryContentInputText(modifier: Modifier = Modifier) {
-    AppSearchModalStory(result = { contentResult(it) }, inputText = stringResource(id = R.string.city_rio))
+    AppSearchModalStory(result = contentResult(), inputText = stringResource(id = R.string.city_rio))
 }
 
 @Composable
 @AppSearchModalComponent
 @ComposeStory("Loading")
 fun AppSearchModalStoryLoading(modifier: Modifier = Modifier) {
-    AppSearchModalStory(result = { loadingResult() }, inputText = stringResource(id = R.string.city_dubai))
+    AppSearchModalStory(result = loadingResult(), inputText = stringResource(id = R.string.city_dubai))
 }
 
 @Composable
 @AppSearchModalComponent
 @ComposeStory("Error")
 fun AppSearchModalStoryError(modifier: Modifier = Modifier) {
-    AppSearchModalStory(result = { errorResult() })
+    AppSearchModalStory(result = errorResult())
 }
 
 @Composable
@@ -87,7 +87,7 @@ fun AppSearchModalStoryError(modifier: Modifier = Modifier) {
 @ComposeStory("Prefix - Text")
 fun AppSearchModalStoryPrefixText(modifier: Modifier = Modifier) {
     AppSearchModalStory(
-        result = { contentResult(it) },
+        result = contentResult(),
         inputText = stringResource(id = R.string.city_dubai),
         prefix = Prefix.Text(
             stringResource(id = R.string.text_field_prefix),
@@ -97,7 +97,7 @@ fun AppSearchModalStoryPrefixText(modifier: Modifier = Modifier) {
 
 @Composable
 private fun AppSearchModalStory(
-    result: @Composable (() -> Unit) -> BpkAppSearchModalResult,
+    result: BpkAppSearchModalResult,
     modifier: Modifier = Modifier,
     inputText: String = "",
     prefix: Prefix = Prefix.Icon(),
@@ -109,7 +109,7 @@ private fun AppSearchModalStory(
 
 @Composable
 internal fun DefaultAppSearchModalSample(
-    result: @Composable (() -> Unit) -> BpkAppSearchModalResult,
+    result: BpkAppSearchModalResult,
     inputText: String,
     modifier: Modifier = Modifier,
     prefix: Prefix = Prefix.Icon(),
@@ -128,7 +128,7 @@ internal fun DefaultAppSearchModalSample(
             title = stringResource(id = R.string.destination),
             inputText = destination.value,
             inputHint = stringResource(id = R.string.text_field_hint),
-            results = result { showModal.value = false },
+            results = result,
             closeAccessibilityLabel = stringResource(id = R.string.navigation_close),
             onClose = { showModal.value = false },
             onInputChanged = { destination.value = it },
@@ -141,7 +141,7 @@ internal fun DefaultAppSearchModalSample(
 }
 
 @Composable
-internal fun contentResult(onItemSelected: () -> Unit) = BpkAppSearchModalResult.Content(
+internal fun contentResult() = BpkAppSearchModalResult.Content(
     sections = listOf(
         BpkSection(
             items = listOf(
@@ -151,7 +151,7 @@ internal fun contentResult(onItemSelected: () -> Unit) = BpkAppSearchModalResult
                     },
                     subtitle = buildAnnotatedString { append(stringResource(id = R.string.current_location_subtitle)) },
                     icon = BpkIcon.UseLocation,
-                    onItemSelected = { onItemSelected() },
+                    onItemSelected = {},
                 ),
             ),
         ),
@@ -165,7 +165,7 @@ internal fun contentResult(onItemSelected: () -> Unit) = BpkAppSearchModalResult
                     title = buildAnnotatedString { append(stringResource(id = R.string.city_london)) },
                     subtitle = buildAnnotatedString { append(stringResource(id = R.string.search_modal_item_subtitle)) },
                     icon = BpkIcon.City,
-                    onItemSelected = { onItemSelected() },
+                    onItemSelected = {},
                 ),
                 BpkItem(
                     title = buildAnnotatedString {
@@ -176,7 +176,7 @@ internal fun contentResult(onItemSelected: () -> Unit) = BpkAppSearchModalResult
                     },
                     subtitle = buildAnnotatedString { append(stringResource(id = R.string.search_modal_item_subtitle)) },
                     icon = BpkIcon.Airports,
-                    onItemSelected = { onItemSelected() },
+                    onItemSelected = {},
                 ),
             ),
         ),
@@ -189,28 +189,28 @@ internal fun contentResult(onItemSelected: () -> Unit) = BpkAppSearchModalResult
                     title = buildAnnotatedString { append(stringResource(id = R.string.city_shenzhen)) },
                     subtitle = buildAnnotatedString { append(stringResource(id = R.string.search_modal_item_subtitle)) },
                     icon = BpkIcon.City,
-                    onItemSelected = { onItemSelected() },
+                    onItemSelected = {},
                     tertiaryLabel = stringResource(id = R.string.search_modal_item_tertiary_label),
                 ),
                 BpkItem(
                     title = buildAnnotatedString { append(stringResource(id = R.string.city_paris)) },
                     subtitle = buildAnnotatedString { append(stringResource(id = R.string.search_modal_item_subtitle)) },
                     icon = BpkIcon.City,
-                    onItemSelected = { onItemSelected() },
+                    onItemSelected = {},
                     tertiaryLabel = stringResource(id = R.string.search_modal_item_tertiary_label),
                 ),
                 BpkItem(
                     title = buildAnnotatedString { append(stringResource(id = R.string.city_algiers)) },
                     subtitle = buildAnnotatedString { append(stringResource(id = R.string.search_modal_item_subtitle)) },
                     icon = BpkIcon.City,
-                    onItemSelected = { onItemSelected() },
+                    onItemSelected = {},
                     tertiaryLabel = stringResource(id = R.string.search_modal_item_tertiary_label),
                 ),
                 BpkItem(
                     title = buildAnnotatedString { append(stringResource(id = R.string.city_madrid)) },
                     subtitle = buildAnnotatedString { append(stringResource(id = R.string.search_modal_item_subtitle)) },
                     icon = BpkIcon.City,
-                    onItemSelected = { onItemSelected() },
+                    onItemSelected = {},
                     tertiaryLabel = stringResource(id = R.string.search_modal_item_tertiary_label),
                 ),
             ),

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/appsearchmodal/BpkAppSearchModal.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/appsearchmodal/BpkAppSearchModal.kt
@@ -104,7 +104,6 @@ fun BpkAppSearchModal(
             onInputChanged = onInputChanged,
             clearAction = clearAction,
             prefix = prefix,
-            onHideModal = { state.hide() },
             behaviouralEventWrapper = behaviouralEventWrapper,
         )
     }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/appsearchmodal/internal/BpkAppSearchModalImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/appsearchmodal/internal/BpkAppSearchModalImpl.kt
@@ -38,7 +38,6 @@ internal fun BpkAppSearchModalImpl(
     results: BpkAppSearchModalResult,
     onInputChanged: (String) -> Unit,
     clearAction: BpkClearAction,
-    onHideModal: suspend () -> Unit,
     modifier: Modifier = Modifier,
     prefix: Prefix = Prefix.Icon(),
     behaviouralEventWrapper: BpkBehaviouralEventWrapper? = null,
@@ -62,11 +61,7 @@ internal fun BpkAppSearchModalImpl(
                     clearAction = clearAction,
                 )
                 if (results is BpkAppSearchModalResult.Content) {
-                    BpkSearchModalContent(
-                        results = results,
-                        onHideModal = onHideModal,
-                        behaviouralEventWrapper = behaviouralEventWrapper,
-                    )
+                    BpkSearchModalContent(results = results, behaviouralEventWrapper = behaviouralEventWrapper)
                 } else if (results is BpkAppSearchModalResult.Loading) {
                     BpkSearchModalLoading(results)
                 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/appsearchmodal/internal/BpkSearchModalContent.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/appsearchmodal/internal/BpkSearchModalContent.kt
@@ -29,18 +29,13 @@ import net.skyscanner.backpack.compose.utils.BpkBehaviouralEventWrapper
 @Composable
 internal fun BpkSearchModalContent(
     results: BpkAppSearchModalResult.Content,
-    onHideModal: suspend () -> Unit,
     modifier: Modifier = Modifier,
     behaviouralEventWrapper: BpkBehaviouralEventWrapper? = null,
 ) {
     LazyColumn(modifier = modifier) {
         results.shortcuts?.let {
             item {
-                BpkShortcuts(
-                    shortcuts = it,
-                    onHideModal = onHideModal,
-                    behaviouralEventWrapper = behaviouralEventWrapper,
-                )
+                BpkShortcuts(shortcuts = it, behaviouralEventWrapper = behaviouralEventWrapper)
             }
         }
         results.sections.forEach { section ->
@@ -59,14 +54,12 @@ internal fun BpkSearchModalContent(
                     behaviouralEventWrapper(it, Modifier) {
                         BpkSectionItem(
                             item = it,
-                            onHideModal = onHideModal,
                             clickHandleScope = this,
                         )
                     }
                 } else {
                     BpkSectionItem(
                         item = it,
-                        onHideModal = onHideModal,
                     )
                 }
             }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/appsearchmodal/internal/BpkSection.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/appsearchmodal/internal/BpkSection.kt
@@ -24,12 +24,10 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
-import kotlinx.coroutines.launch
 import net.skyscanner.backpack.compose.appsearchmodal.BpkItem
 import net.skyscanner.backpack.compose.appsearchmodal.BpkSectionHeading
 import net.skyscanner.backpack.compose.button.BpkButton
@@ -68,19 +66,11 @@ internal fun BpkSectionHeading(
 }
 
 @Composable
-internal fun BpkSectionItem(
-    item: BpkItem,
-    onHideModal: suspend () -> Unit,
-    modifier: Modifier = Modifier,
-    clickHandleScope: BpkClickHandleScope? = null,
-) {
-    val coroutineScope = rememberCoroutineScope()
+internal fun BpkSectionItem(item: BpkItem, modifier: Modifier = Modifier, clickHandleScope: BpkClickHandleScope? = null) {
     Row(
         modifier = modifier
             .clickable {
-                coroutineScope
-                    .launch { onHideModal() }
-                    .invokeOnCompletion { item.onItemSelected() }
+                item.onItemSelected()
                 clickHandleScope?.notifyClick()
             }
             .fillMaxWidth()

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/appsearchmodal/internal/BpkShortcuts.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/appsearchmodal/internal/BpkShortcuts.kt
@@ -23,9 +23,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import kotlinx.coroutines.launch
 import net.skyscanner.backpack.compose.appsearchmodal.BpkShortcut
 import net.skyscanner.backpack.compose.chipgroup.single.BpkSingleChipItem
 import net.skyscanner.backpack.compose.chipgroup.single.BpkSingleSelectChipGroup
@@ -35,14 +33,12 @@ import net.skyscanner.backpack.compose.utils.BpkBehaviouralEventWrapper
 @Composable
 internal fun BpkShortcuts(
     shortcuts: List<BpkShortcut>,
-    onHideModal: suspend () -> Unit,
     modifier: Modifier = Modifier,
     behaviouralEventWrapper: BpkBehaviouralEventWrapper? = null,
 ) {
     val singleSelectChips = shortcuts.map {
         BpkSingleChipItem(text = it.text, icon = it.icon)
     }
-    val coroutineScope = rememberCoroutineScope()
     BpkSingleSelectChipGroup(
         modifier = modifier.padding(
             top = BpkSpacing.Md,
@@ -51,9 +47,8 @@ internal fun BpkShortcuts(
         contentPadding = PaddingValues(horizontal = BpkSpacing.Base),
         chips = singleSelectChips,
         selectedIndex = remember { mutableIntStateOf(-1) }.intValue,
-        onItemClicked = { item ->
-            coroutineScope.launch { onHideModal() }
-                .invokeOnCompletion { shortcuts[singleSelectChips.indexOf(item)].onShortcutSelected() }
+        onItemClicked = {
+            shortcuts[singleSelectChips.indexOf(it)].onShortcutSelected()
         },
         behaviouralEventWrapper = behaviouralEventWrapper,
     )


### PR DESCRIPTION
As we are having issue with the current location issue, we believe this issue is coming from this changes, so we reversing it
[Screen_recording_20240712_142014.webm](https://github.com/user-attachments/assets/a9d85df6-0214-4c3b-8eac-b93a75e4496f)



…selected (#2041)"

This reverts commit 0421c2d55ac8029d4c0bd8ece532b41a01969405.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] Component `README.md`
+ [x] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
