### PR TITLE
DON-1626 Create custom navBarActionContentDescription 

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/navbar/BpkNavBar.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/navbar/BpkNavBar.kt
@@ -112,6 +112,7 @@ class BpkNavBar @JvmOverloads constructor(
         var title: CharSequence?
         var navIcon: Drawable?
         var menu = 0
+        var navIconContentDescription: CharSequence?
 
         createContextThemeWrapper(context, attrs, R.attr.bpkNavBarStyle).theme.obtainStyledAttributes(
             attrs,
@@ -121,12 +122,14 @@ class BpkNavBar @JvmOverloads constructor(
             title = it.getString(R.styleable.BpkNavBar_navBarTitle)
             navIcon = it.getDrawable(R.styleable.BpkNavBar_navBarIcon)
             menu = it.getResourceId(R.styleable.BpkNavBar_navBarMenu, menu)
+            navIconContentDescription = it.getString(R.styleable.BpkNavBar_navBarActionContentDescription)
         }
 
         this.background = ColorDrawable(context.getColor(R.color.bpkCanvas))
         this.title = title
         this.icon = navIcon
         this.navAction = navAction
+        this.toolbar.navigationContentDescription = navIconContentDescription
         this.menu = menu
         this.stateListAnimator = shadowStateListAnimator()
     }

--- a/Backpack/src/main/res/values/attrs.xml
+++ b/Backpack/src/main/res/values/attrs.xml
@@ -256,6 +256,7 @@
 
     <declare-styleable name="BpkNavBar">
         <attr name="navBarTitle" format="string" />
+        <attr name="navBarActionContentDescription" format="string" />
         <attr name="navBarIcon" format="reference" />
         <attr name="navBarMenu" format="reference" />
     </declare-styleable>


### PR DESCRIPTION
AppCompat's Toolbar has a `navigationContentDescription` which our consumers have tried to use with no success.
Therefore, I believe we have to make a custom attribute that then gets passed down to it internally.

I did try accessing the AppCompat one but it is private.

Consumers should update their layouts from, for example

```
app:navBarIcon="@drawable/bpk_native_android__back"
app:navigationContentDescription="@string/key_accessibility_navigateup"
```

to

```
app:navBarIcon="@drawable/bpk_native_android__back"
app:navBarActionContentDescription="@string/key_accessibility_navigateup"
```

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
