### PR TITLE
[DON-1968] Refactor moved CalendarDayCellTestTag from internal package

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/CalendarDayCellTestTag.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/CalendarDayCellTestTag.kt
@@ -1,5 +1,3 @@
-package net.skyscanner.backpack.compose.calendar.internal
-
 /*
  * Backpack for Android - Skyscanner's Design System
  *
@@ -17,6 +15,8 @@ package net.skyscanner.backpack.compose.calendar.internal
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+package net.skyscanner.backpack.compose.calendar
 
 enum class CalendarDayCellTestTag {
     INACTIVE,

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/internal/data/CalendarCell.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/calendar/internal/data/CalendarCell.kt
@@ -23,7 +23,7 @@ import android.text.style.TtsSpan
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.core.text.buildSpannedString
-import net.skyscanner.backpack.compose.calendar.internal.CalendarDayCellTestTag
+import net.skyscanner.backpack.compose.calendar.CalendarDayCellTestTag
 import net.skyscanner.backpack.compose.calendar.CalendarParams
 import net.skyscanner.backpack.compose.calendar.CalendarParams.DayCellAccessibilityLabel
 import net.skyscanner.backpack.compose.calendar.CalendarSelection


### PR DESCRIPTION
[DON-1968] Refactor moved CalendarDayCellTestTag from internal package

This PR moves a missed file out of the internal package to public.


+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)


[DON-1968]: https://skyscanner.atlassian.net/browse/DON-1968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ