### PR TITLE
Expose onClick on BkpCardWrapper

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cardwrapper/BpkCardWrapper.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cardwrapper/BpkCardWrapper.kt
@@ -68,3 +68,39 @@ fun BpkCardWrapper(
         }
     }
 }
+
+@Composable
+fun BpkCardWrapper(
+    onClick: () -> Unit,
+    backgroundColor: Color,
+    headerContent: @Composable () -> Unit,
+    cardContent: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    cardPadding: BpkCardPadding = BpkCardPadding.Small,
+    corner: BpkCardCorner = BpkCardCorner.Small,
+    elevation: BpkCardElevation = BpkCardElevation.Default,
+) {
+    Card(
+        onClick = onClick,
+        modifier = modifier.fillMaxWidth(),
+        shape = cardShape(corner),
+        colors = CardDefaults.cardColors(
+            containerColor = backgroundColor,
+            disabledContainerColor = backgroundColor,
+        ),
+        elevation = cardElevation(elevation),
+        border = BorderStroke(width = BpkBorderSize.Lg, color = backgroundColor),
+    ) {
+        Column {
+            headerContent.invoke()
+            BpkCard(
+                modifier = Modifier.padding(BpkBorderSize.Lg),
+                corner = corner,
+                padding = cardPadding,
+                elevation = BpkCardElevation.None,
+            ) {
+                cardContent.invoke()
+            }
+        }
+    }
+}


### PR DESCRIPTION
At the moment **BpkCardWrapper** is lacking the ability to set click listener, since internal Card is consuming all clicks. In order for card clicks to work, we need to forward onClick callback the same way as it's done in BpkCard.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
