### PR TITLE
fix bpkswitch when content is empty

### DIFF
--- a/app/src/main/java/net/skyscanner/backpack/demo/compose/SwitchStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/compose/SwitchStory.kt
@@ -62,6 +62,7 @@ fun SwitchStory(modifier: Modifier = Modifier) {
 
         AnnotatedStringSwitchExample()
         CustomContentSwitchExample()
+        EmptyContentWithSwitchExample()
     }
 }
 
@@ -131,6 +132,18 @@ internal fun LongTextWithTopSwitchAlignmentSwitchExample(modifier: Modifier = Mo
         onCheckedChange = { checked = it },
         switchAlignment = Alignment.Top,
         shouldTruncate = false,
+    )
+}
+
+@Composable
+internal fun EmptyContentWithSwitchExample(modifier: Modifier = Modifier) {
+    var checked by remember { mutableStateOf(false) }
+    BpkSwitch(
+        modifier = modifier.fillMaxWidth(),
+        content = {},
+        checked = checked,
+        onCheckedChange = { checked = it },
+        switchAlignment = Alignment.Top,
     )
 }
 

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/switch/BpkSwitch.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/switch/BpkSwitch.kt
@@ -22,7 +22,8 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalMinimumInteractiveComponentSize
@@ -70,12 +71,15 @@ fun BpkSwitch(
         switchAlignment = switchAlignment,
         interactionSource = interactionSource,
         content = {
-            BpkText(
-                modifier = Modifier.weight(1f),
-                text = text,
-                maxLines = if (shouldTruncate) 1 else Int.MAX_VALUE,
-                overflow = TextOverflow.Ellipsis,
-            )
+            takeIf { text.isNotEmpty() }?.let {
+                BpkText(
+                    modifier = Modifier.weight(1f),
+                    text = text,
+                    maxLines = if (shouldTruncate) 1 else Int.MAX_VALUE,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(modifier = Modifier.width(BpkSpacing.Base))
+            }
         },
     )
 }
@@ -99,12 +103,15 @@ fun BpkSwitch(
         switchAlignment = switchAlignment,
         interactionSource = interactionSource,
         content = {
-            BpkText(
-                modifier = Modifier.weight(1f),
-                text = text,
-                maxLines = if (shouldTruncate) 1 else Int.MAX_VALUE,
-                overflow = TextOverflow.Ellipsis,
-            )
+            takeIf { text.isNotEmpty() }?.let {
+                BpkText(
+                    modifier = Modifier.weight(1f),
+                    text = text,
+                    maxLines = if (shouldTruncate) 1 else Int.MAX_VALUE,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(modifier = Modifier.width(BpkSpacing.Base))
+            }
         },
     )
 }
@@ -132,7 +139,8 @@ fun BpkSwitch(
                     onValueChange = onCheckedChange!!,
                     enabled = enabled,
                 )
-            }.applyIf(onCheckedChange == null) {
+            }
+            .applyIf(onCheckedChange == null) {
                 semantics(mergeDescendants = true) {
                     role = Role.Switch
                     toggleableState = ToggleableState(checked)
@@ -149,7 +157,7 @@ fun BpkSwitch(
         )
 
         BpkSwitchImpl(
-            modifier = Modifier.align(switchAlignment).padding(start = BpkSpacing.Base),
+            modifier = Modifier.align(switchAlignment),
             checked = checked,
             onCheckedChange = onCheckedChange,
             enabled = enabled,

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/switch/BpkSwitch.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/switch/BpkSwitch.kt
@@ -25,7 +25,6 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.selection.toggleable
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.LocalMinimumInteractiveComponentSize
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
@@ -33,7 +32,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
@@ -44,6 +42,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.toggleableState
 import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import net.skyscanner.backpack.compose.text.BpkText
@@ -71,15 +70,7 @@ fun BpkSwitch(
         switchAlignment = switchAlignment,
         interactionSource = interactionSource,
         content = {
-            takeIf { text.isNotEmpty() }?.let {
-                BpkText(
-                    modifier = Modifier.weight(1f),
-                    text = text,
-                    maxLines = if (shouldTruncate) 1 else Int.MAX_VALUE,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Spacer(modifier = Modifier.width(BpkSpacing.Base))
-            }
+            TextWithSpacer(buildAnnotatedString { append(text) }, shouldTruncate)
         },
     )
 }
@@ -103,15 +94,7 @@ fun BpkSwitch(
         switchAlignment = switchAlignment,
         interactionSource = interactionSource,
         content = {
-            takeIf { text.isNotEmpty() }?.let {
-                BpkText(
-                    modifier = Modifier.weight(1f),
-                    text = text,
-                    maxLines = if (shouldTruncate) 1 else Int.MAX_VALUE,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Spacer(modifier = Modifier.width(BpkSpacing.Base))
-            }
+            TextWithSpacer(text, shouldTruncate)
         },
     )
 }
@@ -166,7 +149,19 @@ fun BpkSwitch(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalComposeUiApi::class)
+@Composable
+private fun RowScope.TextWithSpacer(annotatedString: AnnotatedString, shouldTruncate: Boolean) {
+    takeIf { annotatedString.isNotEmpty() }?.let {
+        BpkText(
+            modifier = Modifier.Companion.weight(1f),
+            text = annotatedString,
+            maxLines = if (shouldTruncate) 1 else Int.MAX_VALUE,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Spacer(modifier = Modifier.width(BpkSpacing.Base))
+    }
+}
+
 @Composable
 private fun BpkSwitchImpl(
     checked: Boolean,

--- a/docs/compose/Switch/README.md
+++ b/docs/compose/Switch/README.md
@@ -27,6 +27,29 @@ BpkSwitch(
   onCheckedChange = { checked -> },
 )
 ```
+Example of a Switch with annotated string:
+
+```Kotlin
+
+import androidx.compose.ui.text.buildAnnotatedString
+import net.skyscanner.backpack.compose.switch.BpkSwitch
+
+BpkSwitch(
+    text = buildAnnotatedString {
+        append(stringResource(R.string.toggle_long_text))
+        withStyle(
+            style = SpanStyle(
+                color = BpkTheme.colors.textLink,
+                fontFamily = BpkTheme.typography.bodyDefault.fontFamily,
+            ),
+        ) {
+            append(" styled text")
+        }
+  },
+    checked = true,
+    onCheckedChange = { checked -> },
+)
+```
 
 Example of a Switch with custom content:
 


### PR DESCRIPTION
This pull request introduces enhancements to the `BpkSwitch` component in the Backpack Compose library, including new functionality, improved flexibility, and updated documentation. The most notable changes are the addition of a new example, conditional rendering for text content, and adjustments to spacing and alignment.

### Enhancements to `BpkSwitch` functionality:
* Added conditional rendering of the `BpkText` content in `BpkSwitch` to ensure it is only displayed when the `text` parameter is not empty. A `Spacer` is also added for consistent spacing when text is present. 
* Removed the padding on the `Modifier` for the switch alignment to simplify layout customization. 


### Documentation updates:
* Added an example in the `Switch` README to demonstrate the use of an annotated string with styled text in the `BpkSwitch` component. (`docs/compose/Switch/README.md`, [docs/compose/Switch/README.mdR30-R52](diffhunk://#diff-58ce9e83b5e8defe9be08323e38fe3106f6e38fbd6d0458db5ef298bb5355ed7R30-R52))


Notice how the last switch is now rendered properly when text/content is empty.

![image](https://github.com/user-attachments/assets/cc4d9f5e-6251-40c4-a0ac-c67b056572ef)


issue fixed:

|Before|After|
|-|-|
![image](https://github.com/user-attachments/assets/0f809fcf-3625-4174-9502-f9d8e99b5056)|![image](https://github.com/user-attachments/assets/60f1a476-1101-4ce3-80a1-b8c385f00c72)



<!--Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] Component `README.md`
+ [x] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
