### PR TITLE
[DON-2372] Added accessor to get the current shape of BpkButton 

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/button/BpkButton.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/button/BpkButton.kt
@@ -20,9 +20,11 @@ package net.skyscanner.backpack.compose.button
 
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.requiredWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.painter.Painter
 import net.skyscanner.backpack.compose.button.internal.BpkButtonImpl
 import net.skyscanner.backpack.compose.button.internal.ButtonDrawable
@@ -30,6 +32,8 @@ import net.skyscanner.backpack.compose.button.internal.ButtonIcon
 import net.skyscanner.backpack.compose.button.internal.ButtonText
 import net.skyscanner.backpack.compose.button.internal.minHeight
 import net.skyscanner.backpack.compose.icon.BpkIcon
+import net.skyscanner.backpack.compose.tokens.BpkBorderRadius
+import net.skyscanner.backpack.configuration.BpkConfiguration
 
 enum class BpkButtonIconPosition {
     Start,
@@ -53,6 +57,9 @@ enum class BpkButtonType {
     Link,
     LinkOnDark,
 }
+
+val BpkButtonShape: Shape
+    @Composable get() = BpkConfiguration.buttonConfig?.cornerRadius?.let { RoundedCornerShape(it) } ?: RoundedCornerShape(BpkBorderRadius.Sm)
 
 @Suppress("LambdaParameterEventTrailing")
 @Composable

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/button/internal/BpkButtonImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/button/internal/BpkButtonImpl.kt
@@ -28,7 +28,6 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.requiredSize
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -49,13 +48,13 @@ import net.skyscanner.backpack.compose.LocalContentColor
 import net.skyscanner.backpack.compose.LocalTextStyle
 import net.skyscanner.backpack.compose.button.BpkButtonSize
 import net.skyscanner.backpack.compose.button.BpkButtonType
+import net.skyscanner.backpack.compose.button.BpkButtonShape
 import net.skyscanner.backpack.compose.icon.BpkIcon
 import net.skyscanner.backpack.compose.icon.BpkIconSize
 import net.skyscanner.backpack.compose.spinner.BpkSpinner
 import net.skyscanner.backpack.compose.spinner.BpkSpinnerSize
 import net.skyscanner.backpack.compose.text.BpkText
 import net.skyscanner.backpack.compose.theme.BpkTheme
-import net.skyscanner.backpack.compose.tokens.BpkBorderRadius
 import net.skyscanner.backpack.compose.tokens.BpkSpacing
 import net.skyscanner.backpack.compose.utils.applyIf
 import net.skyscanner.backpack.compose.utils.hideContentIf
@@ -113,7 +112,7 @@ internal fun BpkButtonImpl(
                 disabledContainerColor = if (loading) type.loadingBackgroundColor() else type.disabledBackgroundColor(),
                 disabledContentColor = if (loading) type.loadingContentColor() else type.disabledContentColor(),
             ),
-            shape = buttonShape(),
+            shape = BpkButtonShape,
             contentPadding = type.contentPadding(size),
             elevation = null,
             content = {
@@ -189,10 +188,6 @@ internal fun ButtonDrawable(
         modifier = modifier.defaultIconSize(size.iconSize),
     )
 }
-
-private fun buttonShape() = BpkConfiguration.buttonConfig?.cornerRadius?.let {
-    RoundedCornerShape(it)
-} ?: RoundedCornerShape(BpkBorderRadius.Sm)
 
 private fun Modifier.defaultIconSize(size: BpkIconSize): Modifier =
     when (size) {


### PR DESCRIPTION
This pull request refactors how the button shape is determined in the Backpack Compose button components. The main change is the introduction of a shared `BpkButtonShape` composable property.

This is so that shadows can be implemented correctly while using shadowing. This property will no doubt be added as a foundation value when VDL testing work is completed.

```
    // Changes for app
    modifier = Modifier.shadow(
        elevation = BpkElevation.Sm,
        shape = BpkButtonDefaultShape,
    ),
```

* Introduced a `BpkButtonShape` composable property in `BpkButton.kt` to centralize the logic for determining button corner radius, using `BpkConfiguration.buttonConfig?.cornerRadius` or falling back to `BpkBorderRadius.Sm`.
* Updated `BpkButtonImpl.kt` to use the new `BpkButtonShape` property instead of a private `buttonShape()` function, and removed the now-unnecessary `buttonShape()` function. [[1]](diffhunk://#diff-8004ef64ea32ce84bf85b4695d55cfeefe2758c3a88130bc43499456717b2925R51-L58) [[2]](diffhunk://#diff-8004ef64ea32ce84bf85b4695d55cfeefe2758c3a88130bc43499456717b2925L116-R115) [[3]](diffhunk://#diff-8004ef64ea32ce84bf85b4695d55cfeefe2758c3a88130bc43499456717b2925L193-L196)

**Code cleanup:**

* Removed unused imports related to `RoundedCornerShape` and `BpkBorderRadius` from `BpkButtonImpl.kt`. [[1]](diffhunk://#diff-8004ef64ea32ce84bf85b4695d55cfeefe2758c3a88130bc43499456717b2925L31) [[2]](diffhunk://#diff-8004ef64ea32ce84bf85b4695d55cfeefe2758c3a88130bc43499456717b2925R51-L58)

**Dependency updates:**

* Added necessary imports for `RoundedCornerShape`, `Shape`, `BpkBorderRadius`, and `BpkConfiguration` in `BpkButton.kt`.


+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
