### PR TITLE
DON-2146 Replace the Compose compiler workaround for confirmStateChange

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/bottomsheet/BpkModalBottomSheetState.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/bottomsheet/BpkModalBottomSheetState.kt
@@ -30,9 +30,7 @@ import androidx.compose.runtime.remember
 @OptIn(ExperimentalMaterial3Api::class)
 fun rememberBpkModalBottomSheetState(
     skipPartiallyExpanded: Boolean = false,
-    // workaround for: https://issuetracker.google.com/issues/342089957 - remove with next compose compiler update
-//    confirmStateChange: (BpkModalBottomSheetValue) -> Boolean = { true },
-    confirmStateChange: (BpkModalBottomSheetValue) -> Boolean = remember { { true } },
+    confirmStateChange: (BpkModalBottomSheetValue) -> Boolean = { true },
 ): BpkModalBottomSheetState {
     val delegate = rememberModalBottomSheetState(
         skipPartiallyExpanded = skipPartiallyExpanded,


### PR DESCRIPTION
<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

Replace the Compose compiler workaround for confirmStateChange with the standard `{ true }` default now that the K2 lambda memoization bug (https://issuetracker.google.com/issues/342089957) is fixed. 

No public API or usage changes; behavior stays the same.


+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
