### PR TITLE
 no_jira fix Calendar crash after lock device

### DIFF
--- a/backpack-common/src/main/java/net/skyscanner/backpack/calendar2/CalendarParams.kt
+++ b/backpack-common/src/main/java/net/skyscanner/backpack/calendar2/CalendarParams.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import net.skyscanner.backpack.calendar2.CalendarParams.MonthSelectionMode
 import net.skyscanner.backpack.util.InternalBackpackApi
+import java.io.Serializable
 import java.text.SimpleDateFormat
 import java.time.LocalDate
 import java.time.YearMonth
@@ -73,7 +74,7 @@ data class CalendarParams(
      * Describes the selection behaviour
      */
     @Stable
-    sealed interface SelectionMode {
+    sealed interface SelectionMode : Serializable {
         /**
          * No date can be selected
          */

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendarController.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendarController.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.setValue
 import net.skyscanner.backpack.calendar2.CalendarParams
 import net.skyscanner.backpack.calendar2.CalendarSelection
 import net.skyscanner.backpack.calendar2.CalendarState
+import net.skyscanner.backpack.calendar2.CellInfo
 import net.skyscanner.backpack.calendar2.data.CalendarInteraction
 import net.skyscanner.backpack.calendar2.data.dispatchClick
 import net.skyscanner.backpack.calendar2.data.dispatchSetSelection
@@ -115,11 +116,19 @@ fun rememberCalendarController(
     rememberSaveable(
         inputs = arrayOf(initialParams),
         saver = Saver<BpkCalendarController, Serializable>(
-            save = { CalendarSavableData(it.state.selection, it.state.params) },
+            save = {
+                with(it.state.params) {
+                    CalendarSavableData(
+                        it.state.selection,
+                        cellsInfo,
+                        selectionMode,
+                    )
+                }
+            },
             restore = { savedData ->
-                val (savedSelection, savedParams) = savedData as CalendarSavableData
+                val (savedSelection, cellsInfo, selectionMode) = savedData as CalendarSavableData
                 BpkCalendarController(
-                    savedParams,
+                    initialParams.copy(cellsInfo = cellsInfo, selectionMode = selectionMode),
                     savedSelection,
                     lazyGridState,
                     onSelectionChanged,
@@ -133,5 +142,6 @@ fun rememberCalendarController(
 
 internal data class CalendarSavableData(
     val selection: CalendarSelection,
-    val params: CalendarParams,
+    val cellsInfo: Map<LocalDate, CellInfo>,
+    val selectionMode: CalendarParams.SelectionMode,
 ) : Serializable


### PR DESCRIPTION
# Context
Currently the app craches when device is locked due to `CalendarParams` is not `Serializable` 

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
