### PR TITLE
DON-2150 Remove Android Studio bug workaround

### DIFF
--- a/Backpack/src/main/java/net/skyscanner/backpack/text/BpkText.kt
+++ b/Backpack/src/main/java/net/skyscanner/backpack/text/BpkText.kt
@@ -33,7 +33,6 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.core.widget.TextViewCompat
 import net.skyscanner.backpack.R
 import net.skyscanner.backpack.util.ResourcesUtil
-import net.skyscanner.backpack.util.isInEditMode
 import net.skyscanner.backpack.util.use
 import androidx.core.content.withStyledAttributes
 
@@ -208,12 +207,7 @@ private fun internalGetFont(context: Context, textStyle: BpkText.TextStyle): Bpk
     val typeface = if (typefaceResId == -1) {
         textStyleAttributes.getString(R.styleable.BpkTextStyle_android_fontFamily)?.let { Typeface.create(it, Typeface.NORMAL) }
     } else {
-        if (context.isInEditMode()) {
-            // Preview is broken when using the compat version for font loading as of AS 4.2 (see https://issuetracker.google.com/issues/150587499)
-            context.resources.getFont(typefaceResId)
-        } else {
-            ResourcesCompat.getFont(context, typefaceResId)
-        }
+        ResourcesCompat.getFont(context, typefaceResId)
     } ?: throw IllegalStateException("Bpk font not configured correctly")
 
     textStyleAttributes.recycle()


### PR DESCRIPTION
 Removed the Android Studio Preview-only font loading branch so internalGetFont now always uses `ResourcesCompat.getFont...`

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
