### PR TITLE
DON-1098 Add optional click handler for calendar dates

### DIFF
--- a/backpack-common/src/main/java/net/skyscanner/backpack/calendar2/data/CalendarCell.kt
+++ b/backpack-common/src/main/java/net/skyscanner/backpack/calendar2/data/CalendarCell.kt
@@ -83,15 +83,12 @@ sealed class CalendarCell {
 }
 
 @Stable
-@InternalBackpackApi
 sealed interface CalendarInteraction {
 
     @Immutable
-    @InternalBackpackApi
     data class DateClicked(val day: CalendarCell.Day) : CalendarInteraction
 
     @Immutable
-    @InternalBackpackApi
     data class SelectMonthClicked(val header: CalendarCell.Header) : CalendarInteraction
 }
 

--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendarTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendarTest.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onFirst
@@ -179,6 +180,40 @@ class BpkCalendarTest {
             .assertOnClickLabelEquals("startSelectionHint")
             .performClick()
             .assertStateDescriptionEquals("startSelectionState")
+
+        val state = controller.state.first()
+
+        assertEquals(expected, state.selection)
+    }
+
+    @Test
+    fun withCustomSelectionHandling() = runTest {
+        val expected = CalendarSelection.Single(
+            date = LocalDate.of(2019, 1, 31),
+        )
+
+        val controller = createController(DefaultSingle)
+
+        composeTestRule.setContent {
+            BpkTheme {
+                BpkCalendar(controller, customDateHandling = {
+                    controller.setSelection(CalendarSelection.Single(LocalDate.of(2019, 1, 31)))
+                })
+            }
+        }
+
+        composeTestRule.onAllNodesWithText("17")
+            .onFirst()
+            .performClick()
+
+        composeTestRule.onAllNodesWithText("31")
+            .onFirst()
+            .assertOnClickLabelEquals("startSelectionHint")
+            .assertStateDescriptionEquals("startSelectionState")
+
+        composeTestRule.onAllNodesWithText("17")
+            .onFirst()
+            .assertIsNotSelected()
 
         val state = controller.state.first()
 

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendar.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendar.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import net.skyscanner.backpack.calendar2.data.CalendarInteraction
 import net.skyscanner.backpack.compose.calendar.internal.BpkCalendarBadge
 import net.skyscanner.backpack.compose.calendar.internal.BpkCalendarGrid
 import net.skyscanner.backpack.compose.calendar.internal.BpkCalendarHeader
@@ -37,6 +38,7 @@ import net.skyscanner.backpack.compose.tokens.BpkSpacing
 fun BpkCalendar(
     controller: BpkCalendarController,
     modifier: Modifier = Modifier,
+    customDateHandling: ((CalendarInteraction) -> Unit)? = null,
 ) {
 
     val state by controller.state.collectAsState()
@@ -53,7 +55,7 @@ fun BpkCalendar(
             BpkCalendarGrid(
                 state = state,
                 lazyGridState = controller.lazyGridState,
-                onClick = controller.stateMachine::onClick,
+                onClick = customDateHandling ?: controller.stateMachine::onClick,
                 modifier = Modifier.fillMaxSize(),
             )
 

--- a/docs/compose/Calendar2/README.md
+++ b/docs/compose/Calendar2/README.md
@@ -84,6 +84,16 @@ controller
   .launchIn(myCoroutineScope)
 ```
 
+### (Optional) Manual Selection handling
+
+To achieve behaviour that differs from the way the state machine handles things you can provide the optional
+`customDateHandling` property.
+This property is a lambda that will be called when a date is selected by the user.
+You can use it to handle the selection manually.
+You can then set the selection in the controller using the `setSelection` method.
+
+```Kotlin
+
 ### Advanced dates customisation
 
 You can attach some of the information to each date displayed in calendar.


### PR DESCRIPTION
To achieve the functionality we require for Date Selector Milestone 1c we need a way to set the selection that falls outside of the way it is implemented in `BpkCalendar`.

Therefore we have agreed on a new property in the [API](https://www.figma.com/design/gcH57x4gpfjFJ2vhyfayvt/Global-Components?node-id=10760-23886&t=hgEabqh32ZlARRUH-4) that will allow the consumer to receive the selected date and handle it however they want. I removed the `@ InternalBackpackApi` annotation from the `CalendarInteraction ` class so the consumer can access it.

If the click handler is not present then the calendar works as presently.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
