### PR TITLE
Update missed Gradle file after failed deployment.

### DIFF
--- a/gradle-maven-push.gradle
+++ b/gradle-maven-push.gradle
@@ -1,5 +1,4 @@
 apply plugin: 'maven-publish'
-apply plugin: 'signing'
 
 android {
     publishing {
@@ -60,24 +59,3 @@ afterEvaluate { project ->
     }
 }
 
-tasks.register('checkMavenCredentials') {
-    doLast {
-        def props = ["signing.keyId", "signing.password", "signing.secretKeyRingFile"]
-        // Skip GitHub credentials check as they can be provided by GitHub Actions
-        if (!System.getenv("GITHUB_ACTIONS") && props.any { rootProject.ext[it]?.isEmpty() }) {
-            ant.fail("Missing signing credentials")
-        }
-    }
-}
-
-ext["signing.keyId"] = rootProject.ext["signing.keyId"]
-ext["signing.password"] = rootProject.ext["signing.password"]
-ext["signing.secretKeyRingFile"] = rootProject.ext["signing.secretKeyRingFile"]
-
-signing {
-    sign publishing.publications
-}
-
-tasks.withType(Sign) {
-    onlyIf { !project.version.endsWith("SNAPSHOT") }
-}

--- a/publish-root.gradle
+++ b/publish-root.gradle
@@ -1,6 +1,3 @@
-ext["signing.keyId"] = ''
-ext["signing.password"] = ''
-ext["signing.secretKeyRingFile"] = ''
 ext["githubUsername"] = ''
 ext["githubToken"] = ''
 
@@ -12,7 +9,6 @@ if (localProps.exists()) {
 } else {
     Properties p = new Properties()
     p.putAll(System.getenv())
-    ext["signing.secretKeyRingFile"] = "${project.rootDir}/github.gpg"
     p.each { name, value ->
         switch (name) {
             case "GITHUB_USERNAME":
@@ -20,12 +16,6 @@ if (localProps.exists()) {
                 break
             case "GITHUB_TOKEN":
                 ext["githubToken"] = value
-                break
-            case "GITHUB_SIGNING_KEY_ID":
-                ext["signing.keyId"] = value
-                break
-            case "GITHUB_SIGNING_KEY_PASSWORD":
-                ext["signing.password"] = value
                 break
         }
     }

--- a/publish-root.gradle
+++ b/publish-root.gradle
@@ -12,7 +12,7 @@ if (localProps.exists()) {
 } else {
     Properties p = new Properties()
     p.putAll(System.getenv())
-    ext["signing.secretKeyRingFile"] = "${project.rootDir}/sonatype.gpg"
+    ext["signing.secretKeyRingFile"] = "${project.rootDir}/github.gpg"
     p.each { name, value ->
         switch (name) {
             case "GITHUB_USERNAME":
@@ -21,10 +21,10 @@ if (localProps.exists()) {
             case "GITHUB_TOKEN":
                 ext["githubToken"] = value
                 break
-            case "SONATYPE_SINGING_KEY_ID":
+            case "GITHUB_SIGNING_KEY_ID":
                 ext["signing.keyId"] = value
                 break
-            case "SONATYPE_SINGING_KEY_PASSWORD":
+            case "GITHUB_SIGNING_KEY_PASSWORD":
                 ext["signing.password"] = value
                 break
         }


### PR DESCRIPTION
Update missed gradle file that refers to Sonatype still.

Robot says:
> With GitHub Packages, you do **not** need to sign artifacts (and thus do not need `signing.keyId`, `signing.password`, or `signing.secretKeyRingFile`) unless you specifically want to cryptographically sign your published artifacts for extra trust.
> GitHub Packages does not require artifact signing for publishing. Signing is only needed if you want consumers to verify the authenticity of your artifacts, or if you plan to also publish to Maven Central (which requires signing).
> If you only publish to GitHub Packages, you can safely remove the signing configuration and related secrets. If you want to keep signing for extra security, you can leave it as is.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
