### PR TITLE
[MUON-624] - Expose interactionSource to support custom animations

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/graphicpromotion/BpkGraphicPromo.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/graphicpromotion/BpkGraphicPromo.kt
@@ -18,8 +18,10 @@
 
 package net.skyscanner.backpack.compose.graphicpromotion
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import net.skyscanner.backpack.compose.graphicpromotion.internal.BpkGraphicPromoImpl
 import net.skyscanner.backpack.compose.overlay.BpkOverlayType
@@ -45,6 +47,7 @@ fun BpkGraphicPromo(
     verticalAlignment: BpkGraphicPromoVerticalAlignment = BpkGraphicPromoVerticalAlignment.Top,
     sponsor: BpkGraphicsPromoSponsor? = null,
     sponsorLogo: (@Composable () -> Unit)? = null,
+    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     tapAction: () -> Unit = {},
 ) {
     BpkGraphicPromoImpl(
@@ -58,6 +61,7 @@ fun BpkGraphicPromo(
         sponsor = sponsor,
         image = image,
         sponsorLogo = sponsorLogo,
+        interactionSource = interactionSource,
         tapAction = tapAction,
     )
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/graphicpromotion/internal/BpkGraphicPromoImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/graphicpromotion/internal/BpkGraphicPromoImpl.kt
@@ -78,6 +78,7 @@ import net.skyscanner.backpack.compose.utils.isTablet
 internal fun BpkGraphicPromoImpl(
     headline: String,
     image: @Composable BoxScope.() -> Unit,
+    interactionSource: MutableInteractionSource,
     modifier: Modifier = Modifier,
     kicker: String? = null,
     subHeadline: String? = null,
@@ -86,7 +87,6 @@ internal fun BpkGraphicPromoImpl(
     verticalAlignment: BpkGraphicPromoVerticalAlignment = BpkGraphicPromoVerticalAlignment.Top,
     sponsor: BpkGraphicsPromoSponsor? = null,
     sponsorLogo: (@Composable () -> Unit)? = null,
-    interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     tapAction: () -> Unit = {},
 ) {
     val (aspectRatio, maxHeight) = getDeviceConstrains()


### PR DESCRIPTION
https://skyscanner.atlassian.net/browse/MUON-624

Exposing `interactionSource` so we could customize ripple animation to match the old cards in the Homescreen

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
