### PR TITLE
DON-2007 PoC for Backpack chokepoints

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/button/BpkButton.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/button/BpkButton.kt
@@ -27,6 +27,7 @@ import androidx.annotation.Dimension
 import androidx.annotation.IntDef
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.graphics.withTranslation
+import androidx.core.view.doOnAttach
 import androidx.swiperefreshlayout.widget.CircularProgressDrawable
 import net.skyscanner.backpack.R
 import net.skyscanner.backpack.button.internal.BpkButtonBase
@@ -41,7 +42,9 @@ import net.skyscanner.backpack.button.internal.horizontalPadding
 import net.skyscanner.backpack.button.internal.horizontalSpacing
 import net.skyscanner.backpack.button.internal.iconSize
 import net.skyscanner.backpack.button.internal.minHeight
+import net.skyscanner.backpack.configuration.BpkConfiguration
 import net.skyscanner.backpack.text.BpkText
+import net.skyscanner.backpack.util.runOnFirstVisible
 import net.skyscanner.backpack.util.unsafeLazy
 import net.skyscanner.backpack.util.use
 import kotlin.math.roundToInt
@@ -154,6 +157,11 @@ open class BpkButton(
         updateSize()
         applyStyle(style)
         BpkText.getFont(context, BpkText.TextStyle.Label1).applyTo(this)
+        doOnAttach {
+            runOnFirstVisible {
+                BpkConfiguration.performLogging()
+            }
+        }
     }
 
     override fun setEnabled(enabled: Boolean) {

--- a/Backpack/src/main/java/net/skyscanner/backpack/button/internal/ButtonStyles.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/button/internal/ButtonStyles.kt
@@ -20,6 +20,7 @@ package net.skyscanner.backpack.button.internal
 
 import android.content.Context
 import net.skyscanner.backpack.R
+import net.skyscanner.backpack.configuration.BpkConfiguration
 
 internal sealed class ButtonStyles : (Context) -> ButtonStyle {
 
@@ -34,7 +35,20 @@ internal sealed class ButtonStyles : (Context) -> ButtonStyle {
     }
 
     data object Secondary : ButtonStyles() {
-        override fun invoke(context: Context) = ButtonStyle.fromTheme(
+        override fun invoke(context: Context) = BpkConfiguration.buttonConfig?.legacyStyle?.let { legacyStyle ->
+            ButtonStyle(
+                context = context,
+                bgColor = legacyStyle.bgColor,
+                bgPressedColor = legacyStyle.bgPressedColor,
+                bgLoadingColor = legacyStyle.bgLoadingColor,
+                bgDisabledColor = legacyStyle.bgDisabledColor,
+                contentColor = legacyStyle.contentColor,
+                contentPressedColor = legacyStyle.contentPressedColor,
+                contentDisabledColor = legacyStyle.contentDisabledColor,
+                contentLoadingColor = legacyStyle.contentLoadingColor,
+                rippleColor = legacyStyle.rippleColor,
+            )
+        } ?: ButtonStyle.fromTheme(
             context = context,
             style = R.attr.bpkButtonSecondaryStyle,
             bgColorRes = R.color.__privateButtonSecondaryNormalBackground,

--- a/backpack-common/src/main/kotlin/net/skyscanner/backpack/configuration/BpkConfiguration.kt
+++ b/backpack-common/src/main/kotlin/net/skyscanner/backpack/configuration/BpkConfiguration.kt
@@ -18,10 +18,30 @@
 
 package net.skyscanner.backpack.configuration
 
+import androidx.annotation.ColorInt
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import net.skyscanner.backpack.common.R
+
 object BpkConfiguration {
     sealed class BpkExperimentalComponent {
 
-        data object BpkButton : BpkExperimentalComponent()
+        data class BpkButton(
+            val legacyStyle: LegacyStyle? = null,
+            val backgroundColor: Color? = null,
+        ) : BpkExperimentalComponent() {
+            data class LegacyStyle(
+                @ColorInt val bgColor: Int,
+                @ColorInt val bgPressedColor: Int,
+                @ColorInt val bgLoadingColor: Int,
+                @ColorInt val bgDisabledColor: Int,
+                @ColorInt val contentColor: Int,
+                @ColorInt val contentPressedColor: Int,
+                @ColorInt val contentDisabledColor: Int,
+                @ColorInt val contentLoadingColor: Int,
+                @ColorInt val rippleColor: Int,
+            )
+        }
 
         data object BpkText : BpkExperimentalComponent()
 
@@ -31,6 +51,8 @@ object BpkConfiguration {
     }
 
     private var _hasSet: Boolean = false
+
+    var logging: (() -> Unit)? = null
 
     fun setConfigs(
         chipConfig: Boolean = false,
@@ -46,7 +68,10 @@ object BpkConfiguration {
             this.chipConfig = BpkExperimentalComponent.BpkChip
         }
         if (buttonConfig) {
-            this.buttonConfig = BpkExperimentalComponent.BpkButton
+            this.buttonConfig = BpkExperimentalComponent.BpkButton(
+                null,
+                colorResource(R.color.bpkTextSuccess),
+            )
         }
         if (textConfig) {
             this.textConfig = BpkExperimentalComponent.BpkText
@@ -58,6 +83,11 @@ object BpkConfiguration {
 
     var chipConfig: BpkExperimentalComponent.BpkChip? = null
         private set
+
+    fun performLogging() {
+        logging?.invoke()
+        logging = null
+    }
 
     var buttonConfig: BpkExperimentalComponent.BpkButton? = null
         private set

--- a/backpack-common/src/main/kotlin/net/skyscanner/backpack/util/ViewUtils.kt
+++ b/backpack-common/src/main/kotlin/net/skyscanner/backpack/util/ViewUtils.kt
@@ -1,0 +1,63 @@
+package net.skyscanner.backpack.util
+
+import android.graphics.Rect
+import android.view.View
+import android.view.ViewTreeObserver
+import androidx.core.view.doOnAttach
+
+/**
+ * Runs [block] immediately if the View is currently visible on screen.
+ * Returns true if executed, false otherwise.
+ */
+inline fun View.runIfCurrentlyVisible(crossinline block: () -> Unit): Boolean {
+    if (!isAttachedToWindow || !isShown || width == 0 || height == 0) return false
+
+    val visibleBounds = Rect()
+    if (!getGlobalVisibleRect(visibleBounds) ||
+        visibleBounds.width() <= 0 ||
+        visibleBounds.height() <= 0
+    ) {
+        return false
+    }
+
+    block()
+    return true
+}
+
+/**
+ * Runs [block] once, the first time this View is both attached and visible on screen.
+ * If already visible, executes immediately.
+ */
+inline fun View.runOnFirstVisible(crossinline block: () -> Unit) {
+    // Fast path: already visible
+    if (runIfCurrentlyVisible(block)) return
+
+    doOnAttach {
+        val viewTreeObserverRef = viewTreeObserver
+
+        val preDrawListener = object : ViewTreeObserver.OnPreDrawListener {
+            override fun onPreDraw(): Boolean {
+                if (!viewTreeObserverRef.isAlive) return true
+
+                if (runIfCurrentlyVisible(block)) {
+                    viewTreeObserverRef.removeOnPreDrawListener(this)
+                }
+                return true // don't block rendering
+            }
+        }
+
+        viewTreeObserverRef.addOnPreDrawListener(preDrawListener)
+
+        // Clean up if detached before becoming visible
+        addOnAttachStateChangeListener(object : View.OnAttachStateChangeListener {
+            override fun onViewDetachedFromWindow(v: View) {
+                if (viewTreeObserverRef.isAlive) {
+                    viewTreeObserverRef.removeOnPreDrawListener(preDrawListener)
+                }
+                v.removeOnAttachStateChangeListener(this)
+            }
+
+            override fun onViewAttachedToWindow(v: View) = Unit
+        })
+    }
+}

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/button/internal/Colors.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/button/internal/Colors.kt
@@ -26,6 +26,7 @@ import net.skyscanner.backpack.compose.theme.BpkTheme
 import net.skyscanner.backpack.compose.tokens.internal.BpkButtonColors
 import net.skyscanner.backpack.compose.utils.animateAsColor
 import net.skyscanner.backpack.compose.utils.dynamicColorOf
+import net.skyscanner.backpack.configuration.BpkConfiguration
 
 @Composable
 internal fun BpkButtonType.disabledBackgroundColor(): Color =
@@ -68,7 +69,7 @@ internal fun BpkButtonType.backgroundColor(interactionSource: InteractionSource)
 private fun BpkButtonType.defaultBackgroundColor(): Color =
     when (this) {
         BpkButtonType.Primary -> BpkButtonColors.primaryNormalBackground
-        BpkButtonType.Secondary -> BpkButtonColors.secondaryNormalBackground
+        BpkButtonType.Secondary -> BpkConfiguration.buttonConfig?.backgroundColor.also { BpkConfiguration.performLogging() } ?: BpkButtonColors.secondaryNormalBackground
         BpkButtonType.Featured -> BpkButtonColors.featuredNormalBackground
         BpkButtonType.PrimaryOnDark -> BpkButtonColors.primaryOnDarkNormalBackground
         BpkButtonType.PrimaryOnLight -> BpkButtonColors.primaryOnLightNormalBackground


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

PoC for chokepoint emission in Backpack Experiments.
We only want to emit once and only when the component is visible. 
This was trivial for Compose but we had to do funky things for Views as they can be created while not visible.
With thanks to @LokmaneKrizou for the Views extension functions.

On the app side by setting the logging as so

```
 BpkConfiguration.setConfigs(buttonConfig = featureflag)
 BpkConfiguration.logging = {
    logger.log(...)
}
```


+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
