### PR TITLE
[DON-1368] move CalendarDayCellTestTag

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendarDayCellTestTag.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendarDayCellTestTag.kt
@@ -2,7 +2,7 @@ package net.skyscanner.backpack.compose.calendar
 /*
  * Backpack for Android - Skyscanner's Design System
  *
- * Copyright 2018 Skyscanner Ltd
+ * Copyright 2025 Skyscanner Ltd
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendarDayCellTestTag.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendarDayCellTestTag.kt
@@ -1,6 +1,6 @@
 package net.skyscanner.backpack.compose.calendar
 
-enum class CalendarDayCellTestTag {
+enum class BpkCalendarDayCellTestTag {
     INACTIVE,
     INACTIVE_HIGHLIGHTED,
     ACTIVE,

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendarDayCellTestTag.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendarDayCellTestTag.kt
@@ -1,4 +1,21 @@
 package net.skyscanner.backpack.compose.calendar
+/*
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 enum class BpkCalendarDayCellTestTag {
     INACTIVE,

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/CalendarDayCellTestTag.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/CalendarDayCellTestTag.kt
@@ -1,0 +1,8 @@
+package net.skyscanner.backpack.compose.calendar
+
+enum class CalendarDayCellTestTag {
+    INACTIVE,
+    INACTIVE_HIGHLIGHTED,
+    ACTIVE,
+    ACTIVE_HIGHLIGHTED,
+}

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/internal/BpkCalendarDayCell.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/internal/BpkCalendarDayCell.kt
@@ -54,6 +54,7 @@ import net.skyscanner.backpack.calendar2.CellStatusStyle
 import net.skyscanner.backpack.calendar2.data.CalendarCell
 import net.skyscanner.backpack.calendar2.data.CalendarCell.Selection
 import net.skyscanner.backpack.compose.LocalContentColor
+import net.skyscanner.backpack.compose.calendar.CalendarDayCellTestTag
 import net.skyscanner.backpack.compose.icon.BpkIcon
 import net.skyscanner.backpack.compose.icon.findBySmall
 import net.skyscanner.backpack.compose.text.BpkText
@@ -280,11 +281,4 @@ private fun checkDayCellStatus(inactive: Boolean, isHighlighted: Boolean): Strin
         !inactive && isHighlighted -> CalendarDayCellTestTag.ACTIVE_HIGHLIGHTED
         else -> CalendarDayCellTestTag.ACTIVE
     }.toString()
-}
-
-enum class CalendarDayCellTestTag {
-    INACTIVE,
-    INACTIVE_HIGHLIGHTED,
-    ACTIVE,
-    ACTIVE_HIGHLIGHTED,
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/internal/BpkCalendarDayCell.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/internal/BpkCalendarDayCell.kt
@@ -54,7 +54,7 @@ import net.skyscanner.backpack.calendar2.CellStatusStyle
 import net.skyscanner.backpack.calendar2.data.CalendarCell
 import net.skyscanner.backpack.calendar2.data.CalendarCell.Selection
 import net.skyscanner.backpack.compose.LocalContentColor
-import net.skyscanner.backpack.compose.calendar.CalendarDayCellTestTag
+import net.skyscanner.backpack.compose.calendar.BpkCalendarDayCellTestTag
 import net.skyscanner.backpack.compose.icon.BpkIcon
 import net.skyscanner.backpack.compose.icon.findBySmall
 import net.skyscanner.backpack.compose.text.BpkText
@@ -276,9 +276,9 @@ private val EndSemiRect = RelativeRectangleShape(0.5f..1f)
 
 private fun checkDayCellStatus(inactive: Boolean, isHighlighted: Boolean): String {
     return when {
-        inactive && !isHighlighted -> CalendarDayCellTestTag.INACTIVE
-        inactive && isHighlighted -> CalendarDayCellTestTag.INACTIVE_HIGHLIGHTED
-        !inactive && isHighlighted -> CalendarDayCellTestTag.ACTIVE_HIGHLIGHTED
-        else -> CalendarDayCellTestTag.ACTIVE
+        inactive && !isHighlighted -> BpkCalendarDayCellTestTag.INACTIVE
+        inactive && isHighlighted -> BpkCalendarDayCellTestTag.INACTIVE_HIGHLIGHTED
+        !inactive && isHighlighted -> BpkCalendarDayCellTestTag.ACTIVE_HIGHLIGHTED
+        else -> BpkCalendarDayCellTestTag.ACTIVE
     }.toString()
 }


### PR DESCRIPTION
This pull request refactors the `CalendarDayCellTestTag` enum by moving it from an internal scope to a dedicated file and updates its usage accordingly. This change improves code organization and reusability.

### Code Organization:

* Created a new file, `CalendarDayCellTestTag.kt`, and moved the `CalendarDayCellTestTag` enum to this file to make it more modular and accessible.
* Removed the inline definition of `CalendarDayCellTestTag` from `BpkCalendarDayCell.kt` and replaced it with an import statement referencing the new file. [[1]](diffhunk://#diff-087353321220a26429372597e00c53bc6d943457c41afcceba1e3404c1eb0735R57) [[2]](diffhunk://#diff-087353321220a26429372597e00c53bc6d943457c41afcceba1e3404c1eb0735L284-L290)
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
