### PR TITLE
DON-1469 Tweak animations

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/internal/BpkCalendarDayCell.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/internal/BpkCalendarDayCell.kt
@@ -156,7 +156,7 @@ internal fun BpkCalendarDayCell(
                     contentAlignment = Alignment.Center,
                     transitionSpec = {
                         val delay = if (initialState is CellLabel.Loading) {
-                            BpkShimmerSize.Small.durationMillis * 2 // We want to show the shimmer at least twice
+                            (BpkShimmerSize.Small.durationMillis + BpkShimmerSize.Small.delayMillis) * 2 // We want to show the shimmer at least twice
                         } else {
                             0
                         }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/skeleton/BpkSkeleton.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/skeleton/BpkSkeleton.kt
@@ -109,7 +109,7 @@ enum class BpkShimmerSize(
     internal val delayMillis: Int,
 ) {
     Large(durationMillis = 1000, delayMillis = 200),
-    Small(durationMillis = 300, delayMillis = 800),
+    Small(durationMillis = 300, delayMillis = 400),
 }
 
 private fun Modifier.enhanceHeadlineHeight(skeletonHeightSize: BpkSkeletonHeightSizeType): Modifier {


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

I realised that I wanted to delay the animation _between_ each cycle but instead I delayed the animation _before_ each cycle so you wouldn't see it animate most times. To fix this I added the shimmer delay to the BpkCalendarDayCell delay so we now see it and it's a bit smoother.

| Before | After |
| ----- | ----- |
|  <video src=https://github.com/user-attachments/assets/27af3963-147d-46a1-9a44-e996999edb8c /> | <video src=https://github.com/user-attachments/assets/029d908c-3074-461d-89e3-2ae1c620c4d7 /> |


Note 2 shimmers visible in the after video.


+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
