### PR TITLE
Revert "Bump ktor from 3.1.3 to 3.2.0"

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ androidXJunit = "1.2.1"
 coroutines = "1.10.2"
 espresso = "3.6.1"
 kotlinPoet = "2.2.0"
-ktor = "3.2.0"
+ktor = "3.1.3"
 roborazzi = "1.43.1"
 
 [plugins]


### PR DESCRIPTION
Reverts Skyscanner/backpack-android#2317

Caused issue with `:app:recordScreenshots`.
https://skyscanner.slack.com/archives/C0JHPDSSU/p1751422425295619