### PR TITLE
DON-2147 Use stateDescription in BpkStarRating when available

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/starrating/BpkStarRating.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/starrating/BpkStarRating.kt
@@ -47,8 +47,9 @@ open class BpkStarRating @JvmOverloads constructor(
             // Prefer stateDescription where supported so TalkBack reads label then state.
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 info.stateDescription = text
+            } else {
+                info.contentDescription = info.contentDescription?.let { "$it $text" } ?: text
             }
-            info.contentDescription = info.contentDescription?.let { "$it $text" } ?: text
         }
     }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

DON-2147

Updated the accessibility method to use state description where available.

| Before | After |
| ------ | ----- |
| <video src=https://github.com/user-attachments/assets/143497ea-bc9d-4d13-83bf-c81d339478e7 /> | <video src=https://github.com/user-attachments/assets/d8398a08-7ada-41d3-940e-d81bd25abfa3 /> |

(It doesn't really behave any differently 🤷 )









+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
