### PR TITLE
DON-1923 enable title color and collaspe background color to consumer

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/navbar/BpkNavBar.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/navbar/BpkNavBar.kt
@@ -38,6 +38,11 @@ import net.skyscanner.backpack.util.resolveThemeDimen
 import net.skyscanner.backpack.util.use
 import androidx.core.graphics.drawable.toDrawable
 
+enum class NavBarStyle {
+    Default,
+    SurfaceContrast,
+}
+
 class BpkNavBar @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
@@ -60,12 +65,26 @@ class BpkNavBar @JvmOverloads constructor(
         collapsingLayout.addView(it, params)
     }
 
-    var titleColor: Int = context.getColor(R.color.bpkTextPrimary)
+    var style: NavBarStyle = NavBarStyle.Default
         set(value) {
             field = value
-            toolbar.setTitleTextColor(value)
-            collapsingLayout.setCollapsedTitleTextColor(value)
-            collapsingLayout.setExpandedTitleColor(value)
+            when (value) {
+                NavBarStyle.Default -> {
+                    collapsingLayout.contentScrim = context.getColor(R.color.bpkSurfaceDefault).toDrawable()
+                    toolbar.setBackgroundColor(context.getColor(R.color.bpkCanvas))
+                    toolbar.setTitleTextColor(context.getColor(R.color.bpkTextPrimary))
+                    collapsingLayout.setCollapsedTitleTextColor(context.getColor(R.color.bpkTextPrimary))
+                    collapsingLayout.setExpandedTitleColor(context.getColor(R.color.bpkTextPrimary))
+                }
+                NavBarStyle.SurfaceContrast -> {
+                    collapsingLayout.contentScrim = context.getColor(R.color.bpkSurfaceContrast).toDrawable()
+                    toolbar.setBackgroundColor(context.getColor(R.color.bpkSurfaceContrast))
+                    toolbar.setTitleTextColor(context.getColor(R.color.bpkTextOnDark))
+                    collapsingLayout.setCollapsedTitleTextColor(context.getColor(R.color.bpkTextOnDark))
+                    collapsingLayout.setExpandedTitleColor(context.getColor(R.color.bpkTextOnDark))
+                    collapsingLayout.setBackgroundColor(context.getColor(R.color.bpkSurfaceContrast))
+                }
+            }
         }
 
     var title: CharSequence?
@@ -114,12 +133,6 @@ class BpkNavBar @JvmOverloads constructor(
                 value.invoke(it)
                 return@setOnMenuItemClickListener true
             }
-        }
-
-    var collapsedBackgroundColor: Int? = null
-        set(value) {
-            field = value
-            collapsingLayout.contentScrim = value?.toDrawable()
         }
 
     var navIconContentDescription: CharSequence? = null

--- a/Backpack/src/main/java/net/skyscanner/backpack/navbar/BpkNavBar.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/navbar/BpkNavBar.kt
@@ -150,7 +150,6 @@ class BpkNavBar @JvmOverloads constructor(
         this.icon = navIcon
         this.navIconContentDescription = navIconContentDescription
         this.navAction = navAction
-        this.toolbar.navigationContentDescription = navIconContentDescription
         this.menu = menu
         this.stateListAnimator = shadowStateListAnimator()
     }

--- a/Backpack/src/main/java/net/skyscanner/backpack/navbar/BpkNavBar.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/navbar/BpkNavBar.kt
@@ -21,7 +21,6 @@ package net.skyscanner.backpack.navbar
 import android.animation.ObjectAnimator
 import android.animation.StateListAnimator
 import android.content.Context
-import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.view.Menu
@@ -37,6 +36,7 @@ import net.skyscanner.backpack.navbar.internal.BpkToolbar
 import net.skyscanner.backpack.util.createContextThemeWrapper
 import net.skyscanner.backpack.util.resolveThemeDimen
 import net.skyscanner.backpack.util.use
+import androidx.core.graphics.drawable.toDrawable
 
 class BpkNavBar @JvmOverloads constructor(
     context: Context,
@@ -59,6 +59,14 @@ class BpkNavBar @JvmOverloads constructor(
 
         collapsingLayout.addView(it, params)
     }
+
+    var titleColor: Int = context.getColor(R.color.bpkTextPrimary)
+        set(value) {
+            field = value
+            toolbar.setTitleTextColor(value)
+            collapsingLayout.setCollapsedTitleTextColor(value)
+            collapsingLayout.setExpandedTitleColor(value)
+        }
 
     var title: CharSequence?
         get() = toolbar.title
@@ -108,6 +116,18 @@ class BpkNavBar @JvmOverloads constructor(
             }
         }
 
+    var collapsedBackgroundColor: Int? = null
+        set(value) {
+            field = value
+            collapsingLayout.contentScrim = value?.toDrawable()
+        }
+
+    var navIconContentDescription: CharSequence? = null
+        set(value) {
+            field = value
+            toolbar.navigationContentDescription = value
+        }
+
     init {
         var title: CharSequence?
         var navIcon: Drawable?
@@ -125,9 +145,10 @@ class BpkNavBar @JvmOverloads constructor(
             navIconContentDescription = it.getString(R.styleable.BpkNavBar_navBarActionContentDescription)
         }
 
-        this.background = ColorDrawable(context.getColor(R.color.bpkCanvas))
+        this.background = context.getColor(R.color.bpkCanvas).toDrawable()
         this.title = title
         this.icon = navIcon
+        this.navIconContentDescription = navIconContentDescription
         this.navAction = navAction
         this.toolbar.navigationContentDescription = navIconContentDescription
         this.menu = menu

--- a/app/src/main/java/net/skyscanner/backpack/demo/stories/NavBarStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/stories/NavBarStory.kt
@@ -28,6 +28,7 @@ import net.skyscanner.backpack.meta.StoryKind
 import net.skyscanner.backpack.demo.meta.ViewStory
 import net.skyscanner.backpack.demo.ui.AndroidLayout
 import net.skyscanner.backpack.navbar.BpkNavBar
+import net.skyscanner.backpack.navbar.NavBarStyle
 import net.skyscanner.backpack.toast.BpkToast
 
 @Composable
@@ -56,6 +57,14 @@ fun NavBarStoryWithIcon(modifier: Modifier = Modifier) =
 fun NavBarStoryWithMenu(modifier: Modifier = Modifier) =
     NavBarDemo(R.layout.fragment_nav_bar_with_menu, modifier) {
         setExpanded(false)
+    }
+
+@Composable
+@NavBarComponent
+@ViewStory("SurfaceContrast Style", StoryKind.DemoOnly)
+fun NavBarStoryWithSurfaceContrast(modifier: Modifier = Modifier) =
+    NavBarDemo(R.layout.fragment_nav_bar_with_menu, modifier) {
+        style = NavBarStyle.SurfaceContrast
     }
 
 @Composable


### PR DESCRIPTION
This PR is to exposing the title color and collaspe background color to the consumer, as the carhire dayview need this to have the same ui as before 

<img width="1080" height="2424" alt="Screenshot_20250811_103600" src="https://github.com/user-attachments/assets/7518a751-f975-42b8-ba0f-b1e1504eaac2" />

<!--

Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
