### PR TITLE
DON-2201 google map bottom sheet background wipe out issue

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/bottomsheet/BpkBottomSheet.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/bottomsheet/BpkBottomSheet.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.rememberBottomSheetScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import net.skyscanner.backpack.compose.bottomsheet.internal.BottomSheetContent
@@ -64,7 +65,7 @@ fun BpkBottomSheet(
         sheetSwipeEnabled = sheetGesturesEnabled,
         topBar = null,
         snackbarHost = { Box(Modifier) },
-        containerColor = BpkTheme.colors.surfaceDefault,
+        containerColor = Color.Transparent,
         contentColor = BpkTheme.colors.textPrimary,
         content = content,
     )


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.


The update of 
google-mapsCompose = “com.google.maps.android:maps-compose:6.7.2” -> 6.12.1
and 
compose-bom = { group = “androidx.compose”, name = “compose-bom”, version = “2025.09.00" } -> 2025.09.01
cause backpack treat the container color as white instead of transparent, so we need to set the color as transparent



Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)




-->

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
