### PR TITLE
DON-1155 Allow BpkSearchInputSummary to use clickable modifier

### DIFF
--- a/app/src/main/java/net/skyscanner/backpack/demo/compose/BpkSearchInputSummaryStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/compose/BpkSearchInputSummaryStory.kt
@@ -18,15 +18,19 @@
 
 package net.skyscanner.backpack.demo.compose
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import net.skyscanner.backpack.compose.icon.BpkIcon
@@ -50,6 +54,7 @@ import net.skyscanner.backpack.meta.StoryKind
 fun SearchInputSummaryExamples(modifier: Modifier = Modifier) {
     Column(
         modifier = modifier
+            .systemBarsPadding()
             .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.spacedBy(BpkSpacing.Base),
     ) {
@@ -178,35 +183,59 @@ internal fun ReadOnlyExample() {
             prefix = Prefix.None,
             type = BpkSearchInputSummaryType.ReadOnly(isFocused = true),
         )
+
+        var firstFocused by remember { mutableStateOf(false) }
+
+        SearchInputSummaryStory(
+            name = "Read only, focus on click",
+            inputText = stringResource(id = R.string.city_rome),
+            inputHint = stringResource(id = R.string.text_field_hint),
+            prefix = Prefix.None,
+            type = BpkSearchInputSummaryType.ReadOnly(isFocused = firstFocused),
+            searchInputSummaryModifier = Modifier.clickable { firstFocused = !firstFocused },
+        )
+
+        SearchInputSummaryStory(
+            name = "Read only, focus on click",
+            inputText = stringResource(id = R.string.city_rome),
+            inputHint = stringResource(id = R.string.text_field_hint),
+            prefix = Prefix.None,
+            type = BpkSearchInputSummaryType.ReadOnly(isFocused = !firstFocused),
+            searchInputSummaryModifier = Modifier.clickable { firstFocused = !firstFocused },
+        )
     }
 }
 
 @Composable
 internal fun SearchInputSummaryStory(
     name: String,
+    modifier: Modifier = Modifier,
+    searchInputSummaryModifier: Modifier = Modifier,
     inputText: String = stringResource(id = R.string.city_rome),
     inputHint: String = stringResource(id = R.string.text_field_hint),
     prefix: Prefix = Prefix.Icon(BpkIcon.Search),
     type: BpkSearchInputSummaryType = BpkSearchInputSummaryType.TextInput,
 ) {
-    Column {
+    Column(
+        modifier = modifier,
+    ) {
         BpkText(
             text = name,
             style = BpkTheme.typography.heading4,
             modifier = Modifier.padding(vertical = BpkSpacing.Base),
         )
-        val state = remember { mutableStateOf(inputText) }
+        var state by remember { mutableStateOf(inputText) }
         BpkSearchInputSummary(
-            inputText = inputText,
+            inputText = state,
             inputHint = inputHint,
             prefix = prefix,
             onInputChanged = {
-                state.value = it
+                state = it
             },
             clearAction = BpkClearAction(stringResource(id = R.string.text_field_clear_action_description)) {
-                state.value = ""
+                state = ""
             },
-            modifier = Modifier.fillMaxWidth(),
+            modifier = searchInputSummaryModifier.fillMaxWidth(),
             type = type,
         )
     }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/textfield/internal/BpkTextFieldImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/textfield/internal/BpkTextFieldImpl.kt
@@ -144,7 +144,7 @@ internal fun BpkTextFieldImpl(
     BasicTextField(
         value = value,
         onValueChange = onValueChange,
-        enabled = status != BpkFieldStatus.Disabled,
+        enabled = status != BpkFieldStatus.Disabled && !(type == BpkTextFieldType.Search && readOnly),
         readOnly = readOnly,
         textStyle = BpkTheme.typography.bodyDefault.copy(
             color = animateColorAsState(


### PR DESCRIPTION
In order for a Text Field to be clickable, It must not be enabled.
However, in a certain case in the app we need a TextField that is not editable and also clickable.
To do this, I added extra logic to the `BpkTextFieldImpl` to handle this case.

I added an example to the `SearchInputSummaryStory` screen and also fixed the input not being used and also the bottom being cut off by the navigation bar.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
