### PR TITLE
donburi/add convert to segment extension 2

### DIFF
--- a/app/src/main/java/net/skyscanner/backpack/demo/compose/LinkStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/compose/LinkStory.kt
@@ -34,6 +34,7 @@ import net.skyscanner.backpack.compose.divider.BpkDivider
 import net.skyscanner.backpack.compose.link.BpkLink
 import net.skyscanner.backpack.compose.link.BpkLinkStyle
 import net.skyscanner.backpack.compose.link.buildTextSegments
+import net.skyscanner.backpack.compose.link.convertToTextSegments
 import net.skyscanner.backpack.compose.text.BpkText
 import net.skyscanner.backpack.compose.theme.BpkTheme
 import net.skyscanner.backpack.compose.tokens.BpkSpacing
@@ -81,6 +82,7 @@ private fun StoryContent(
         { LinkWithoutUrlExample(style = style, onNotification = showNotification) },
         { TextWithMultipleLinksExample(style = style, onNotification = showNotification) },
         { TypeSafeBuilderExample(style = style, onNotification = showNotification) },
+        { TypeSafeBuilderConvertSegmentExample(style = style, onNotification = showNotification) },
         { PriceLinksExample(style = style, onNotification = showNotification) },
         { TextStyleVariationsExample(style = style, onNotification = showNotification) },
     )
@@ -230,6 +232,31 @@ internal fun TypeSafeBuilderExample(
                 link(carsText, carsUrl)
                 text(searchSuffix)
             },
+            style = style,
+            onLinkClicked = { url ->
+                onNotification(openingTemplate.format(url))
+            },
+        )
+    }
+}
+
+@Composable
+internal fun TypeSafeBuilderConvertSegmentExample(
+    modifier: Modifier = Modifier,
+    style: BpkLinkStyle = BpkLinkStyle.Default,
+    onNotification: (String) -> Unit = {},
+) {
+    val openingTemplate = stringResource(R.string.link_story_notification_opening)
+    val text = stringResource(R.string.key_login_method_selection_tos_and_privacy_policy)
+    val segment = text.convertToTextSegments(listOf("https://example.com/terms", "https://example.com/privacy"))
+
+    LinkExample(
+        title = stringResource(R.string.link_story_builder_title_covert_segment),
+        modifier = modifier,
+        style = style,
+    ) {
+        BpkLink(
+            segments = segment,
             style = style,
             onLinkClicked = { url ->
                 onNotification(openingTemplate.format(url))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -438,6 +438,7 @@
 
     <!-- New Link Story Examples -->
     <string name="link_story_builder_title">Type-Safe Builder</string>
+    <string name="link_story_builder_title_covert_segment">Type-Safe Builder Covert Segment</string>
     <string name="link_story_price_links_title">Price Links</string>
     <string name="link_story_text_styles_title">Different Text Styles</string>
     <string name="link_story_price_flight_markdown">From [£99](https://book.flight/99) London to Paris</string>
@@ -459,5 +460,6 @@
     <string name="link_story_url_hotel_booking">https://book.hotel/149</string>
     <string name="link_story_url_terms">https://terms.com</string>
     <string name="link_story_hotel_price_accessibility">one hundred and forty-nine pounds</string>
+    <string name="key_login_method_selection_tos_and_privacy_policy">By continuing you agree to our &lt;link0&gt;Terms of Service&lt;/link0&gt; and &lt;link1&gt;Privacy Policy&lt;/link1&gt;.</string>
 
 </resources>

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/link/internal/SegmentsParser.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/link/internal/SegmentsParser.kt
@@ -33,7 +33,7 @@ internal fun processLinkMatch(
 
     segments.add(
         TextSegment.Link(
-            text = linkMatch.groupValues[1],
+            text = linkMatch.groupValues[2],
             url = url,
         ),
     )


### PR DESCRIPTION
- **"Add utility for parsing and converting text with link placeholders into text segments and associated tests"**
- **add license**
- **Update backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/link/internal/SegmentsParser.kt**
- **[DON-2436] fix issue**

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)


[DON-2436]: https://skyscanner.atlassian.net/browse/DON-2436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ