### PR TITLE
PAN-4316: Deprecated some old map markers.

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/map/BpkHotelMapMarker.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/map/BpkHotelMapMarker.kt
@@ -49,6 +49,7 @@ enum class BpkHotelMarkerStatus {
 /**
  * @param onClick Callback invoked when the marker is clicked. Return true to consume the event, for example to disable the default centre map on marker behaviour.
  */
+@Deprecated("Use BpkPoiMapMarker instead.", ReplaceWith("BpkPoiMapMarker"), DeprecationLevel.WARNING)
 @Composable
 fun BpkHotelMapMarker(
     contentDescription: String,

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/map/BpkIconMapMarker.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/map/BpkIconMapMarker.kt
@@ -50,6 +50,7 @@ enum class BpkIconMarkerStatus {
 /**
  * @param onClick Callback invoked when the marker is clicked. Return true to consume the event, for example to disable the default centre map on marker behaviour.
  */
+@Deprecated("Use BpkPoiMapMarker instead.", ReplaceWith("BpkPoiMapMarker"), DeprecationLevel.WARNING)
 @Composable
 fun BpkIconMapMarker(
     contentDescription: String,

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/map/BpkPointerMapMarker.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/map/BpkPointerMapMarker.kt
@@ -38,6 +38,7 @@ import net.skyscanner.backpack.compose.tokens.BpkBorderSize
 import net.skyscanner.backpack.compose.tokens.BpkSpacing
 import net.skyscanner.backpack.compose.utils.rememberCapturedComposeBitmapDescriptor
 
+@Deprecated("Use BpkLocationMapMarker instead.", ReplaceWith("BpkLocationMapMarker"), DeprecationLevel.WARNING)
 @Composable
 fun BpkPointerMapMarker(
     title: String,

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/map/BpkPriceMapMarker.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/map/BpkPriceMapMarker.kt
@@ -51,6 +51,7 @@ enum class BpkPriceMarkerStatus {
     Disabled,
 }
 
+@Deprecated("Use BpkPriceMapMarkerV2 instead.", ReplaceWith("BpkPriceMapMarkerV2"), DeprecationLevel.WARNING)
 @Composable
 fun BpkPriceMapMarker(
     title: String,

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/map/BpkPriceMapMarkerV2.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/map/BpkPriceMapMarkerV2.kt
@@ -62,7 +62,7 @@ fun BpkPriceMapMarkerV2(
     onClick: (Marker) -> Boolean = { false },
     prefixIcon: BpkIcon? = null,
 ) {
-    val icon = rememberCapturedComposeBitmapDescriptor(title, status.name) {
+    val icon = rememberCapturedComposeBitmapDescriptor(title, status, prefixIcon) {
         PriceMarkerV2Layout(title = title, status = status, prefixIcon = prefixIcon)
     }
 

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/utils/ComposeToBitmap.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/utils/ComposeToBitmap.kt
@@ -38,7 +38,7 @@ import com.google.android.gms.maps.model.BitmapDescriptorFactory
 
 @Composable
 internal fun rememberCapturedComposeBitmapDescriptor(
-    vararg keys: Any,
+    vararg keys: Any?,
     content: @Composable () -> Unit,
 ): BitmapDescriptor {
     val bitmap = rememberCapturedComposeBitmap(*keys, content = content)
@@ -47,7 +47,7 @@ internal fun rememberCapturedComposeBitmapDescriptor(
 
 @Composable
 internal fun rememberCapturedComposeBitmap(
-    vararg keys: Any,
+    vararg keys: Any?,
     content: @Composable () -> Unit,
 ): Bitmap {
     val parent = LocalView.current as ViewGroup


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

https://skyscanner.atlassian.net/browse/PAN-4316

### Context
There are some differences between [design](https://www.figma.com/design/irZ3YBx8vOm16ICkAr7mB3/Backpack-Components?node-id=8191-8904&p=f&t=zDhfRNLe9b1rpXkK-0) and actual [implementation](https://www.skyscanner.design/latest/components/map/compose-Z0sCXGGA).
So we'd like to remove the markers which should be deprecated and deprecated them firstly.
discuss: https://skyscanner.slack.com/archives/C0JHPDSSU/p1752223047085589

### Changes
- Deprecate `BpkPriceMapMarker`, user can use `BpkPriceMapMarkerV2` to instead.
- Deprecate `BpkIconMapMarker`  and `BpkHotelMapMarker`, user can use `BpkPoiMapMarker` to instead.
- Deprecate `BpkPointerMapMarker`, user can use `BpkLocationMapMarker` to instead.
- Refresh bitmap of `BpkPriceMapMarkerV2` when prefix icon was added.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
