### PR TITLE
DON-1639 Change scroll handling in BpkCalendar to return visible months

### DIFF
--- a/app/src/main/java/net/skyscanner/backpack/demo/compose/CalendarStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/compose/CalendarStory.kt
@@ -140,7 +140,7 @@ private fun CalendarDemo(
         when (type) {
             CalendarStoryType.SelectionWholeMonth -> controller.setSelection(CalendarStorySelection.WholeMonthRange)
             CalendarStoryType.PreselectedRange -> controller.setSelection(PreselectedRange)
-            CalendarStoryType.WithLabels -> controller.setSelection(CalendarStorySelection.PreselectedRange)
+            CalendarStoryType.WithLabels -> controller.setSelection(PreselectedRange)
             CalendarStoryType.MultiSelection -> controller.setSelection(CalendarStorySelection.PreselectedDate)
             else -> Unit
         }

--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendarTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendarTest.kt
@@ -240,12 +240,12 @@ class BpkCalendarTest {
     @Test
     fun withScrollHandling() = runTest {
         val controller = createController(DefaultSingle)
-        var visitedMonth = YearMonth.of(2019, 1)
+        val visitedMonth = mutableListOf(YearMonth.of(2019, 1))
 
         composeTestRule.setContent {
             BpkTheme {
-                BpkCalendar(controller, onScrollToMonth = {
-                    visitedMonth = it
+                BpkCalendar(controller, onVisibleMonthsChanged = {
+                    visitedMonth += it
                 })
             }
         }
@@ -255,7 +255,7 @@ class BpkCalendarTest {
 
         composeTestRule.waitForIdle()
 
-        assert(visitedMonth.monthValue > 1)
+        assertEquals(10, visitedMonth.size)
     }
 
     private fun createController(params: CalendarParams): BpkCalendarController =

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendar.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendar.kt
@@ -39,7 +39,7 @@ fun BpkCalendar(
     controller: BpkCalendarController,
     modifier: Modifier = Modifier,
     customDateHandling: ((CalendarInteraction) -> Unit)? = null,
-    onScrollToMonth: ((YearMonth) -> Unit)? = null,
+    onVisibleMonthsChanged: ((Set<YearMonth>) -> Unit)? = null,
 ) {
 
     val state = controller.state
@@ -71,9 +71,9 @@ fun BpkCalendar(
             }
         }
 
-        onScrollToMonth?.let {
-            LaunchedEffect(onScrollToMonth, controller.firstVisibleItemMonth) {
-                onScrollToMonth(controller.firstVisibleItemMonth)
+        onVisibleMonthsChanged?.let {
+            LaunchedEffect(onVisibleMonthsChanged, controller.visibleMonths) {
+                onVisibleMonthsChanged(controller.visibleMonths)
             }
         }
     }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendarController.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/BpkCalendarController.kt
@@ -90,8 +90,11 @@ class BpkCalendarController(
         }
     }
 
-    internal val firstVisibleItemMonth: YearMonth
+    private val firstVisibleItemMonth: YearMonth
         get() = _state.cells[lazyGridState.firstVisibleItemIndex].yearMonth
+
+    internal val visibleMonths: Set<YearMonth>
+        get() = lazyGridState.layoutInfo.visibleItemsInfo.map { _state.cells[it.index].yearMonth }.toSet()
 
     /**
      * Returns the first visible item year.

--- a/docs/compose/Calendar2/README.md
+++ b/docs/compose/Calendar2/README.md
@@ -103,20 +103,22 @@ You can then set the selection in the controller using the `setSelection` method
 
 ### (Optional) Handling Calendar Scroll Updates
 
-To receive notifications when the calendar is scrolled, you can utilize the `onScrollToMonth` parameter.
-This callback is triggered whenever the `lazyGridState.firstVisibleItemIndex` property of the `BpkCalendarController` is
-updated.
+To receive notifications when the calendar is scrolled, you can utilize the `onVisibleMonthsChanged` parameter.
+This callback is triggered whenever the visible months in the calendar change, allowing you to respond to user interactions
+or update UI elements based on the currently visible months.
 
-For example you can show the furthest scrolled month's number (i.e. January = 1, February = 2, etc.) in a `BpkText` label:
+For example you can show the furthest scrolled month in a `BpkText` label:
 
 ```Kotlin
+import java.time.YearMonth
+
 Column {
-    var month: YearMonth by remember { mutableStateOf(YearMonth.now()) }
-    BpkText("Month: ${month.monthValue}")
+    val month: MutableList<YearMonth> = remember { mutableListOf() }
+    BpkText("Month: ${month.last()}")
     BpkCalendar(
         controller = controller,
-        onScrollToMonth = {
-            month = it
+        onVisibleMonthsChanged = {
+            month += it
         }
     )
 }


### PR DESCRIPTION
This supports taller screens better as if the calendar is scrolled to the end the consumer only knew what the top month was.
Now the consumer can observe a changing list of visible months, with no duplicates.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
