### PR TITLE
ralp/no-jira Add workaround hanging Android Tests

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -167,7 +167,7 @@ jobs:
             adb uninstall net.skyscanner.backpack.compose.test || :
             adb uninstall net.skyscanner.backpack.common.test || :
 
-            ./gradlew :Backpack:connected${{ env.config }}AndroidTest :backpack-compose:connected${{ env.config }}AndroidTest :backpack-common:connected${{ env.config }}AndroidTest
+            ./gradlew :Backpack:connected${{ env.config }}AndroidTest :backpack-compose:connected${{ env.config }}AndroidTest :backpack-common:connected${{ env.config }}AndroidTest && killall -INT crashpad_handler || true
 
   Screenshots:
     name: Screenshots tests


### PR DESCRIPTION
This PR is a workaround for the Android Tests stage, which is failing because the emulator is not terminating and causing a timeout.

Here, we got the same issue reported:
https://github.com/ReactiveCircus/android-emulator-runner/issues/385

We also used this workaround:
https://github.com/devinbileck/bisqremote_Android/commit/da1b4167d282a5ff2451bf1993da8e3ee12f4d3a

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
