### PR TITLE
[DON-999] add scroll to selected index to backpack select

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/select/internal/BpkSelectImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/select/internal/BpkSelectImpl.kt
@@ -21,12 +21,14 @@ package net.skyscanner.backpack.compose.select.internal
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.MenuAnchorType
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -48,6 +50,8 @@ import net.skyscanner.backpack.compose.tokens.BpkSpacing
 import net.skyscanner.backpack.compose.utils.applyIf
 import net.skyscanner.backpack.compose.utils.clickableWithRipple
 
+private const val PIXEL_COUNT_100 = 100
+
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 @Suppress("ModifierNotUsedAtRoot")
@@ -63,6 +67,13 @@ internal fun BpkSelectImpl(
     var expanded by remember { mutableStateOf(false) }
     val selectText = selectedIndex?.let { options.getOrNull(selectedIndex) } ?: ""
     val focusManager = LocalFocusManager.current
+    val scrollState = rememberScrollState()
+
+    LaunchedEffect(expanded, selectedIndex) {
+        if (expanded && selectedIndex != null) {
+            scrollState.scrollTo(selectedIndex * PIXEL_COUNT_100)
+        }
+    }
     ExposedDropdownMenuBox(
         expanded = expanded,
         onExpandedChange = { expanded = !expanded },
@@ -79,6 +90,7 @@ internal fun BpkSelectImpl(
         )
         ExposedDropdownMenu(
             expanded = if (status != BpkFieldStatus.Disabled) expanded else false,
+            scrollState = scrollState,
             modifier = Modifier
                 .background(BpkTheme.colors.surfaceDefault)
                 .applyIf(dropDownWidth == BpkDropDownWidth.MaxWidth) {


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Currently, the bpk selects scroll state only remember where the last scroll position. This cause an issue that the selector would not focus on the selected index before the user interacts with it. Here we want to make sure it always scroll to selected index when the drop-down menu open

|Current Production| Fix in this PR |
|-|-|
![video1](https://github.com/user-attachments/assets/530c08fa-3f4c-45c2-b76a-d58e0bccc117)|![video1](https://github.com/user-attachments/assets/9ff7b6e6-1b56-4c4c-b4d7-91f81e04145e)


+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
