### PR TITLE
[NO JIRA]: Fix commit automations for CI

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -28,13 +28,15 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
-
       - uses: actions/create-github-app-token@v1
         id: app-token
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+      
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Fetch Dependabot metadata
         id: dependabot-metadata
@@ -85,12 +87,9 @@ jobs:
 
       - name: Token commit
         if: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' && steps.tokenUpdate.outputs.CHANGED_FILES != '' && contains(steps.dependabot-metadata.outputs.dependency-names, 'bpk-') }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git remote set-url origin https://x-access-token:$GITHUB_TOKEN@github.com/${{ github.repository }}
+          git config --local user.email "197108191+skyscanner-backpack-bot[bot]@users.noreply.github.com"
+          git config --local user.name "skyscanner-backpack-bot[bot]"
           git fetch origin $GITHUB_HEAD_REF
           git checkout $GITHUB_HEAD_REF
           git add .
@@ -178,9 +177,16 @@ jobs:
       contents: write
     timeout-minutes: 20
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.GH_APP_ID }}
+          private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Set up JDK
         uses: actions/setup-java@v4
@@ -204,12 +210,9 @@ jobs:
 
       - name: Commit changes
         if: ${{ github.event_name == 'pull_request' && steps.screenshotTests.outputs.CHANGED_FILES != '' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git remote set-url origin https://x-access-token:$GITHUB_TOKEN@github.com/${{ github.repository }}
+          git config --local user.email "197108191+skyscanner-backpack-bot[bot]@users.noreply.github.com"
+          git config --local user.name "skyscanner-backpack-bot[bot]"
           git fetch origin $GITHUB_HEAD_REF
           git checkout $GITHUB_HEAD_REF
           git add app/screenshots/*


### PR DESCRIPTION
During the recent channge to the workflows #2195 to use a github app over default github token, it was missed that the screenshot update and commits were missed being tested as these hadn;t changed during this process.

We recently found via backpack-ios that with the new setup for our org this causes commiting to the branch fails when updating screenshots.

To solve this we replicate the same fix from [backpack-ios](https://github.com/Skyscanner/backpack-ios/pull/2167/commits/7eb653480aceee221fae3dede6c160e22259f5e7)

This fix:

- Generates our token
- Supplies it to our repo setup
- Updates the git config to be the bot author

