### PR TITLE
Avoid default dependabot semver labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     interval: daily
     time: "10:00"
   open-pull-requests-limit: 10
+  labels: # Avoid default semver labels (https://github.com/dependabot/dependabot-core/issues/3465)
+    - dependencies
+    - java
   groups:
     kotlin-ksp:
       patterns:


### PR DESCRIPTION
Right now dependabot is adding the default semver labels, which leads to our Dependabot pr's to be failing because we do use semver labels for identifying libary changes.

See https://github.com/dependabot/dependabot-core/issues/3465