### PR TITLE
[DON-2460] fix: update BpkFloatingNotification to handle font scaling…

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/floatingnotification/BpkFloatingNotification.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/floatingnotification/BpkFloatingNotification.kt
@@ -22,9 +22,9 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.requiredHeight
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -68,12 +68,12 @@ fun BpkFloatingNotification(
     }
     val componentHeight =
         if (widthDp >= TABLET_MIN_WIDTH.dp) DefaultTabletSize.height else DefaultPhoneSize.height
-    val slideDistancePx = with(LocalDensity.current) { (BpkSpacing.Lg + componentHeight).toPx().toInt() }
+    val slideOffsetPx = with(LocalDensity.current) { BpkSpacing.Lg.toPx().toInt() }
 
     AnimatedContent(
         targetState = currentData,
         modifier = modifier,
-        transitionSpec = floatingNotificationTransforms(slideDistancePx),
+        transitionSpec = floatingNotificationTransforms(slideOffsetPx),
         label = "Floating Notification",
     ) { data ->
 
@@ -89,7 +89,7 @@ fun BpkFloatingNotification(
                 BpkFloatingNotificationImpl(
                     data = data,
                     modifier = Modifier
-                        .requiredHeight(componentHeight)
+                        .heightIn(min = componentHeight)
                         .widthIn(max = DefaultTabletSize.width),
                 )
             }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/floatingnotification/internal/BpkFloatingNotification.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/floatingnotification/internal/BpkFloatingNotification.kt
@@ -28,7 +28,6 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Surface
@@ -62,7 +61,6 @@ internal fun BpkFloatingNotificationImpl(
     ) {
         Row(
             modifier = Modifier
-                .fillMaxHeight()
                 .padding(horizontal = BpkSpacing.Base),
             horizontalArrangement = Arrangement.spacedBy(BpkSpacing.Base),
             verticalAlignment = Alignment.CenterVertically,
@@ -99,12 +97,12 @@ internal fun BpkFloatingNotificationImpl(
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
 internal fun floatingNotificationTransforms(
-    slideDistancePx: Int,
+    slideOffsetPx: Int,
 ): AnimatedContentTransitionScope<BpkFloatingNotificationData?>.() -> ContentTransform =
     {
         ContentTransform(
-            targetContentEnter = fadeIn(tween(TRANSITION_DURATION)) + slideInVertically(tween(TRANSITION_DURATION)) { slideDistancePx },
-            initialContentExit = fadeOut(tween(TRANSITION_DURATION)) + slideOutVertically(tween(TRANSITION_DURATION)) { slideDistancePx },
+            targetContentEnter = fadeIn(tween(TRANSITION_DURATION)) + slideInVertically(tween(TRANSITION_DURATION)) { height -> height + slideOffsetPx },
+            initialContentExit = fadeOut(tween(TRANSITION_DURATION)) + slideOutVertically(tween(TRANSITION_DURATION)) { height -> height + slideOffsetPx },
         )
     }
 


### PR DESCRIPTION
This pull request refactors the floating notification component to improve its sizing and animation logic, making it more flexible and visually consistent across different device types. The main changes focus on how the notification's height is handled and how the animation offset is calculated, resulting in smoother transitions and better adaptability.

**Single Line**
| Scale | Before | After |
|--------|--------|--------|
| Default | <img width="270" height="600" alt="before single default" src="https://github.com/user-attachments/assets/31050b25-ed4c-4e5f-987f-ba2785a6500d" /> | <img width="270" height="600" alt="after single default" src="https://github.com/user-attachments/assets/8bb38d1e-6961-419c-bb0c-35fb3da83eae" /> |
| Max | <img width="270" height="600" alt="before single max" src="https://github.com/user-attachments/assets/7d4ed58d-2077-4b24-b001-9f345b043c6d" /> | <img width="270" height="600" alt="after single max" src="https://github.com/user-attachments/assets/0525941f-c29a-4496-ba37-2e207d88c1e8" /> |


**Multi Line (concatenation)**
| Scale | Before | After |
|--------|--------|--------|
| Default | <img width="270" height="600" alt="before multi default" src="https://github.com/user-attachments/assets/8839afab-2857-4c8d-a3d8-a9461c1c35a6" /> | <img width="270" height="600" alt="after multi default" src="https://github.com/user-attachments/assets/ee6805f6-7fb6-467e-8895-5191af457fbe" /> |
| Max | <img width="270" height="600" alt="before multi max" src="https://github.com/user-attachments/assets/ea229039-5e67-4b52-8827-ecb5cf434dfe" /> | <img width="270" height="600" alt="after multi max" src="https://github.com/user-attachments/assets/9826dd57-8e9d-4268-82bf-6530d1a7991e" /> | 


**Floating notification sizing improvements:**

* Changed from using `requiredHeight` to `heightIn(min = ...)` for the notification component, allowing it to have a minimum height but be flexible if needed. (`BpkFloatingNotification.kt` [backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/floatingnotification/BpkFloatingNotification.ktL92-R92](diffhunk://#diff-be21440f7e07b1ef39489a90cd882ef78cbc0d4ff466567ebb4eb6c46e58e9bfL92-R92))
* Removed the use of `fillMaxHeight()` in the internal implementation to avoid forcing the notification to occupy all available vertical space. (`BpkFloatingNotification.kt` [backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/floatingnotification/internal/BpkFloatingNotification.ktL65](diffhunk://#diff-c101eafeb797451e71e2a56a069991bda7109ee193396a20243774d5ff0edb34L65))

**Animation logic updates:**

* Updated the calculation of the slide animation offset to use only the spacing value (`BpkSpacing.Lg`), rather than spacing plus component height, for a more consistent animation. (`BpkFloatingNotification.kt` [backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/floatingnotification/BpkFloatingNotification.ktL71-R76](diffhunk://#diff-be21440f7e07b1ef39489a90cd882ef78cbc0d4ff466567ebb4eb6c46e58e9bfL71-R76))
* Refactored the animation transforms to use the new offset logic, ensuring that the slide-in and slide-out animations are based on the component's height plus the offset. (`BpkFloatingNotification.kt` [backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/floatingnotification/internal/BpkFloatingNotification.ktL102-R105](diffhunk://#diff-c101eafeb797451e71e2a56a069991bda7109ee193396a20243774d5ff0edb34L102-R105))

**Code cleanup:**

* Removed unused imports related to layout height management to keep the codebase clean. (`BpkFloatingNotification.kt` [[1]](diffhunk://#diff-be21440f7e07b1ef39489a90cd882ef78cbc0d4ff466567ebb4eb6c46e58e9bfR25-L27) [[2]](diffhunk://#diff-c101eafeb797451e71e2a56a069991bda7109ee193396a20243774d5ff0edb34L31)


+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
