### PR TITLE
Fix missing bom dependency in backpack-common

### DIFF
--- a/backpack-common/build.gradle.kts
+++ b/backpack-common/build.gradle.kts
@@ -49,6 +49,10 @@ android {
 }
 
 dependencies {
+    val composeBom = platform(libs.compose.bom)
+    api(composeBom)
+    implementation(composeBom)
+
     api(libs.compose.ui)
     testImplementation(libs.test.junit)
     implementation(libs.compose.runtime)
@@ -56,7 +60,6 @@ dependencies {
     androidTestImplementation(libs.test.junit)
     androidTestImplementation(libs.test.junitAndroid)
     androidTestImplementation(libs.test.coroutines)
-    implementation(platform(libs.compose.bom))
 }
 
 apply(from = "tokens.gradle.kts")


### PR DESCRIPTION
This pull request makes a small adjustment to the dependency declarations in `backpack-common` to fix an issue that appears when using Gradle version 9+ due to the missing bom dependency declaration for `compose.ui`:

```
FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':features:feature-name:compileDebugJavaWithJavac'.
> Could not resolve all dependencies for configuration ':features:feature-name:debugCompileClasspath'.
   > Could not find androidx.compose.ui:ui:.
     Required by:
         project ':features:feature-name' > net.skyscanner.backpack:backpack-android:76.4.0 > net.skyscanner.backpack:backpack-common:76.4.0
```