### PR TITLE
[MUON-474] - Add Header tag as optional parameter into BpkSnippet, BpkSectionHeader, and BpkRailCardList

### DIFF
--- a/app/src/main/java/net/skyscanner/backpack/demo/compose/CardListStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/compose/CardListStory.kt
@@ -76,6 +76,7 @@ private fun CardLayout(data: CardListSample) {
         imageOrientation = ImageOrientation.Landscape,
         headline = stringResource(data.headline),
         bodyText = data.bodyText?.let { stringResource(it) },
+        accessibilityHeaderTagEnabled = false,
     ) {
         Image(
             modifier = Modifier.fillMaxSize(),

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cardlist/rail/BpkRailCardList.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cardlist/rail/BpkRailCardList.kt
@@ -30,6 +30,7 @@ fun BpkRailCardList(
     description: String,
     totalCards: Int,
     modifier: Modifier = Modifier,
+    accessibilityHeaderTagEnabled: Boolean? = true,
     headerButton: BpkSectionHeaderButton? = null,
     content: @Composable (LazyItemScope.(Int) -> Unit),
 ) {
@@ -38,6 +39,7 @@ fun BpkRailCardList(
         description = description,
         headerButton = headerButton,
         totalCards = totalCards,
+        accessibilityHeaderTagEnabled = accessibilityHeaderTagEnabled,
         modifier = modifier,
         content = content,
     )

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cardlist/rail/internal/BpkRailCardListImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cardlist/rail/internal/BpkRailCardListImpl.kt
@@ -41,6 +41,7 @@ internal fun BpkRailCardListImpl(
     description: String,
     headerButton: BpkSectionHeaderButton?,
     totalCards: Int,
+    accessibilityHeaderTagEnabled: Boolean?,
     modifier: Modifier = Modifier,
     content: @Composable (LazyItemScope.(Int) -> Unit),
 ) {
@@ -52,6 +53,7 @@ internal fun BpkRailCardListImpl(
             description = description,
             modifier = Modifier.padding(horizontal = BpkSpacing.Base),
             button = headerButton,
+            accessibilityHeaderTagEnabled = accessibilityHeaderTagEnabled,
         )
 
         Spacer(modifier = Modifier.height(BpkSpacing.Base))

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/sectionheader/BpkSectionHeader.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/sectionheader/BpkSectionHeader.kt
@@ -28,6 +28,7 @@ fun BpkSectionHeader(
     modifier: Modifier = Modifier,
     description: String? = null,
     button: BpkSectionHeaderButton? = null,
+    accessibilityHeaderTagEnabled: Boolean? = true,
     type: BpkSectionHeaderType = BpkSectionHeaderType.Default,
 ) {
     BpkSectionHeaderImpl(
@@ -35,6 +36,7 @@ fun BpkSectionHeader(
         modifier = modifier,
         description = description,
         button = button,
+        accessibilityHeaderTagEnabled = accessibilityHeaderTagEnabled,
         type = type,
     )
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/sectionheader/internal/BpkSectionHeaderImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/sectionheader/internal/BpkSectionHeaderImpl.kt
@@ -46,6 +46,7 @@ internal fun BpkSectionHeaderImpl(
     type: BpkSectionHeaderType,
     description: String?,
     button: BpkSectionHeaderButton?,
+    accessibilityHeaderTagEnabled: Boolean?,
     modifier: Modifier = Modifier,
 ) {
     val isTablet = isTablet()
@@ -67,7 +68,11 @@ internal fun BpkSectionHeaderImpl(
                     BpkTheme.typography.heading3
                 },
                 color = getTextColor(type),
-                modifier = Modifier.semantics { heading() },
+                modifier = Modifier.semantics {
+                    if (accessibilityHeaderTagEnabled == true) {
+                        heading()
+                    }
+                },
             )
             if (!description.isNullOrBlank()) {
                 BpkText(

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/snippet/BpkSnippet.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/snippet/BpkSnippet.kt
@@ -29,6 +29,7 @@ fun BpkSnippet(
     headline: String? = null,
     subHeading: String? = null,
     bodyText: String? = null,
+    accessibilityHeaderTagEnabled: Boolean? = true,
     onClick: (() -> Unit)? = null,
     content: @Composable (() -> Unit),
 ) {
@@ -38,6 +39,7 @@ fun BpkSnippet(
         headline = headline,
         subHeading = subHeading,
         bodyText = bodyText,
+        accessibilityHeaderTagEnabled = accessibilityHeaderTagEnabled,
         onClick = onClick,
         content = content,
     )

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/snippet/internal/BpkSnippetImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/snippet/internal/BpkSnippetImpl.kt
@@ -45,6 +45,7 @@ internal fun BpkSnippetImpl(
     subHeading: String?,
     bodyText: String?,
     onClick: (() -> Unit)?,
+    accessibilityHeaderTagEnabled: Boolean?,
     modifier: Modifier = Modifier,
     content: @Composable (() -> Unit),
 ) {
@@ -71,8 +72,11 @@ internal fun BpkSnippetImpl(
                 text = headline,
                 style = BpkTheme.typography.heading4,
                 color = BpkTheme.colors.textPrimary,
-                modifier = Modifier.semantics { heading() },
-
+                modifier = Modifier.semantics {
+                    if (accessibilityHeaderTagEnabled == true) {
+                        heading()
+                    }
+                },
             )
             Spacer(modifier = Modifier.height(BpkSpacing.Sm))
         }

--- a/docs/compose/CardList/README.md
+++ b/docs/compose/CardList/README.md
@@ -26,6 +26,8 @@ Example of a CardList:
 
 ## Rail
 
+* `AccessibilityHeaderTagEnabled`: Used to disable `Heading()` accessibility tag from internal `BpkSectionHeader` - Optional, true by default.
+
 ```Kotlin
 import androidx.annotation.StringRes
 import net.skyscanner.backpack.compose.cardlist.BpkCardList

--- a/docs/compose/SectionHeader/README.md
+++ b/docs/compose/SectionHeader/README.md
@@ -24,6 +24,8 @@ Backpack Compose is available through [Maven Central](https://search.maven.org/a
 
 ## Usage
 
+* `AccessibilityHeaderTagEnabled`: Used to disable `Heading()` accessibility tag - Optional, true by default.
+
 ### Basic section header with a title.
 If you don't specify a `style` parameter it will use the `.default` type
 

--- a/docs/compose/Snippet/README.md
+++ b/docs/compose/Snippet/README.md
@@ -28,6 +28,8 @@ Backpack Compose is available through [Maven Central](https://search.maven.org/a
 
 ## Usage
 
+* `AccessibilityHeaderTagEnabled`: Used to disable `Heading()` accessibility tag - Optional, true by default.
+
 ### Snippet with image only
 All text fields are optional, which means by default `BPKSnippet` only has an image.
 If you don't specify an `imageOrientation` parameter it will use the `Landscape` type


### PR DESCRIPTION
https://skyscanner.atlassian.net/browse/MUON-474
This PR adds an optional parameter to enable/disable `Heading accessibility tag` into BpkSnippet, BpkSectionHeader, and BpkRailCardList.


| | Recording|
| - | - |
| No header activated| <video src="https://github.com/user-attachments/assets/93d3388e-c135-49d7-99eb-40e03842b35e" width="400">|
| Section Header enabled | <video src="https://github.com/user-attachments/assets/3986a554-166f-4e1d-bcae-b7843a2b38f4" width="400">|
| Section Header and Snippet enabled. This last one is set though CardList content parameter | <video src="https://github.com/user-attachments/assets/dca0704c-81e9-42be-92b2-963d2d263858" width="400">|





<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [x] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
