### PR TITLE
[DON-2137] Fix CI failure in parallelized screenshot tests

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -219,7 +219,6 @@ jobs:
       - name: Screenshot Tests - ${{ matrix.variant.name }}
         run: |
           set -e
-          rm -rf app/screenshots/oss
           ./gradlew app:recordRoborazziOssDebug -Dvariant=${{ matrix.variant.flag }}
 
       - name: Upload Screenshots


### PR DESCRIPTION
## Summary

Fixes the CI failure at https://github.com/Skyscanner/backpack-android/actions/runs/20855946561/job/59924567334

## Problem

After merging PR #2522 which parallelized screenshot tests, the CI started failing on the main branch with exit code 255. The issue was in the Screenshots job where each parallel variant was deleting the `app/screenshots/oss` directory before running:

```bash
rm -rf app/screenshots/oss
./gradlew app:recordRoborazziOssDebug -Dvariant=${{ matrix.variant.flag }}
```

This meant each variant was generating ONLY its own screenshots in isolation, instead of accumulating screenshots from all variants like the original sequential approach did.

## Solution

Removed the `rm -rf app/screenshots/oss` line from individual variant jobs. The directory cleanup now only happens once in the Screenshots-Collect job before combining all variant results. This ensures that:

1. Each variant generates its screenshots independently (in parallel)
2. All screenshots are preserved in their respective artifacts
3. The Collect job combines all screenshots into a single directory
4. The final result matches what the original sequential approach produced

## Testing

- The workflow change has been pushed and will be tested by CI
- Local testing confirmed the fix resolves the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>