### PR TITLE
Update release.yml to align with other Backpack repos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Deploy Dokka docs
         uses: peaceiris/actions-gh-pages@v4
         with:
-          deploy_key: ${{ secrets.DOKKA_DEPLOY_KEY }}
+          personal_token: ${{ secrets.DEPLOY_KEY }}
           publish_dir: dokka/
           keep_files: true
           external_repository: backpack/android


### PR DESCRIPTION
This PR updates the documentation deploy step to utilise the `personal_token` field instead of `deploy_key` as SSH key from the automated user is not allowed under new security setup for github.com/skyscanner.

Using it this way and with this name aligns across all the Backpack repos to ease maintenance and readability

See:

[Backpack iOS](https://github.com/Skyscanner/backpack-ios/blob/main/.github/workflows/release.yml#L137-L144)
[Backpack Web](https://github.com/Skyscanner/backpack/blob/main/.github/workflows/main.yml#L146-L154)