### PR TITLE
[MUON-625] Homepagehero click animation

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/graphicpromotion/BpkGraphicPromo.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/graphicpromotion/BpkGraphicPromo.kt
@@ -18,12 +18,14 @@
 
 package net.skyscanner.backpack.compose.graphicpromotion
 
+import androidx.compose.foundation.IndicationNodeFactory
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import net.skyscanner.backpack.compose.graphicpromotion.internal.BpkGraphicPromoImpl
+import net.skyscanner.backpack.compose.graphicpromotion.internal.getInteractiveBackgroundIndicationNodeFactory
 import net.skyscanner.backpack.compose.overlay.BpkOverlayType
 
 enum class BpkGraphicPromoVariant { OnDark, OnLight, }
@@ -49,6 +51,7 @@ fun BpkGraphicPromo(
     sponsorLogo: (@Composable () -> Unit)? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     tapAction: () -> Unit = {},
+    animationIndicationNode: IndicationNodeFactory = getInteractiveBackgroundIndicationNodeFactory(),
 ) {
     BpkGraphicPromoImpl(
         headline = headline,
@@ -63,5 +66,6 @@ fun BpkGraphicPromo(
         sponsorLogo = sponsorLogo,
         interactionSource = interactionSource,
         tapAction = tapAction,
+        animationIndicationNode = animationIndicationNode,
     )
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/graphicpromotion/internal/BpkGraphicPromoImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/graphicpromotion/internal/BpkGraphicPromoImpl.kt
@@ -88,6 +88,7 @@ internal fun BpkGraphicPromoImpl(
     sponsor: BpkGraphicsPromoSponsor? = null,
     sponsorLogo: (@Composable () -> Unit)? = null,
     tapAction: () -> Unit = {},
+    animationIndicationNode: IndicationNodeFactory = InteractiveBackgroundIndicationNodeFactory,
 ) {
     val (aspectRatio, maxHeight) = getDeviceConstrains()
     val roundedCornerShape = RoundedCornerShape(BpkBorderRadius.Md)
@@ -98,6 +99,7 @@ internal fun BpkGraphicPromoImpl(
             .aspectRatio(ratio = aspectRatio)
             .heightIn(max = maxHeight.dp)
             .clip(roundedCornerShape)
+            .indication(interactionSource, animationIndicationNode)
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,
@@ -111,8 +113,7 @@ internal fun BpkGraphicPromoImpl(
         if (overlayType != null) {
             BpkOverlay(
                 modifier = Modifier
-                    .matchParentSize()
-                    .indication(interactionSource, InteractiveBackgroundIndicationNodeFactory),
+                    .matchParentSize(),
                 overlayType = overlayType,
                 foregroundContent = {
                     ForegroundContent(
@@ -130,8 +131,7 @@ internal fun BpkGraphicPromoImpl(
         } else {
             Box(
                 modifier = Modifier
-                    .matchParentSize()
-                    .indication(interactionSource, InteractiveBackgroundIndicationNodeFactory),
+                    .matchParentSize(),
                 content = image,
             )
             ForegroundContent(
@@ -334,6 +334,10 @@ private object InteractiveBackgroundIndicationNodeFactory : IndicationNodeFactor
     override fun hashCode(): Int = -1
 
     override fun equals(other: Any?) = other === this
+}
+
+fun getInteractiveBackgroundIndicationNodeFactory(): IndicationNodeFactory {
+    return InteractiveBackgroundIndicationNodeFactory
 }
 
 private class InteractiveBackgroundIndicationNode(private val interactionSource: InteractionSource) : Modifier.Node(),

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/graphicpromotion/internal/BpkGraphicPromoImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/graphicpromotion/internal/BpkGraphicPromoImpl.kt
@@ -98,8 +98,8 @@ internal fun BpkGraphicPromoImpl(
         modifier = modifier
             .aspectRatio(ratio = aspectRatio)
             .heightIn(max = maxHeight.dp)
-            .clip(roundedCornerShape)
             .indication(interactionSource, animationIndicationNode)
+            .clip(roundedCornerShape)
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,


### PR DESCRIPTION
Just changing the order of two lines to keep the rounded corners after animation

| Before | Now |
|--------|-----|
| ![image](https://github.com/user-attachments/assets/1bafe41d-3d5a-496d-af4b-0330ab94f047) | ![image](https://github.com/user-attachments/assets/4a4e09d9-bcc1-4ed5-a077-bfef277ba62e) |



+ [X] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [X] Component `README.md`
+ [X] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
