### PR TITLE
foundations bump plus final general clean up for backpack

### DIFF
--- a/Backpack/src/androidTest/java/net/skyscanner/backpack/spinner/BpkSpinnerTest.kt
+++ b/Backpack/src/androidTest/java/net/skyscanner/backpack/spinner/BpkSpinnerTest.kt
@@ -45,13 +45,13 @@ class BpkSpinnerTest {
     fun test_default() {
         Assert.assertFalse(subject.small)
         Assert.assertEquals(BpkSpinner.Type.PRIMARY, subject.type)
-        Assert.assertEquals(subject.context.getColor(R.color.bpkSkyBlue), subject.getColor())
+        Assert.assertEquals(subject.context.getColor(R.color.bpkTextLink), subject.getColor())
     }
 
     @Test
     fun test_light() {
         subject.type = BpkSpinner.Type.LIGHT
-        Assert.assertEquals(subject.context.getColor(R.color.bpkWhite), subject.getColor())
+        Assert.assertEquals(subject.context.getColor(R.color.bpkTextOnDark), subject.getColor())
     }
 
     @Test

--- a/Backpack/src/main/java/net/skyscanner/backpack/badge/BpkBadge.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/badge/BpkBadge.kt
@@ -88,7 +88,7 @@ open class BpkBadge @JvmOverloads constructor(
          * Style for badges with a dark background
          */
         @Deprecated("Switch to a different badge style")
-        Dark(7, R.color.bpkCorePrimary, R.color.bpkWhite),
+        Dark(7, R.color.bpkCorePrimary, R.color.bpkTextOnDark),
 
         /**
          * Style for badges

--- a/Backpack/src/main/java/net/skyscanner/backpack/horisontalnav/BpkHorizontalNav.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/horisontalnav/BpkHorizontalNav.kt
@@ -61,8 +61,8 @@ open class BpkHorizontalNav @JvmOverloads constructor(
             id = 1,
             styleAttribute = R.attr.bpkHorizontalNavStyleAlternate,
             defaultTextColor = R.color.bpkCanvasContrast,
-            defaultTextSelectedColor = R.color.bpkWhite,
-            defaultIndicatorColor = R.color.bpkWhite,
+            defaultTextSelectedColor = R.color.bpkTextOnDark,
+            defaultIndicatorColor = R.color.bpkTextOnDark,
         ),
     }
 

--- a/Backpack/src/main/java/net/skyscanner/backpack/overlay/BpkOverlay.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/overlay/BpkOverlay.kt
@@ -65,7 +65,7 @@ open class BpkOverlay @JvmOverloads constructor(
         None(0),
         Tint(
             id = 1,
-            colorRes = R.color.bpkBlack,
+            colorRes = R.color.bpkTextOnLight,
             opacity = 0.56f,
         ),
     }

--- a/Backpack/src/main/java/net/skyscanner/backpack/spinner/BpkSpinner.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/spinner/BpkSpinner.kt
@@ -61,7 +61,7 @@ open class BpkSpinner @JvmOverloads constructor(
 
     private val colors = arrayOf(
         R.color.bpkCoreAccent,
-        R.color.bpkWhite,
+        R.color.bpkTextOnDark,
         R.color.bpkTextSecondary,
         R.color.bpkTextPrimary,
         R.color.bpkTextDisabled,

--- a/Backpack/src/main/res/layout/bpk_dialog_flare.xml
+++ b/Backpack/src/main/res/layout/bpk_dialog_flare.xml
@@ -37,7 +37,7 @@
                     android:id="@+id/dialog_image"
                     android:layout_width="match_parent"
                     android:layout_height="match_parent"
-                    android:background="@color/bpkSkyBlue"
+                    android:background="@color/bpkTextLink"
                     android:scaleType="centerCrop"
                     tools:ignore="ContentDescription" />
 

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -48,21 +48,21 @@
 
     <style name="LondonThemeButtonPrimary">
         <item name="buttonBackgroundColor">?bpkPrimaryColor</item>
-        <item name="buttonTextColor">@color/bpkWhite</item>
+        <item name="buttonTextColor">@color/bpkTextOnDark</item>
     </style>
 
     <style name="LondonThemeButtonSecondary">
-        <item name="buttonBackgroundColor">@color/bpkWhite</item>
+        <item name="buttonBackgroundColor">@color/bpkTextOnDark</item>
         <item name="buttonTextColor">?bpkPrimaryColor</item>
     </style>
 
     <style name="LondonThemeButtonFeatured">
         <item name="buttonBackgroundColor">#ED1B28</item>
-        <item name="buttonTextColor">@color/bpkWhite</item>
+        <item name="buttonTextColor">@color/bpkTextOnDark</item>
     </style>
 
     <style name="LondonThemeButtonDestructive">
-        <item name="buttonBackgroundColor">@color/bpkWhite</item>
+        <item name="buttonBackgroundColor">@color/bpkTextOnDark</item>
         <item name="buttonTextColor">#ED1B28</item>
     </style>
 
@@ -78,7 +78,7 @@
         <item name="calendarDateSelectedBackgroundColor">#D11622</item>
         <item name="calendarDateSelectedSameDayBackgroundColor">#ED1B28</item>
         <item name="calendarDateSelectedRangeBackgroundColor">#ED1B28</item>
-        <item name="calendarDateSelectedTextColor">@color/bpkWhite</item>
+        <item name="calendarDateSelectedTextColor">@color/bpkTextOnDark</item>
     </style>
 
     <style name="LondonThemeFab">
@@ -104,7 +104,7 @@
 
     <style name="LondonThemeBarChart">
         <item name="barChartColumnTitleColor">?bpkPrimaryColor</item>
-        <item name="barChartColumnSubtitleColor">@color/bpkSkyBlue</item>
+        <item name="barChartColumnSubtitleColor">@color/bpkTextLink</item>
         <item name="barChartGroupTitleColor">?bpkPrimaryColor</item>
         <item name="barChartBarBackgroundColor">@color/bpkSurfaceHighlight</item>
         <item name="barChartBarForegroundColor">?bpkPrimaryColor</item>
@@ -130,7 +130,7 @@
         <item name="textFieldColorHintNormal">#9dbde6</item>
         <item name="textFieldColorHintFocused">#6392ce</item>
         <item name="textFieldColorIcon">?bpkPrimaryColor</item>
-        <item name="textFieldBackground">@color/bpkWhite</item>
+        <item name="textFieldBackground">@color/bpkTextOnDark</item>
     </style>
 
     <style name="LondonThemeTextInputLayout">
@@ -202,11 +202,11 @@
 
     <style name="DohaThemeButtonPrimary">
         <item name="buttonBackgroundColor">#ffb300</item>
-        <item name="buttonTextColor">@color/bpkWhite</item>
+        <item name="buttonTextColor">@color/bpkTextOnDark</item>
     </style>
 
     <style name="DohaThemeButtonSecondary">
-        <item name="buttonBackgroundColor">@color/bpkWhite</item>
+        <item name="buttonBackgroundColor">@color/bpkTextOnDark</item>
         <item name="buttonTextColor">#9B104C</item>
     </style>
 
@@ -218,7 +218,7 @@
         <item name="calendarDateSelectedBackgroundColor">#7F083B</item>
         <item name="calendarDateSelectedSameDayBackgroundColor">#9B104C</item>
         <item name="calendarDateSelectedRangeBackgroundColor">#9B104C</item>
-        <item name="calendarDateSelectedTextColor">@color/bpkWhite</item>
+        <item name="calendarDateSelectedTextColor">@color/bpkTextOnDark</item>
     </style>
 
     <style name="DohaThemeChip">
@@ -263,7 +263,7 @@
         <item name="textFieldColorHintNormal">#ffd677</item>
         <item name="textFieldColorHintFocused">#ffca4c</item>
         <item name="textFieldColorIcon">?bpkPrimaryColor</item>
-        <item name="textFieldBackground">@color/bpkWhite</item>
+        <item name="textFieldBackground">@color/bpkTextOnDark</item>
     </style>
 
     <style name="DohaThemeTextInputLayout">
@@ -288,7 +288,7 @@
 
     <style name="DohaThemeBarChart">
         <item name="barChartColumnTitleColor">?bpkPrimaryColor</item>
-        <item name="barChartColumnSubtitleColor">@color/bpkSkyBlue</item>
+        <item name="barChartColumnSubtitleColor">@color/bpkTextLink</item>
         <item name="barChartGroupTitleColor">?bpkPrimaryColor</item>
         <item name="barChartBarBackgroundColor">@color/bpkSurfaceHighlight</item>
         <item name="barChartBarForegroundColor">?bpkPrimaryColor</item>

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/tokens/BpkBorderRadius.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/tokens/BpkBorderRadius.kt
@@ -25,13 +25,17 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 public object BpkBorderRadius {
-    public val Xs: Dp = 4.dp
+    public val Full: Dp = 9_999.dp
 
-    public val Sm: Dp = 8.dp
+    public val Xl: Dp = 40.dp
 
     public val Md: Dp = 12.dp
 
-    public val Lg: Dp = 24.dp
+    public val NavTabs: Dp = 18.dp
 
-    public val Xl: Dp = 40.dp
+    public val Sm: Dp = 8.dp
+
+    public val Xs: Dp = 4.dp
+
+    public val Lg: Dp = 24.dp
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/tokens/BpkTypography.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/tokens/BpkTypography.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.LineHeightStyle
 
 public data class BpkTypography internal constructor(
+    public val baseLarken: TextStyle,
     public val bodyDefault: TextStyle,
     public val bodyLongform: TextStyle,
     public val caption: TextStyle,
@@ -44,9 +45,21 @@ public data class BpkTypography internal constructor(
     public val label1: TextStyle,
     public val label2: TextStyle,
     public val label3: TextStyle,
+    public val smLarken: TextStyle,
     public val subheading: TextStyle,
+    public val xsLarken: TextStyle,
 ) {
     internal constructor(defaultFontFamily: FontFamily = FontFamily.SansSerif) : this(
+      baseLarken = TextStyle(
+        fontWeight = FontWeight.Bold,
+        fontSize = BpkFontSize.Base,
+        lineHeight = BpkLineHeight.BaseTight,
+        fontFamily = defaultFontFamily,
+        lineHeightStyle = LineHeightStyle(
+            alignment = LineHeightStyle.Alignment(topRatio = 0.2f),
+            trim = LineHeightStyle.Trim.None,
+        ),
+      ),
       bodyDefault = TextStyle(
         fontWeight = FontWeight.Normal,
         fontSize = BpkFontSize.Base,
@@ -222,10 +235,30 @@ public data class BpkTypography internal constructor(
             trim = LineHeightStyle.Trim.None,
         ),
       ),
+      smLarken = TextStyle(
+        fontWeight = FontWeight.Bold,
+        fontSize = BpkFontSize.Sm,
+        lineHeight = BpkLineHeight.Sm,
+        fontFamily = defaultFontFamily,
+        lineHeightStyle = LineHeightStyle(
+            alignment = LineHeightStyle.Alignment(topRatio = 0.2f),
+            trim = LineHeightStyle.Trim.None,
+        ),
+      ),
       subheading = TextStyle(
         fontWeight = FontWeight.Normal,
         fontSize = BpkFontSize.Xl,
         lineHeight = BpkLineHeight.Xl,
+        fontFamily = defaultFontFamily,
+        lineHeightStyle = LineHeightStyle(
+            alignment = LineHeightStyle.Alignment(topRatio = 0.2f),
+            trim = LineHeightStyle.Trim.None,
+        ),
+      ),
+      xsLarken = TextStyle(
+        fontWeight = FontWeight.Bold,
+        fontSize = BpkFontSize.Xs,
+        lineHeight = BpkLineHeight.Xs,
         fontFamily = defaultFontFamily,
         lineHeightStyle = LineHeightStyle(
             alignment = LineHeightStyle.Alignment(topRatio = 0.2f),

--- a/docs/view/Overlay/README.md
+++ b/docs/view/Overlay/README.md
@@ -39,7 +39,7 @@ Example of a Overlay in XML
       android:layout_height="wrap_content"
       android:layout_gravity="center"
       android:text="Rounded corners"
-      android:textColor="@color/bpkWhite" />
+      android:textColor="@color/bpkTextOnDark" />
 
   </net.skyscanner.backpack.overlay.BpkOverlay>
 ```

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     },
     "homepage": "https://github.com/Skyscanner/backpack-android#readme",
     "devDependencies": {
-        "@skyscanner/bpk-foundations-android": "^21.1.0",
+        "@skyscanner/bpk-foundations-android": "^22.0.0",
         "@skyscanner/bpk-svgs": "^20.4.1"
     }
 }


### PR DESCRIPTION
With the recent backpack fix from Muon, backpack android can now use the latest version of foundations without issue, with this bump the lingering static tokens left in backpack can now be removed once and for all

This PR can be found here - https://github.com/Skyscanner/backpack-android/pull/2347

This pull request introduces a series of updates to improve color consistency across the Backpack Android components and themes, as well as enhancements to the Backpack Compose tokens for typography and border radius. The changes primarily focus on replacing outdated color references, adding new typography styles, and modifying border radius values for better design alignment.



### Color consistency improvements:
* Updated color references in `BpkSpinnerTest.kt` to use `bpkTextLink` and `bpkTextOnDark` for better alignment with the design system.
* Modified colors in `BpkBadge.kt`, `BpkHorizontalNav.kt`, and `BpkOverlay.kt` to replace deprecated or outdated color values with `bpkTextOnDark` and `bpkTextOnLight`. [[1]](diffhunk://#diff-1924eccfcedc7f93c94ffb145a00a98e4d0a71106fa2775e3a31b346cf466707L91-R91) [[2]](diffhunk://#diff-c191fbd3ea17fb4e409ecce063233a4293b2ba90c0c1e36f02bda07ea55b4230L64-R65) [[3]](diffhunk://#diff-ba7f07ed258f2b60cf261a9646336774b61f2a7909400dee17d86b6b25dca19dL68-R68)
* Adjusted multiple theme styles in `themes.xml` to replace `bpkWhite` and `bpkSkyBlue` with `bpkTextOnDark` and `bpkTextLink`. [[1]](diffhunk://#diff-683326448134b180d2575e28185ff2552667470a4c81d10271c59f0de0a781ffL51-R65) [[2]](diffhunk://#diff-683326448134b180d2575e28185ff2552667470a4c81d10271c59f0de0a781ffL81-R81) [[3]](diffhunk://#diff-683326448134b180d2575e28185ff2552667470a4c81d10271c59f0de0a781ffL107-R107) [[4]](diffhunk://#diff-683326448134b180d2575e28185ff2552667470a4c81d10271c59f0de0a781ffL133-R133) [[5]](diffhunk://#diff-683326448134b180d2575e28185ff2552667470a4c81d10271c59f0de0a781ffL205-R209) [[6]](diffhunk://#diff-683326448134b180d2575e28185ff2552667470a4c81d10271c59f0de0a781ffL221-R221) [[7]](diffhunk://#diff-683326448134b180d2575e28185ff2552667470a4c81d10271c59f0de0a781ffL266-R266) [[8]](diffhunk://#diff-683326448134b180d2575e28185ff2552667470a4c81d10271c59f0de0a781ffL291-R291)

### Backpack Compose enhancements:
* Rearranged and added new border radius values (`Full`, `NavTabs`) in `BpkBorderRadius.kt` for improved flexibility in component design.
* Introduced new typography styles (`baseLarken`, `smLarken`, `xsLarken`) in `BpkTypography.kt` to expand the available text options and align with design guidelines. [[1]](diffhunk://#diff-87c20a256ebf7678a0f662d03903bcadc768a506a3c954f487920ea4d41f30feR30) [[2]](diffhunk://#diff-87c20a256ebf7678a0f662d03903bcadc768a506a3c954f487920ea4d41f30feR48-R62) [[3]](diffhunk://#diff-87c20a256ebf7678a0f662d03903bcadc768a506a3c954f487920ea4d41f30feR238-R247) [[4]](diffhunk://#diff-87c20a256ebf7678a0f662d03903bcadc768a506a3c954f487920ea4d41f30feR258-R267)

### Documentation and dependency updates:
* Updated the `Overlay` component documentation to reflect the new `bpkTextOnDark` color usage.
* Upgraded the `@skyscanner/bpk-foundations-android` dependency in `package.json` to version `^22.0.0`.With the recent fix for the trailing backpackj This pull request primarily updates color references across multiple components and themes to improve visual consistency and accessibility. Additionally, it introduces new typography styles and adjusts border radius tokens in the Backpack Compose library.



### Color Updates for Accessibility and Consistency:
* Updated color references in `BpkSpinnerTest.kt` to replace `bpkSkyBlue` and `bpkWhite` with `bpkTextLink` and `bpkTextOnDark`, respectively.
* Modified various color attributes in `themes.xml` for buttons, calendar, text fields, and bar charts to use `bpkTextOnDark` and `bpkTextLink` instead of `bpkWhite` and `bpkSkyBlue`. [[1]](diffhunk://#diff-683326448134b180d2575e28185ff2552667470a4c81d10271c59f0de0a781ffL51-R65) [[2]](diffhunk://#diff-683326448134b180d2575e28185ff2552667470a4c81d10271c59f0de0a781ffL81-R81) [[3]](diffhunk://#diff-683326448134b180d2575e28185ff2552667470a4c81d10271c59f0de0a781ffL107-R107) [[4]](diffhunk://#diff-683326448134b180d2575e28185ff2552667470a4c81d10271c59f0de0a781ffL133-R133) [[5]](diffhunk://#diff-683326448134b180d2575e28185ff2552667470a4c81d10271c59f0de0a781ffL205-R209) [[6]](diffhunk://#diff-683326448134b180d2575e28185ff2552667470a4c81d10271c59f0de0a781ffL221-R221) [[7]](diffhunk://#diff-683326448134b180d2575e28185ff2552667470a4c81d10271c59f0de0a781ffL266-R266) [[8]](diffhunk://#diff-683326448134b180d2575e28185ff2552667470a4c81d10271c59f0de0a781ffL291-R291)
* Adjusted color references in `BpkBadge.kt`, `BpkHorizontalNav.kt`, `BpkOverlay.kt`, and `BpkSpinner.kt` to improve contrast and align with updated design guidelines. [[1]](diffhunk://#diff-1924eccfcedc7f93c94ffb145a00a98e4d0a71106fa2775e3a31b346cf466707L91-R91) [[2]](diffhunk://#diff-c191fbd3ea17fb4e409ecce063233a4293b2ba90c0c1e36f02bda07ea55b4230L64-R65) [[3]](diffhunk://#diff-ba7f07ed258f2b60cf261a9646336774b61f2a7909400dee17d86b6b25dca19dL68-R68) [[4]](diffhunk://#diff-d0e32d51852dec00ef677121b26aeead804f18250cc772b33f3e19474ac8b10aL64-R64)
* Updated the `bpk_dialog_flare.xml` layout and `Overlay/README.md` documentation to reflect the new color scheme. [[1]](diffhunk://#diff-df9b759270842a34eb3f88802375b36773ec3ed6d2b9615d7053ee2845b87040L40-R40) [[2]](diffhunk://#diff-b6da0f52a6e1d525f73f951b0777e9c77360b113a034074de576c9b770c0ef16L42-R42)

### Typography Enhancements:
* Introduced new typography styles (`baseLarken`, `smLarken`, `xsLarken`) in `BpkTypography.kt` to support additional text formatting options. [[1]](diffhunk://#diff-87c20a256ebf7678a0f662d03903bcadc768a506a3c954f487920ea4d41f30feR30) [[2]](diffhunk://#diff-87c20a256ebf7678a0f662d03903bcadc768a506a3c954f487920ea4d41f30feR48-R62) [[3]](diffhunk://#diff-87c20a256ebf7678a0f662d03903bcadc768a506a3c954f487920ea4d41f30feR238-R247) [[4]](diffhunk://#diff-87c20a256ebf7678a0f662d03903bcadc768a506a3c954f487920ea4d41f30feR258-R267)

### Border Radius Adjustments:
* Reorganized and added new border radius tokens (`Full`, `NavTabs`) in `BpkBorderRadius.kt` for better flexibility in UI design.

### Dependency Update:
* Updated the `@skyscanner/bpk-foundations-android` dependency in `package.json` from version `21.1.0` to `22.0.0`.<!--
Thanks for contributing to Backpack :pray:

