### PR TITLE
DON-800 Calendar day cell animations

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/internal/BpkCalendarDayCell.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/internal/BpkCalendarDayCell.kt
@@ -18,6 +18,7 @@
 
 package net.skyscanner.backpack.compose.calendar.internal
 
+import androidx.compose.animation.Crossfade
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -65,92 +66,95 @@ internal fun BpkCalendarDayCell(
     onClick: (CalendarCell.Day) -> Unit,
 ) {
 
-    val selection = model.selection
-    val inactive = model.inactive
+    Crossfade(model, label = "Day cell selection transition") { mModel ->
+        val selection = mModel.selection
+        val inactive = mModel.inactive
 
-    val status = model.info.status
-    val style = model.info.style
-    val label = model.info.label
+        val status = mModel.info.status
+        val style = mModel.info.style
+        val label = mModel.info.label
 
-    Column(
-        verticalArrangement = Arrangement.Top,
-        horizontalAlignment = Alignment.CenterHorizontally,
-        modifier = modifier
-            .padding(bottom = BpkSpacing.Lg)
-            .clickable(
-                indication = null,
-                enabled = !inactive,
-                onClick = { onClick(model) },
-                onClickLabel = model.onClickLabel,
-                interactionSource = remember { MutableInteractionSource() },
-            )
-            .semantics {
-                if (model.stateDescription != null) {
-                    stateDescription = model.stateDescription!!
-                } else {
-                    selected = selection != null && selection != Selection.Middle
-                }
-            },
-    ) {
-        Box(
-            contentAlignment = Alignment.Center,
-            modifier = Modifier
-                .fillMaxWidth()
-                .cellSelectionBackground(
-                    surfaceSubtle = BpkTheme.colors.surfaceSubtle,
-                    selection = selection,
-                ),
+        Column(
+            verticalArrangement = Arrangement.Top,
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = modifier
+                .padding(bottom = BpkSpacing.Lg)
+                .clickable(
+                    indication = null,
+                    enabled = !inactive,
+                    onClick = { onClick(mModel) },
+                    onClickLabel = mModel.onClickLabel,
+                    interactionSource = remember { MutableInteractionSource() },
+                )
+                .semantics {
+                    if (mModel.stateDescription != null) {
+                        stateDescription = mModel.stateDescription!!
+                    } else {
+                        selected = selection != null && selection != Selection.Middle
+                    }
+                },
         ) {
-
-            Spacer(
-                Modifier
-                    .size(BpkCalendarSizes.SelectionHeight)
-                    .cellDayBackground(
-                        coreAccent = BpkTheme.colors.coreAccent,
+            Box(
+                contentAlignment = Alignment.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .cellSelectionBackground(
                         surfaceSubtle = BpkTheme.colors.surfaceSubtle,
                         selection = selection,
                     ),
-            )
+            ) {
 
-            BpkText(
-                text = model.text.toString(),
-                modifier = Modifier.semantics {
-                    contentDescription = model.contentDescription
-                },
-                overflow = TextOverflow.Ellipsis,
-                maxLines = 1,
-                style = BpkTheme.typography.label1,
-                color = dateColor(selection, status, inactive, style),
-            )
-        }
+                Spacer(
+                    Modifier
+                        .size(BpkCalendarSizes.SelectionHeight)
+                        .cellDayBackground(
+                            coreAccent = BpkTheme.colors.coreAccent,
+                            surfaceSubtle = BpkTheme.colors.surfaceSubtle,
+                            selection = selection,
+                        ),
+                )
 
-        if (!inactive) {
-            when (val cellLabel = model.info.label) {
-                is CellLabel.Text -> {
-                    if (cellLabel.text.isNotBlank()) {
-                        BpkText(
-                            text = cellLabel.text,
-                            modifier = Modifier
-                                .padding(horizontal = BpkSpacing.Sm),
-                            overflow = TextOverflow.Ellipsis,
-                            textAlign = TextAlign.Center,
-                            maxLines = 2,
-                            style = BpkTheme.typography.caption,
-                            color = labelColor(status, style),
-                        )
-                    }
-                }
-                is CellLabel.Icon -> {
-                    cellLabel.resId.let { resId ->
-                        BpkIcon.findBySmall(resId)?.let { bpkIcon ->
-                            val iconTint = cellLabel.tint
-                                ?.let { colorRes -> ContextCompat.getColor(LocalContext.current, colorRes) }
-                                ?.let { Color(it) } ?: LocalContentColor.current
-                            BpkIcon(
-                                icon = bpkIcon,
-                                tint = iconTint,
-                                contentDescription = null,
+                BpkText(
+                    text = mModel.text.toString(),
+                    modifier = Modifier.semantics {
+                        contentDescription = mModel.contentDescription
+                    },
+                    overflow = TextOverflow.Ellipsis,
+                    maxLines = 1,
+                    style = BpkTheme.typography.label1,
+                    color = dateColor(selection, status, inactive, style),
+                )
+            }
+
+            if (!inactive) {
+                when (val cellLabel = mModel.info.label) {
+                    is CellLabel.Text -> {
+                        if (cellLabel.text.isNotBlank()) {
+                            BpkText(
+                                text = cellLabel.text,
+                                modifier = Modifier
+                                    .padding(horizontal = BpkSpacing.Sm),
+                                overflow = TextOverflow.Ellipsis,
+                                textAlign = TextAlign.Center,
+                                maxLines = 2,
+                                style = BpkTheme.typography.caption,
+                                color = labelColor(status, style),
                             )
+                        }
+                    }
+
+                    is CellLabel.Icon -> {
+                        cellLabel.resId.let { resId ->
+                            BpkIcon.findBySmall(resId)?.let { bpkIcon ->
+                                val iconTint = cellLabel.tint
+                                    ?.let { colorRes -> ContextCompat.getColor(LocalContext.current, colorRes) }
+                                    ?.let { Color(it) } ?: LocalContentColor.current
+                                BpkIcon(
+                                    icon = bpkIcon,
+                                    tint = iconTint,
+                                    contentDescription = null,
+                                )
+                            }
                         }
                     }
                 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/internal/BpkCalendarGrid.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/internal/BpkCalendarGrid.kt
@@ -72,7 +72,7 @@ internal fun BpkCalendarGrid(
                 when (val item = state.cells[index]) {
                     is CalendarCell.Day -> BpkCalendarDayCell(item) { onClick(CalendarInteraction.DateClicked(it)) }
                     is CalendarCell.Header -> BpkCalendarHeaderCell(item) { onClick(CalendarInteraction.SelectMonthClicked(it)) }
-                    is CalendarCell.Space -> BpkCalendarSpaceCell(item)
+                    is CalendarCell.Space -> BpkCalendarSpaceCell()
                 }
             },
         )

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/internal/BpkCalendarSpaceCell.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/internal/BpkCalendarSpaceCell.kt
@@ -18,25 +18,16 @@
 
 package net.skyscanner.backpack.compose.calendar.internal
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import net.skyscanner.backpack.calendar2.data.CalendarCell
-import net.skyscanner.backpack.compose.theme.BpkTheme
-import net.skyscanner.backpack.compose.utils.applyIf
 
 @Composable
 internal fun BpkCalendarSpaceCell(
-    model: CalendarCell.Space,
     modifier: Modifier = Modifier,
 ) {
     Spacer(
-        modifier = modifier
-            .height(BpkCalendarSizes.SelectionHeight)
-            .applyIf(model.selected) {
-                background(BpkTheme.colors.surfaceSubtle)
-            },
+        modifier = modifier.height(BpkCalendarSizes.SelectionHeight),
     )
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->
DON-800
Add crossfade to calendar day cell.
Based on [discussions](https://skyscanner.slack.com/archives/C07LH0LRCAK/p1727262745607979?thread_ts=1727167165.640119&cid=C07LH0LRCAK) with designer and product, change `BpkCalendarSpaceCell` to not show selection.

## Before

https://github.com/user-attachments/assets/6b7ede40-0a90-4605-80a2-8c1177844db6


## After

https://github.com/user-attachments/assets/9a5c6f10-f6ae-464a-a485-98307bff6d2a


+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
