### PR TITLE
[DON-2456] Update copyright year updater workflow to use GitHub App t…

### DIFF
--- a/.github/workflows/update-copyright.yml
+++ b/.github/workflows/update-copyright.yml
@@ -13,15 +13,27 @@ permissions:
 
 jobs:
   update-copyright:
-    runs-on: ubuntu-latest
-    
+    runs-on: ubuntu-24.04-16cores-public
+
     steps:
+    - uses: actions/create-github-app-token@v2
+      id: app-token
+      with:
+        app-id: ${{ vars.GH_APP_ID }}
+        private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+
     - name: Checkout repository
       uses: actions/checkout@v6
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-      
+        token: ${{ steps.app-token.outputs.token }}
+
+    - name: Set current year
+      id: date
+      run: echo "year=$(date +'%Y')" >> $GITHUB_OUTPUT
+
     - name: Run copyright update script
+      env:
+        YEAR: ${{ steps.date.outputs.year }}
       run: |
         ./scripts/update-copyright-year.sh
         
@@ -40,18 +52,19 @@ jobs:
       if: steps.changes.outputs.changes == 'true'
       uses: peter-evans/create-pull-request@v8
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: "chore: update copyright year to $(date +%Y)"
-        title: "chore: update copyright year to $(date +%Y)"
+        token: ${{ steps.app-token.outputs.token }}
+        commit-message: "chore: update copyright year to ${{ steps.date.outputs.year }}"
+        title: "chore: update copyright year to ${{ steps.date.outputs.year }}"
         body: |
-          This PR updates the copyright year in all source files from 2018 to $(date +%Y).
-          
+          This PR updates the copyright year in all source files from 2018 to ${{ steps.date.outputs.year }}.
+
           Changes:
           - Updated copyright headers in all .kt, .java, and .sh files
           - Updated copyright template file
-          
+
           This is an automated update triggered by the scheduled workflow.
-        branch: copyright-year-update-$(date +%Y)
+        branch: copyright-year-update-${{ steps.date.outputs.year }}
+        labels: skip-changelog
         delete-branch: true
         
     - name: Output result


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for automatically updating copyright years. The main improvements are the use of a GitHub App token for authentication and dynamically setting the current year for commit messages, branch names, and PR titles.

See for working example using same code on branch: https://github.com/Skyscanner/backpack-android/pull/2548 

Note: Once merged rerun workflow to change for 2026

AI Summary:

Authentication improvements:
* Switched from using the default `GITHUB_TOKEN` to generating a token via the `actions/create-github-app-token@v2` action, which uses a GitHub App's credentials for better security and permissions (`.github/workflows/update-copyright.yml`).
* Updated all workflow steps that require authentication (`actions/checkout` and `peter-evans/create-pull-request`) to use the new app token instead of the default token (`.github/workflows/update-copyright.yml`) [[1]](diffhunk://#diff-cfc74014e97027c33b25f5639d38ead8f54cc34a7287fbfca2120932af508045L16-R36) [[2]](diffhunk://#diff-cfc74014e97027c33b25f5639d38ead8f54cc34a7287fbfca2120932af508045L43-R67).

Dynamic year handling:
* Added a step to set the current year as an output variable, and used this variable in commit messages, PR titles, branch names, and the PR body for more accurate and maintainable updates (`.github/workflows/update-copyright.yml`) [[1]](diffhunk://#diff-cfc74014e97027c33b25f5639d38ead8f54cc34a7287fbfca2120932af508045L16-R36) [[2]](diffhunk://#diff-cfc74014e97027c33b25f5639d38ead8f54cc34a7287fbfca2120932af508045L43-R67).

Workflow enhancements:
* Added the `labels: skip-changelog` option to the PR creation step to automatically label these PRs and avoid unnecessary changelog entries (`.github/workflows/update-copyright.yml`).
* Updated the runner to use `ubuntu-24.04-16cores-public` for improved performance and consistency (`.github/workflows/update-copyright.yml`).

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
