### PR TITLE
Revert "[DON-1385] change selection mode single to support dynamic accessbility"

### DIFF
--- a/app/src/main/java/net/skyscanner/backpack/demo/data/CalendarStoryType.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/data/CalendarStoryType.kt
@@ -20,7 +20,6 @@ package net.skyscanner.backpack.demo.data
 
 import net.skyscanner.backpack.R
 import net.skyscanner.backpack.calendar2.CalendarParams
-import net.skyscanner.backpack.calendar2.CalendarParams.DayCellAccessibilityLabel
 import net.skyscanner.backpack.calendar2.CalendarSelection
 import net.skyscanner.backpack.calendar2.CellInfo
 import net.skyscanner.backpack.calendar2.CellLabel
@@ -172,8 +171,18 @@ enum class CalendarStoryType {
                 MultiSelection -> CalendarParams(
                     now = now,
                     range = range,
-                    selectionMode = multipleSelectionModeWithDynamicAccessibilityLabels(),
-                    cellsInfo = createCombinedCellsInfo(range),
+                    selectionMode = singleSelectionModeWithAccessibilityLabels(),
+                    cellsInfo = mapOf(
+                        LocalDate.of(2019, 1, 9) to CellInfo(
+                            highlighted = true,
+                        ),
+                        LocalDate.of(2019, 1, 25) to CellInfo(
+                            highlighted = true,
+                        ),
+                        LocalDate.of(2019, 2, 2) to CellInfo(
+                            highlighted = true,
+                        ),
+                    ),
                 )
 
                 Loading ->
@@ -194,93 +203,21 @@ enum class CalendarStoryType {
             }
 
         private fun rangeSelectionModeWithAccessibilityLabels() = CalendarParams.SelectionMode.Range(
-            startSelectionHint = DayCellAccessibilityLabel.Static("Select as departure date"),
-            endSelectionHint = DayCellAccessibilityLabel.Static("Select as return date"),
-            startSelectionState = DayCellAccessibilityLabel.Static("Selected as departure date"),
-            endSelectionState = DayCellAccessibilityLabel.Static("Selected as return date"),
+            startSelectionHint = "Select as departure date",
+            endSelectionHint = "Select as return date",
+            startSelectionState = "Selected as departure date",
+            endSelectionState = "Selected as return date",
             startAndEndSelectionState = "Selected as departure and return date",
             betweenSelectionState = "Between departure and return date",
-        )
-
-        private fun multipleSelectionModeWithDynamicAccessibilityLabels() = CalendarParams.SelectionMode.Single(
-            startSelectionHint = DayCellAccessibilityLabel.Dynamic {
-                "Select as departure from Taiwan $it"
-            },
-            startSelectionState = DayCellAccessibilityLabel.Dynamic {
-                "Selected as departure from Taiwan $it"
-            },
-            noSelectionState = "No selection for departure from Taiwan",
-            contentDescription = {
-                "Selected as departure from Tokyo, Japan"
-            },
+            noSelectionState = "No selection",
         )
 
         private fun singleSelectionModeWithAccessibilityLabels() = CalendarParams.SelectionMode.Single(
-            startSelectionHint = DayCellAccessibilityLabel.Static("Select as departure date"),
-            startSelectionState = DayCellAccessibilityLabel.Static("Selected as departure date"),
+            startSelectionHint = "Select as departure date",
+            startSelectionState = "Selected as departure date",
             noSelectionState = "No selection",
-            contentDescription = {
-                "Selected as departure from Tokyo, Japan"
-            },
         )
     }
-}
-
-fun createCombinedCellsInfo(range: ClosedRange<LocalDate>): Map<LocalDate, CellInfo> {
-    val maxPrice = 5
-    val noPriceThreshold = 0
-    val emptyPriceThreshold = 1
-    val positivePriceThreshold = 2
-    val neutralPriceThreshold = 3
-    val negativePriceThreshold = 4
-    val minPrice = 0
-
-    val baseCellsInfo = range.toIterable().associateWith {
-        val price = it.dayOfMonth % maxPrice
-        CellInfo(
-            label = when (price) {
-                in minPrice..noPriceThreshold -> CellLabel.Icon(
-                    resId = R.drawable.bpk_search_sm,
-                    tint = R.color.bpkCoreAccent,
-                )
-
-                else -> CellLabel.Text("£${(it.dayOfMonth * 2.35f).roundToInt()}")
-            },
-            status = when (price) {
-                noPriceThreshold -> null
-                emptyPriceThreshold -> CellStatus.Empty
-                positivePriceThreshold -> CellStatus.Positive
-                neutralPriceThreshold -> CellStatus.Neutral
-                negativePriceThreshold -> CellStatus.Negative
-                else -> CellStatus.Empty
-            },
-            style = CellStatusStyle.Label,
-        )
-    }
-
-    val highlightedCells = mapOf(
-        LocalDate.of(2019, 1, 6) to CellInfo(
-            highlighted = true,
-            label = CellLabel.Icon(
-                resId = R.drawable.bpk_search_sm,
-                tint = R.color.bpkCoreAccent,
-            ),
-        ),
-        LocalDate.of(2019, 1, 9) to CellInfo(
-            highlighted = true,
-            label = CellLabel.Text("£100"),
-        ),
-        LocalDate.of(2019, 1, 25) to CellInfo(
-            highlighted = true,
-            label = CellLabel.Text("£100"),
-        ),
-        LocalDate.of(2019, 2, 2) to CellInfo(
-            highlighted = true,
-            label = CellLabel.Text("£100"),
-        ),
-    )
-
-    return baseCellsInfo + highlightedCells
 }
 
 object CalendarStorySelection {

--- a/backpack-common/src/androidTest/java/net/skyscanner/backpack/calendar2/data/CalendarAccessibilityLabelTests.kt
+++ b/backpack-common/src/androidTest/java/net/skyscanner/backpack/calendar2/data/CalendarAccessibilityLabelTests.kt
@@ -18,7 +18,7 @@
 
 package net.skyscanner.backpack.calendar2.data
 
-import net.skyscanner.backpack.calendar2.CalendarParams.DayCellAccessibilityLabel
+import net.skyscanner.backpack.calendar2.CalendarParams
 import net.skyscanner.backpack.calendar2.CalendarSettings
 import net.skyscanner.backpack.calendar2.firstDay
 import net.skyscanner.backpack.calendar2.testCalendarWith
@@ -26,17 +26,16 @@ import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.time.LocalDate
 import java.time.Month
-import net.skyscanner.backpack.calendar2.CalendarParams.SelectionMode
 
 class CalendarAccessibilityLabelTests {
 
     @Test
     fun accessibility_labels_are_correct_when_single_selection_mode_and_no_date_selected() {
         val calendarParams = CalendarSettings.Default.copy(
-            selectionMode = SelectionMode.Single(
-                startSelectionHint = DayCellAccessibilityLabel.Static("startSelectionHint"),
+            selectionMode = CalendarParams.SelectionMode.Single(
+                startSelectionHint = "startSelectionHint",
                 noSelectionState = "noSelectionState",
-                startSelectionState = DayCellAccessibilityLabel.Static("startSelectionState"),
+                startSelectionState = "startSelectionState",
             ),
         )
         testCalendarWith(calendarParams) {
@@ -51,10 +50,10 @@ class CalendarAccessibilityLabelTests {
     @Test
     fun accessibility_labels_are_correct_when_single_selection_mode_and_date_selected() {
         val calendarParams = CalendarSettings.Default.copy(
-            selectionMode = SelectionMode.Single(
-                startSelectionHint = DayCellAccessibilityLabel.Static("startSelectionHint"),
+            selectionMode = CalendarParams.SelectionMode.Single(
+                startSelectionHint = "startSelectionHint",
                 noSelectionState = "noSelectionState",
-                startSelectionState = DayCellAccessibilityLabel.Static("startSelectionState"),
+                startSelectionState = "startSelectionState",
             ),
         )
         testCalendarWith(calendarParams) {
@@ -72,11 +71,12 @@ class CalendarAccessibilityLabelTests {
     @Test
     fun accessibility_labels_are_correct_when_range_selection_mode_and_no_date_selected() {
         val calendarParams = CalendarSettings.Default.copy(
-            selectionMode = SelectionMode.Range(
-                startSelectionHint = DayCellAccessibilityLabel.Static("startSelectionHint"),
-                startSelectionState = DayCellAccessibilityLabel.Static("startSelectionState"),
-                endSelectionHint = DayCellAccessibilityLabel.Static("endSelectionHint"),
-                endSelectionState = DayCellAccessibilityLabel.Static("endSelectionState"),
+            selectionMode = CalendarParams.SelectionMode.Range(
+                startSelectionHint = "startSelectionHint",
+                noSelectionState = "noSelectionState",
+                startSelectionState = "startSelectionState",
+                endSelectionHint = "endSelectionHint",
+                endSelectionState = "endSelectionState",
             ),
         )
         testCalendarWith(calendarParams) {
@@ -91,11 +91,12 @@ class CalendarAccessibilityLabelTests {
     @Test
     fun accessibility_labels_are_correct_when_range_selection_mode_and_start_date_selected() {
         val calendarParams = CalendarSettings.Default.copy(
-            selectionMode = SelectionMode.Range(
-                startSelectionHint = DayCellAccessibilityLabel.Static("startSelectionHint"),
-                startSelectionState = DayCellAccessibilityLabel.Static("startSelectionState"),
-                endSelectionHint = DayCellAccessibilityLabel.Static("endSelectionHint"),
-                endSelectionState = DayCellAccessibilityLabel.Static("endSelectionState"),
+            selectionMode = CalendarParams.SelectionMode.Range(
+                startSelectionHint = "startSelectionHint",
+                noSelectionState = "noSelectionState",
+                startSelectionState = "startSelectionState",
+                endSelectionHint = "endSelectionHint",
+                endSelectionState = "endSelectionState",
             ),
         )
         testCalendarWith(calendarParams) {
@@ -117,11 +118,12 @@ class CalendarAccessibilityLabelTests {
     @Test
     fun accessibility_labels_are_correct_when_range_selection_mode_and_start_and_end_dates_selected() {
         val calendarParams = CalendarSettings.Default.copy(
-            selectionMode = SelectionMode.Range(
-                startSelectionHint = DayCellAccessibilityLabel.Static("startSelectionHint"),
-                startSelectionState = DayCellAccessibilityLabel.Static("startSelectionState"),
-                endSelectionHint = DayCellAccessibilityLabel.Static("endSelectionHint"),
-                endSelectionState = DayCellAccessibilityLabel.Static("endSelectionState"),
+            selectionMode = CalendarParams.SelectionMode.Range(
+                startSelectionHint = "startSelectionHint",
+                noSelectionState = "noSelectionState",
+                startSelectionState = "startSelectionState",
+                endSelectionHint = "endSelectionHint",
+                endSelectionState = "endSelectionState",
             ),
         )
         testCalendarWith(calendarParams) {

--- a/backpack-common/src/main/java/net/skyscanner/backpack/calendar2/CalendarParams.kt
+++ b/backpack-common/src/main/java/net/skyscanner/backpack/calendar2/CalendarParams.kt
@@ -20,6 +20,7 @@ package net.skyscanner.backpack.calendar2
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
+import net.skyscanner.backpack.calendar2.CalendarParams.MonthSelectionMode
 import net.skyscanner.backpack.util.InternalBackpackApi
 import java.io.Serializable
 import java.text.SimpleDateFormat
@@ -87,41 +88,23 @@ data class CalendarParams(
          * Accessibility labels are NOT supported in the view version
          */
         data class Single(
-            @Transient
-            val startSelectionHint: DayCellAccessibilityLabel? = null,
+            val startSelectionHint: String? = null,
             val noSelectionState: String? = null,
-            @Transient
-            val startSelectionState: DayCellAccessibilityLabel? = null,
-            @Transient
-            val contentDescription: ((LocalDate) -> String)? = null,
+            val startSelectionState: String? = null,
         ) : SelectionMode
 
         /**
          * A range of dates can be selected.
          */
         data class Range(
-            @Transient
-            val startSelectionHint: DayCellAccessibilityLabel? = null,
-            @Transient
-            val endSelectionHint: DayCellAccessibilityLabel? = null,
-            @Transient
-            val startSelectionState: DayCellAccessibilityLabel? = null,
+            val startSelectionHint: String? = null,
+            val endSelectionHint: String? = null,
+            val noSelectionState: String? = null,
+            val startSelectionState: String? = null,
             val startAndEndSelectionState: String? = null,
-            @Transient
-            val endSelectionState: DayCellAccessibilityLabel? = null,
+            val endSelectionState: String? = null,
             val betweenSelectionState: String? = null,
-            @Transient
-            val contentDescription: ((LocalDate) -> String)? = null,
         ) : SelectionMode
-    }
-
-    /**
-     * Describes the accessibility label of a day cell
-     * support Static string and dynamic string
-     */
-    sealed class DayCellAccessibilityLabel {
-        data class Static(val label: String) : DayCellAccessibilityLabel()
-        data class Dynamic(val label: (LocalDate) -> String) : DayCellAccessibilityLabel()
     }
 
     /**

--- a/backpack-common/src/main/java/net/skyscanner/backpack/calendar2/data/CalendarCell.kt
+++ b/backpack-common/src/main/java/net/skyscanner/backpack/calendar2/data/CalendarCell.kt
@@ -23,9 +23,7 @@ import android.text.style.TtsSpan
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.core.text.buildSpannedString
-import net.skyscanner.backpack.calendar2.CalendarDayCellTestTag
 import net.skyscanner.backpack.calendar2.CalendarParams
-import net.skyscanner.backpack.calendar2.CalendarParams.DayCellAccessibilityLabel
 import net.skyscanner.backpack.calendar2.CalendarSelection
 import net.skyscanner.backpack.calendar2.CellInfo
 import net.skyscanner.backpack.util.InternalBackpackApi
@@ -63,7 +61,6 @@ sealed class CalendarCell {
         val selection: Selection?,
         val text: CharSequence,
         val outOfRange: Boolean,
-        val testTag: String,
         val contentDescription: String,
         val stateDescription: String?,
         val onClickLabel: String?,
@@ -105,7 +102,7 @@ internal fun CalendarCellDay(
     yearMonth = yearMonth,
     info = params.cellsInfo[date] ?: CellInfo.Default,
     outOfRange = date !in params.range,
-    contentDescription = date.format(params.dateContentDescriptionFormatter) + ". " + generateContentDescription(date, params.selectionMode),
+    contentDescription = date.format(params.dateContentDescriptionFormatter),
     stateDescription = stateDescription(date, params.selectionMode, selection),
     onClickLabel = onClickLabel(date, params.selectionMode, selection),
     text = buildSpannedString {
@@ -117,7 +114,6 @@ internal fun CalendarCellDay(
             .build()
         append(date.dayOfMonth.toString(), span, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
     },
-    testTag = checkDayCellStatus(params, date) + date.format(params.dateContentDescriptionFormatter),
     selection = when (selection) {
         is CalendarSelection.None -> null
         is CalendarSelection.Single -> when (date) {
@@ -143,15 +139,6 @@ internal fun CalendarCellDay(
     },
 )
 
-private fun generateContentDescription(
-    date: LocalDate,
-    selectionMode: CalendarParams.SelectionMode,
-): String = when (selectionMode) {
-    is CalendarParams.SelectionMode.Single -> selectionMode.contentDescription?.let { it(date) } ?: ""
-    is CalendarParams.SelectionMode.Range -> selectionMode.contentDescription?.let { it(date) } ?: ""
-    else -> ""
-}
-
 private fun stateDescription(
     date: LocalDate,
     selectionMode: CalendarParams.SelectionMode,
@@ -161,7 +148,7 @@ private fun stateDescription(
         is CalendarSelection.None -> selectionMode.noSelectionState
         is CalendarSelection.Single ->
             when (selection.date) {
-                date -> selectionMode.startSelectionState?.getAccessibilityLabel(date)
+                date -> selectionMode.startSelectionState
                 else -> null
             }
         else -> null
@@ -171,9 +158,9 @@ private fun stateDescription(
         is CalendarSelection.Dates ->
             when {
                 selection.start == date && selection.end == date -> selectionMode.startAndEndSelectionState
-                selection.start == date && selection.end == null -> selectionMode.startSelectionState?.getAccessibilityLabel(date)
-                selection.start == date && selection.end != null -> selectionMode.startSelectionState?.getAccessibilityLabel(date)
-                selection.end == date -> selectionMode.endSelectionState?.getAccessibilityLabel(date)
+                selection.start == date && selection.end == null -> selectionMode.startSelectionState
+                selection.start == date && selection.end != null -> selectionMode.startSelectionState
+                selection.end == date -> selectionMode.endSelectionState
                 selection.end != null && date in selection -> selectionMode.betweenSelectionState
                 else -> null
             }
@@ -189,35 +176,17 @@ private fun onClickLabel(
     selectionMode: CalendarParams.SelectionMode,
     selection: CalendarSelection,
 ): String? = when (selectionMode) {
-    is CalendarParams.SelectionMode.Single -> selectionMode.startSelectionHint?.getAccessibilityLabel(date)
+    is CalendarParams.SelectionMode.Single -> selectionMode.startSelectionHint
     is CalendarParams.SelectionMode.Range -> when (selection) {
-        is CalendarSelection.None -> selectionMode.startSelectionHint?.getAccessibilityLabel(date)
+        is CalendarSelection.None -> selectionMode.startSelectionHint
         is CalendarSelection.Dates ->
             when {
-                selection.end != null || date < selection.start -> selectionMode.startSelectionHint?.getAccessibilityLabel(date)
-                else -> selectionMode.endSelectionHint?.getAccessibilityLabel(date)
+                selection.end != null || date < selection.start -> selectionMode.startSelectionHint
+                else -> selectionMode.endSelectionHint
             }
 
         else -> null
     }
 
     is CalendarParams.SelectionMode.Disabled -> null
-}
-
-private fun checkDayCellStatus(params: CalendarParams, date: LocalDate): String {
-    val info = (params.cellsInfo[date] ?: CellInfo.Default)
-    val outOfRange = date !in params.range
-    val inactive = info.disabled || outOfRange
-    val isHighlighted = info.highlighted
-    return when {
-        inactive && !isHighlighted -> CalendarDayCellTestTag.INACTIVE
-        inactive && isHighlighted -> CalendarDayCellTestTag.INACTIVE_HIGHLIGHTED
-        !inactive && isHighlighted -> CalendarDayCellTestTag.ACTIVE_HIGHLIGHTED
-        else -> CalendarDayCellTestTag.ACTIVE
-    }.toString()
-}
-
-fun DayCellAccessibilityLabel.getAccessibilityLabel(date: LocalDate): String = when (this) {
-    is DayCellAccessibilityLabel.Static -> label
-    is DayCellAccessibilityLabel.Dynamic -> label(date)
 }

--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendarTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendarTest.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
 import androidx.compose.ui.test.assert
-import androidx.compose.ui.test.assertContentDescriptionContains
 import androidx.compose.ui.test.assertIsNotSelected
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -37,7 +36,6 @@ import androidx.compose.ui.test.performScrollToIndex
 import androidx.compose.ui.test.performScrollToNode
 import kotlinx.coroutines.test.runTest
 import net.skyscanner.backpack.calendar2.CalendarParams
-import net.skyscanner.backpack.calendar2.CalendarParams.DayCellAccessibilityLabel
 import net.skyscanner.backpack.calendar2.CalendarSelection
 import net.skyscanner.backpack.compose.calendar.internal.CALENDAR_GRID_TEST_TAG
 import net.skyscanner.backpack.compose.theme.BpkTheme
@@ -58,12 +56,9 @@ class BpkCalendarTest {
     private val DefaultSingle = CalendarParams(
         locale = Locale.UK,
         selectionMode = CalendarParams.SelectionMode.Single(
-            startSelectionHint = DayCellAccessibilityLabel.Static("startSelectionHint"),
+            startSelectionHint = "startSelectionHint",
             noSelectionState = "noSelectionState",
-            startSelectionState = DayCellAccessibilityLabel.Static("startSelectionState"),
-            contentDescription = {
-                "contentDescription"
-            },
+            startSelectionState = "startSelectionState",
         ),
         range = initialRange,
         now = now,
@@ -71,15 +66,13 @@ class BpkCalendarTest {
 
     private val DefaultRange = DefaultSingle.copy(
         selectionMode = CalendarParams.SelectionMode.Range(
-            startSelectionHint = DayCellAccessibilityLabel.Static("startSelectionHint"),
-            endSelectionHint = DayCellAccessibilityLabel.Static("endSelectionHint"),
-            startSelectionState = DayCellAccessibilityLabel.Static("startSelectionState"),
+            startSelectionHint = "startSelectionHint",
+            endSelectionHint = "endSelectionHint",
+            noSelectionState = "noSelectionState",
+            startSelectionState = "startSelectionState",
             startAndEndSelectionState = "startAndEndSelectionState",
-            endSelectionState = DayCellAccessibilityLabel.Static("endSelectionState"),
+            endSelectionState = "endSelectionState",
             betweenSelectionState = "betweenSelectionState",
-            contentDescription = {
-                "contentDescription"
-            },
         ),
     )
 
@@ -98,13 +91,11 @@ class BpkCalendarTest {
 
         composeTestRule.onAllNodesWithText("17")
             .onFirst()
-            .assertContentDescriptionContains("contentDescription", true, true)
             .assertOnClickLabelEquals("startSelectionHint")
             .performClick()
 
         composeTestRule.onAllNodesWithText("17")
             .onFirst()
-            .assertContentDescriptionContains("contentDescription", true, true)
             .assertOnClickLabelEquals("endSelectionHint")
             .assertStateDescriptionEquals("startSelectionState")
             .performClick()
@@ -126,18 +117,14 @@ class BpkCalendarTest {
 
         composeTestRule.onAllNodesWithText("13")
             .onLast()
-            .assertContentDescriptionContains("contentDescription", true, true)
             .assertOnClickLabelEquals("startSelectionHint")
             .performClick()
-            .assertContentDescriptionContains("contentDescription", true, true)
             .assertStateDescriptionEquals("startSelectionState")
 
         composeTestRule.onAllNodesWithText("14")
             .onLast()
-            .assertContentDescriptionContains("contentDescription", true, true)
             .assertOnClickLabelEquals("startSelectionHint")
             .performClick()
-            .assertContentDescriptionContains("contentDescription", true, true)
             .assertStateDescriptionEquals("startSelectionState")
 
         val state = controller.state
@@ -160,14 +147,12 @@ class BpkCalendarTest {
 
         composeTestRule.onAllNodesWithText("17")
             .onFirst()
-            .assertContentDescriptionContains("contentDescription", true, true)
             .assertOnClickLabelEquals("startSelectionHint")
             .performClick()
             .assertStateDescriptionEquals("startSelectionState")
 
         composeTestRule.onAllNodesWithText("14")
             .onLast()
-            .assertContentDescriptionContains("contentDescription", true, true)
             .assertOnClickLabelEquals("endSelectionHint")
             .performClick()
             .assertStateDescriptionEquals("endSelectionState")
@@ -190,7 +175,6 @@ class BpkCalendarTest {
 
         composeTestRule.onAllNodesWithText("17")
             .onFirst()
-            .assertContentDescriptionContains("contentDescription", true, true)
             .assertOnClickLabelEquals("startSelectionHint")
             .performClick()
             .assertStateDescriptionEquals("startSelectionState")
@@ -218,18 +202,15 @@ class BpkCalendarTest {
 
         composeTestRule.onAllNodesWithText("17")
             .onFirst()
-            .assertContentDescriptionContains("contentDescription", true, true)
             .performClick()
 
         composeTestRule.onAllNodesWithText("31")
             .onFirst()
-            .assertContentDescriptionContains("contentDescription", true, true)
             .assertOnClickLabelEquals("startSelectionHint")
             .assertStateDescriptionEquals("startSelectionState")
 
         composeTestRule.onAllNodesWithText("17")
             .onFirst()
-            .assertContentDescriptionContains("contentDescription", true, true)
             .assertIsNotSelected()
 
         val state = controller.state

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendarDayCellTestTag.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendarDayCellTestTag.kt
@@ -1,5 +1,4 @@
-package net.skyscanner.backpack.calendar2
-
+package net.skyscanner.backpack.compose.calendar
 /*
  * Backpack for Android - Skyscanner's Design System
  *
@@ -18,7 +17,7 @@ package net.skyscanner.backpack.calendar2
  * limitations under the License.
  */
 
-enum class CalendarDayCellTestTag {
+enum class BpkCalendarDayCellTestTag {
     INACTIVE,
     INACTIVE_HIGHLIGHTED,
     ACTIVE,

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/internal/BpkCalendarDayCell.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/internal/BpkCalendarDayCell.kt
@@ -60,6 +60,7 @@ import net.skyscanner.backpack.calendar2.CellStatusStyle
 import net.skyscanner.backpack.calendar2.data.CalendarCell
 import net.skyscanner.backpack.calendar2.data.CalendarCell.Selection
 import net.skyscanner.backpack.compose.LocalContentColor
+import net.skyscanner.backpack.compose.calendar.BpkCalendarDayCellTestTag
 import net.skyscanner.backpack.compose.icon.BpkIcon
 import net.skyscanner.backpack.compose.icon.findBySmall
 import net.skyscanner.backpack.compose.skeleton.BpkHeadlineSkeleton
@@ -95,7 +96,7 @@ internal fun BpkCalendarDayCell(
                 onClickLabel = model.onClickLabel,
                 interactionSource = remember { MutableInteractionSource() },
             )
-            .testTag(model.testTag)
+            .testTag(checkDayCellStatus(inactive, model.info.highlighted))
             .semantics {
                 testTagsAsResourceId = true
                 if (model.stateDescription != null) {
@@ -322,3 +323,12 @@ private fun labelColor(status: CellStatus?, style: CellStatusStyle?): Color =
 
 private val StartSemiRect = RelativeRectangleShape(0f..0.5f)
 private val EndSemiRect = RelativeRectangleShape(0.5f..1f)
+
+private fun checkDayCellStatus(inactive: Boolean, isHighlighted: Boolean): String {
+    return when {
+        inactive && !isHighlighted -> BpkCalendarDayCellTestTag.INACTIVE
+        inactive && isHighlighted -> BpkCalendarDayCellTestTag.INACTIVE_HIGHLIGHTED
+        !inactive && isHighlighted -> BpkCalendarDayCellTestTag.ACTIVE_HIGHLIGHTED
+        else -> BpkCalendarDayCellTestTag.ACTIVE
+    }.toString()
+}

--- a/docs/compose/Calendar2/README.md
+++ b/docs/compose/Calendar2/README.md
@@ -76,7 +76,7 @@ import net.skyscanner.backpack.compose.calendar.rememberCalendarController
 val controller = rememberCalendarController(
   initialParams = CalendarParams(
     range = LocalDate.of(2019, 1, 2)..LocalDate.of(2019, 12, 31), // start and end dates in the range
-    selectionMode = CalendarParams.SelectionMode.Single, // selection mode - can be Single, Range with ability of passing static or dynamic accessibility labels
+    selectionMode = CalendarParams.SelectionMode.Single, // selection mode - can be Single, Dates, Months or Disabled,
     onSelectionChanged = { selection -> // callback for selection change, you can react to the selection here
         when (selection) {
             is CalendarSelection.None -> {}


### PR DESCRIPTION
Reverts Skyscanner/backpack-android#2290

This was marked as `minor` but included breaking changes.
Marking _this_ one as `patch` as it will return the release to not having breaking changes compared to 67.14.0