### PR TITLE
[DON-1958] Add missing spacing sizes to Android

### DIFF
--- a/Backpack/src/main/res/values-night/backpack.semantic.color.xml
+++ b/Backpack/src/main/res/values-night/backpack.semantic.color.xml
@@ -52,4 +52,5 @@
     <color name="bpkTextPrimary">#ffffffff</color>
     <color name="bpkTextPrimaryInverse">#ff010913</color>
     <color name="bpkTextSecondary">#ffbdc4cb</color>
+    <color name="bpkTextSuccess">#ff62f1c6</color>
 </resources>

--- a/Backpack/src/main/res/values/backpack.dimensions.spacing.xml
+++ b/Backpack/src/main/res/values/backpack.dimensions.spacing.xml
@@ -20,11 +20,13 @@
 
   <!-- THIS FILE IS AUTO GENERATED. DO NOT MODIFY! -->
 
-    <dimen name="bpkSpacingSm">4dp</dimen>
-    <dimen name="bpkSpacingMd">8dp</dimen>
     <dimen name="bpkSpacingBase">16dp</dimen>
-    <dimen name="bpkSpacingLg">24dp</dimen>
+    <dimen name="bpkSpacingXxxl">64dp</dimen>
     <dimen name="bpkSpacingXl">32dp</dimen>
     <dimen name="bpkSpacingXxl">40dp</dimen>
+    <dimen name="bpkSpacingXxxxl">96dp</dimen>
+    <dimen name="bpkSpacingMd">8dp</dimen>
     <dimen name="bpkSpacingNone">0dp</dimen>
+    <dimen name="bpkSpacingSm">4dp</dimen>
+    <dimen name="bpkSpacingLg">24dp</dimen>
 </resources>

--- a/Backpack/src/main/res/values/backpack.semantic.color.xml
+++ b/Backpack/src/main/res/values/backpack.semantic.color.xml
@@ -52,4 +52,5 @@
     <color name="bpkTextPrimary">#ff161616</color>
     <color name="bpkTextPrimaryInverse">#ffffffff</color>
     <color name="bpkTextSecondary">#ff626971</color>
+    <color name="bpkTextSuccess">#ff0c838a</color>
 </resources>

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/tokens/BpkColors.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/tokens/BpkColors.kt
@@ -58,6 +58,7 @@ public class BpkColors private constructor(
     public val textPrimary: Color,
     public val textPrimaryInverse: Color,
     public val textSecondary: Color,
+    public val textSuccess: Color,
 ) {
     internal companion object {
         public fun light(
@@ -93,6 +94,7 @@ public class BpkColors private constructor(
             textPrimary: Color = Color(0xFF161616),
             textPrimaryInverse: Color = Color(0xFFFFFFFF),
             textSecondary: Color = Color(0xFF626971),
+            textSuccess: Color = Color(0xFF0C838A),
         ): BpkColors = BpkColors(
             isLight = true,
             canvas = canvas,
@@ -127,6 +129,7 @@ public class BpkColors private constructor(
             textPrimary = textPrimary,
             textPrimaryInverse = textPrimaryInverse,
             textSecondary = textSecondary,
+            textSuccess = textSuccess,
         )
 
         public fun dark(
@@ -162,6 +165,7 @@ public class BpkColors private constructor(
             textPrimary: Color = Color(0xFFFFFFFF),
             textPrimaryInverse: Color = Color(0xFF010913),
             textSecondary: Color = Color(0xFFBDC4CB),
+            textSuccess: Color = Color(0xFF62F1C6),
         ): BpkColors = BpkColors(
             isLight = false,
             canvas = canvas,
@@ -196,6 +200,7 @@ public class BpkColors private constructor(
             textPrimary = textPrimary,
             textPrimaryInverse = textPrimaryInverse,
             textSecondary = textSecondary,
+            textSuccess = textSuccess,
         )
     }
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/tokens/BpkSpacing.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/tokens/BpkSpacing.kt
@@ -25,17 +25,21 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
 public object BpkSpacing {
-    public val Sm: Dp = 4.dp
-
-    public val Md: Dp = 8.dp
-
     public val Base: Dp = 16.dp
 
-    public val Lg: Dp = 24.dp
+    public val Xxxl: Dp = 64.dp
 
     public val Xl: Dp = 32.dp
 
     public val Xxl: Dp = 40.dp
 
+    public val Xxxxl: Dp = 96.dp
+
+    public val Md: Dp = 8.dp
+
     public val None: Dp = 0.dp
+
+    public val Sm: Dp = 4.dp
+
+    public val Lg: Dp = 24.dp
 }

--- a/buildSrc/src/main/kotlin/net/skyscanner/backpack/tokens/BpkDimensions.kt
+++ b/buildSrc/src/main/kotlin/net/skyscanner/backpack/tokens/BpkDimensions.kt
@@ -33,7 +33,7 @@ object BpkDimension {
         object Spacing : Category() {
             override fun invoke(source: Map<String, Any>): BpkDimensions =
                 parseDimensions(source, "spacings", "SPACING_") {
-                    it.key.toLowerCase() in setOf("base", "lg", "md", "none", "sm", "xl", "xxl")
+                    it.key.toLowerCase() in setOf("base", "lg", "md", "none", "sm", "xl", "xxl", "xxxl", "xxxxl")
                 }
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.0.0",
             "license": "Apache-2.0",
             "devDependencies": {
-                "@skyscanner/bpk-foundations-android": "^22.0.0",
+                "@skyscanner/bpk-foundations-android": "^22.3.0",
                 "@skyscanner/bpk-svgs": "^20.4.1"
             },
             "engines": {
@@ -18,20 +18,20 @@
             }
         },
         "node_modules/@skyscanner/bpk-foundations-android": {
-            "version": "22.0.0",
-            "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-android/-/bpk-foundations-android-22.0.0.tgz",
-            "integrity": "sha512-Ru8JbIEIX5S3EdLqiG/2RrGmSNQg23SnYr4EkAYhl67LiX/g4VCyicQxw3edTqVveHqs0joeMLevljSoSpbN2Q==",
+            "version": "22.3.0",
+            "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-android/-/bpk-foundations-android-22.3.0.tgz",
+            "integrity": "sha512-ANyfAnRBcSU1vDvwTttUght7FJu2rGTudSzuBLV2Xq8/l5h8ya9g8Z8+bbaocTD45PHjU4c/X/le3UIpHleBrg==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@skyscanner/bpk-foundations-common": "^22.0.0",
+                "@skyscanner/bpk-foundations-common": "^22.3.0",
                 "color": "^5.0.0"
             }
         },
         "node_modules/@skyscanner/bpk-foundations-common": {
-            "version": "22.0.0",
-            "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-22.0.0.tgz",
-            "integrity": "sha512-jOymcaYniJn5xdyAEx1hyJ9hJ/uYqQFvdV16JCgvj9WWI1s12xYH3OhzYMmYHDUEKO3aDP1Fy+84jFEEFgBN3g==",
+            "version": "22.3.0",
+            "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-22.3.0.tgz",
+            "integrity": "sha512-QrZP/jEIT1RR7+CIhlg7VLMH1HE1KanuF9Kg2kojPYMexRXScXw8jNDu25nTEI0/4TjyZX53chJQMEbLfcn86A==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -101,19 +101,19 @@
     },
     "dependencies": {
         "@skyscanner/bpk-foundations-android": {
-            "version": "22.0.0",
-            "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-android/-/bpk-foundations-android-22.0.0.tgz",
-            "integrity": "sha512-Ru8JbIEIX5S3EdLqiG/2RrGmSNQg23SnYr4EkAYhl67LiX/g4VCyicQxw3edTqVveHqs0joeMLevljSoSpbN2Q==",
+            "version": "22.3.0",
+            "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-android/-/bpk-foundations-android-22.3.0.tgz",
+            "integrity": "sha512-ANyfAnRBcSU1vDvwTttUght7FJu2rGTudSzuBLV2Xq8/l5h8ya9g8Z8+bbaocTD45PHjU4c/X/le3UIpHleBrg==",
             "dev": true,
             "requires": {
-                "@skyscanner/bpk-foundations-common": "^22.0.0",
+                "@skyscanner/bpk-foundations-common": "^22.3.0",
                 "color": "^5.0.0"
             }
         },
         "@skyscanner/bpk-foundations-common": {
-            "version": "22.0.0",
-            "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-22.0.0.tgz",
-            "integrity": "sha512-jOymcaYniJn5xdyAEx1hyJ9hJ/uYqQFvdV16JCgvj9WWI1s12xYH3OhzYMmYHDUEKO3aDP1Fy+84jFEEFgBN3g==",
+            "version": "22.3.0",
+            "resolved": "https://registry.npmjs.org/@skyscanner/bpk-foundations-common/-/bpk-foundations-common-22.3.0.tgz",
+            "integrity": "sha512-QrZP/jEIT1RR7+CIhlg7VLMH1HE1KanuF9Kg2kojPYMexRXScXw8jNDu25nTEI0/4TjyZX53chJQMEbLfcn86A==",
             "dev": true,
             "requires": {
                 "color": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     },
     "homepage": "https://github.com/Skyscanner/backpack-android#readme",
     "devDependencies": {
-        "@skyscanner/bpk-foundations-android": "^22.0.0",
+        "@skyscanner/bpk-foundations-android": "^22.3.0",
         "@skyscanner/bpk-svgs": "^20.4.1"
     }
 }


### PR DESCRIPTION
Added additional sizes to the backpack dimensions Gradle script

Bump to backpack foundations to 22.3.0 - Includes spacing and text success colour.

<img width="270" height="600" alt="Screenshot_20250815_112112" src="https://github.com/user-attachments/assets/36241d96-d059-4dc3-a2fa-1b221c0ba96b" />
<img width="270" height="600" alt="Screenshot_20250815_112049" src="https://github.com/user-attachments/assets/684ed74a-1115-4285-b569-058aa83c6b20" />


+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
