### PR TITLE
Change Dependabot schedule to weekly on Mondays

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,8 +3,9 @@ updates:
 - package-ecosystem: gradle
   directory: "/"
   schedule:
-    interval: daily
-    time: "10:00"
+    interval: weekly
+    day: monday
+    time: "19:00"
   open-pull-requests-limit: 10
   labels: # Avoid default semver labels (https://github.com/dependabot/dependabot-core/issues/3465)
     - dependencies
@@ -23,8 +24,9 @@ updates:
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
-    time: "10:00"
+    interval: weekly
+    day: monday
+    time: "19:00"
   open-pull-requests-limit: 10
   versioning-strategy: increase-if-necessary
   allow:
@@ -32,6 +34,7 @@ updates:
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
-    interval: daily
-    time: "10:00"
+    interval: weekly
+    day: monday
+    time: "19:00"
   open-pull-requests-limit: 10


### PR DESCRIPTION
Changed the update schedule for Bundler, npm, and GitHub Actions to weekly on Mondays at 19:00.

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
