### PR TITLE
[DON-2457] Fix bottom sheet height to use wrapContentSize for better …

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/bottomsheet/internal/BpkModalBottomSheetImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/bottomsheet/internal/BpkModalBottomSheetImpl.kt
@@ -14,16 +14,19 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.TopAppBarColors
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.movableContentOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.launch
 import net.skyscanner.backpack.compose.bottomsheet.BpkModalBottomSheetCloseAction
@@ -153,6 +156,16 @@ private fun ModalBottomSheetContent(
 }
 
 @Composable
+private fun OverrideTextSizeScaling(content: @Composable () -> Unit) {
+    CompositionLocalProvider(
+        LocalDensity provides Density(
+            density = LocalDensity.current.density,
+            fontScale = 1f,
+        ),
+    ) { content() }
+}
+
+@Composable
 @OptIn(ExperimentalMaterial3Api::class)
 private fun BpkModalBottomSheetHeader(
     title: String?,
@@ -179,20 +192,22 @@ private fun BpkModalBottomSheetHeader(
             .padding(horizontal = BpkSpacing.Base),
         title = {
             title?.let {
-                BpkText(
-                    text = it,
-                    style = BpkTheme.typography.heading5,
-                    textAlign = TextAlign.Center,
-                    modifier = Modifier
-                        .semantics {
-                            heading()
-                        }
-                        .applyIf(titleContentDescription != null) {
-                            semantics {
-                                contentDescription = titleContentDescription!!
+                OverrideTextSizeScaling {
+                    BpkText(
+                        text = it,
+                        style = BpkTheme.typography.heading5,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier
+                            .semantics {
+                                heading()
                             }
-                        },
-                )
+                            .applyIf(titleContentDescription != null) {
+                                semantics {
+                                    contentDescription = titleContentDescription!!
+                                }
+                            },
+                    )
+                }
             }
         },
         navigationIcon = {
@@ -216,7 +231,11 @@ private fun BpkModalBottomSheetHeader(
             }
         },
         actions = {
-            action?.let { TextAction(action = it) }
+            action?.let {
+                OverrideTextSizeScaling {
+                    TextAction(action = it)
+                }
+            }
         },
         windowInsets = WindowInsets(top = 0.dp, bottom = 0.dp),
         colors = TopAppBarColors(

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/navigationbar/internal/BpkTopNavBarImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/navigationbar/internal/BpkTopNavBarImpl.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import net.skyscanner.backpack.compose.icon.BpkIcon
 import net.skyscanner.backpack.compose.icon.BpkIconSize
+import net.skyscanner.backpack.compose.link.BpkLink
+import net.skyscanner.backpack.compose.link.buildTextSegments
 import net.skyscanner.backpack.compose.navigationbar.Action
 import net.skyscanner.backpack.compose.navigationbar.IconAction
 import net.skyscanner.backpack.compose.navigationbar.NavBarStyle
@@ -71,6 +73,7 @@ internal fun BpkTopNavBarImpl(
             NavBarStyle.CanvasContrast -> BpkTheme.colors.canvasContrast
             else -> BpkTheme.colors.surfaceDefault
         }
+
         else -> when (style) {
             NavBarStyle.OnImage -> Color.Transparent
             NavBarStyle.Default -> BpkTheme.colors.canvas
@@ -84,6 +87,7 @@ internal fun BpkTopNavBarImpl(
             NavBarStyle.SurfaceContrast -> BpkTheme.colors.textOnDark
             else -> BpkTheme.colors.textPrimary
         }
+
         else -> when (style) {
             NavBarStyle.OnImage, NavBarStyle.SurfaceContrast -> BpkTheme.colors.textOnDark
             NavBarStyle.Default, NavBarStyle.CanvasContrast -> BpkTheme.colors.textPrimary
@@ -163,12 +167,10 @@ internal fun TextAction(action: TextAction, modifier: Modifier = Modifier) {
             .clickableWithRipple(bounded = false, role = Role.Button) { action.onClick() },
         contentAlignment = Alignment.Center,
     ) {
-        BpkText(
-            text = action.text,
-            color = BpkTheme.colors.textLink,
-            style = BpkTheme.typography.label1,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
+        BpkLink(
+            segments = buildTextSegments { link(action.text, "") },
+            textStyle = BpkTheme.typography.heading5,
+            onLinkClicked = { action.onClick() },
         )
     }
 }


### PR DESCRIPTION
This pull request improves accessibility and visual consistency in the Backpack Compose bottom sheet and navigation bar components by overriding text scaling for certain UI elements and updating the navigation bar action to use a link style. 

This will be applied in the main app wherever the bottom sheet is used.

- net/skyscanner/drops/ui/monthfilter/composable/DropsMonthFilter.kt
- net/skyscanner/hotel/details/ui/pricecomparison/composable/content/filters/ProviderFilterSelectorModal.kt
- net/skyscanner/hotels/dayview/ui/filter/composable/SortAndFilterScreen.kt


| Font Scale | Before | After |
|--------|--------|--------|
| Normal | <img width="270" height="600" alt="before normal" src="https://github.com/user-attachments/assets/a0c3bd81-4b43-4729-8db1-4e0c8ae271e1" /> | <img width="270" height="600" alt="after normal" src="https://github.com/user-attachments/assets/66df3af4-5bc6-4d26-8110-bb95fe907b06" /> |
| Max | <img width="270" height="600" alt="before max" src="https://github.com/user-attachments/assets/efe5d18c-35f6-4f0d-81b4-385d6ae913bb" /> | <img width="270" height="600" alt="after max" src="https://github.com/user-attachments/assets/889a251d-6237-4936-adf0-34e950730995" />
 |

- Layout improvement:
  * Replaced the use of `Modifier.height(BpkSpacing.Lg)` with `Modifier.wrapContentSize()` for the modal bottom sheet header, allowing the header to size itself based on its content instead of a fixed height.
  * Removed the unused import of `height` and added `wrapContentSize` to the imports in `BpkModalBottomSheetImpl.kt`.



+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
