### PR TITLE
[WASABI-11050] BpkRangeSlider accessibility improvement

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/slider/internal/BpkRangeSliderImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/slider/internal/BpkRangeSliderImpl.kt
@@ -20,13 +20,15 @@ package net.skyscanner.backpack.compose.slider.internal
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import kotlin.math.roundToInt
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.progressSemantics
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
+import androidx.compose.ui.semantics.progressBarRangeInfo
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.RangeSlider
 import androidx.compose.runtime.Composable
@@ -133,7 +135,8 @@ internal fun BpkRangeSliderImpl(
                             .rangeThumbSemantics(
                                 label = lowerThumbLabel,
                                 currentValue = value.start,
-                                valueRange = minValue..maxValue,
+                                fullRange = minValue..maxValue,
+                                clampRange = minValue..value.endInclusive,
                                 steps = steps,
                                 enabled = enabled,
                                 onValueChange = { newStart ->
@@ -151,7 +154,8 @@ internal fun BpkRangeSliderImpl(
                             .rangeThumbSemantics(
                                 label = upperThumbLabel,
                                 currentValue = value.endInclusive,
-                                valueRange = minValue..maxValue,
+                                fullRange = minValue..maxValue,
+                                clampRange = value.start..maxValue,
                                 steps = steps,
                                 enabled = enabled,
                                 onValueChange = { newEnd ->
@@ -238,25 +242,40 @@ private fun LabelLayout(
 private fun Modifier.rangeThumbSemantics(
     label: String,
     currentValue: Float,
-    valueRange: ClosedFloatingPointRange<Float>,
+    fullRange: ClosedFloatingPointRange<Float>,
+    clampRange: ClosedFloatingPointRange<Float>,
     steps: Int,
     enabled: Boolean,
     onValueChange: (Float) -> Unit,
 ): Modifier = semantics {
     stateDescription = label
+    progressBarRangeInfo = ProgressBarRangeInfo(currentValue, fullRange, steps)
     if (!enabled) disabled()
     setProgress { targetValue ->
-        val newValue = targetValue.coerceIn(valueRange.start, valueRange.endInclusive)
+        val newValue = snapToStep(targetValue, fullRange, steps)
+            .coerceIn(clampRange.start, clampRange.endInclusive)
         if (newValue != currentValue) {
             onValueChange(newValue)
             true
         } else false
     }
-}.progressSemantics(
-    value = currentValue,
-    valueRange = valueRange,
-    steps = steps,
-)
+}
+
+// Mirrors M3's internal step-snapping logic: snaps a raw targetValue to the nearest
+// discrete tick position defined by [steps]. steps=0 means continuous (no snapping).
+private fun snapToStep(
+    targetValue: Float,
+    valueRange: ClosedFloatingPointRange<Float>,
+    steps: Int,
+): Float {
+    if (steps == 0) return targetValue.coerceIn(valueRange.start, valueRange.endInclusive)
+    val totalIntervals = steps + 1
+    val rangeSize = valueRange.endInclusive - valueRange.start
+    val nearestIndex = ((targetValue - valueRange.start) / rangeSize * totalIntervals)
+        .roundToInt()
+        .coerceIn(0, totalIntervals)
+    return valueRange.start + nearestIndex * rangeSize / totalIntervals
+}
 
 private val FlareHeight = 6.dp
 private val BorderRadius = 6.dp

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/slider/internal/BpkRangeSliderImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/slider/internal/BpkRangeSliderImpl.kt
@@ -20,15 +20,12 @@ package net.skyscanner.backpack.compose.slider.internal
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import kotlin.math.roundToInt
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.ui.semantics.ProgressBarRangeInfo
-import androidx.compose.ui.semantics.progressBarRangeInfo
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.RangeSlider
 import androidx.compose.runtime.Composable
@@ -37,10 +34,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.semantics.ProgressBarRangeInfo
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.disabled
 import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.isTraversalGroup
+import androidx.compose.ui.semantics.progressBarRangeInfo
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.setProgress
 import androidx.compose.ui.semantics.stateDescription
@@ -51,6 +50,7 @@ import net.skyscanner.backpack.compose.text.BpkText
 import net.skyscanner.backpack.compose.theme.BpkTheme
 import net.skyscanner.backpack.compose.tokens.BpkSpacing
 import net.skyscanner.backpack.compose.utils.FlareShape
+import kotlin.math.roundToInt
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -268,9 +268,12 @@ private fun snapToStep(
     valueRange: ClosedFloatingPointRange<Float>,
     steps: Int,
 ): Float {
+    val rangeSize = valueRange.endInclusive - valueRange.start
+    // Guard against zero-length range to avoid NaN/Infinity
+    if (rangeSize <= 0f) return valueRange.start
+
     if (steps == 0) return targetValue.coerceIn(valueRange.start, valueRange.endInclusive)
     val totalIntervals = steps + 1
-    val rangeSize = valueRange.endInclusive - valueRange.start
     val nearestIndex = ((targetValue - valueRange.start) / rangeSize * totalIntervals)
         .roundToInt()
         .coerceIn(0, totalIntervals)

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/slider/internal/BpkRangeSliderImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/slider/internal/BpkRangeSliderImpl.kt
@@ -22,8 +22,11 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.progressSemantics
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.RangeSlider
 import androidx.compose.runtime.Composable
@@ -32,8 +35,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
-import androidx.compose.ui.semantics.invisibleToUser
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.disabled
+import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.setProgress
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import net.skyscanner.backpack.compose.flare.BpkFlarePointerDirection
@@ -62,52 +70,102 @@ internal fun BpkRangeSliderImpl(
     val isLowerThumbBeingTouched = startInteractionSource.collectIsDraggedAsState().value
     val isUpperThumbBeingTouched = endInteractionSource.collectIsDraggedAsState().value
 
-    RangeSlider(
-        value = value,
-        onValueChange = onValueChange,
-        modifier = modifier,
-        enabled = enabled,
-        startInteractionSource = startInteractionSource,
-        endInteractionSource = endInteractionSource,
-        valueRange = minValue..maxValue,
-        steps = steps,
-        onValueChangeFinished = onValueChangeFinished,
-        startThumb = {
-            if (isLowerThumbBeingTouched && lowerThumbLabel != null) {
-                SlideRangeLabel(
-                    label = lowerThumbLabel,
+    val needsA11yProxy = lowerThumbLabel != null || upperThumbLabel != null
+
+    val sliderContent: @Composable (Modifier) -> Unit = { sliderModifier ->
+        RangeSlider(
+            value = value,
+            onValueChange = onValueChange,
+            modifier = sliderModifier,
+            enabled = enabled,
+            startInteractionSource = startInteractionSource,
+            endInteractionSource = endInteractionSource,
+            valueRange = minValue..maxValue,
+            steps = steps,
+            onValueChangeFinished = onValueChangeFinished,
+            startThumb = {
+                if (isLowerThumbBeingTouched && lowerThumbLabel != null) {
+                    SlideRangeLabel(
+                        label = lowerThumbLabel,
+                        enabled = enabled,
+                        interactionSource = startInteractionSource,
+                    )
+                } else {
+                    SliderThumb(
+                        interactionSource = startInteractionSource,
+                        enabled = enabled,
+                    )
+                }
+            },
+            endThumb = {
+                if (isUpperThumbBeingTouched && upperThumbLabel != null) {
+                    SlideRangeLabel(
+                        label = upperThumbLabel,
+                        enabled = enabled,
+                        interactionSource = endInteractionSource,
+                    )
+                } else {
+                    SliderThumb(
+                        interactionSource = endInteractionSource,
+                        enabled = enabled,
+                    )
+                }
+            },
+            track = { rangeSliderState ->
+                RangeSliderTrack(
                     enabled = enabled,
-                    interactionSource = startInteractionSource,
+                    rangeSliderState = rangeSliderState,
                 )
-            } else {
-                SliderThumb(
-                    interactionSource = startInteractionSource,
-                    enabled = enabled,
-                )
+            },
+            colors = sliderColors(),
+        )
+    }
+
+    if (needsA11yProxy) {
+        Box(modifier = modifier.semantics { isTraversalGroup = true }) {
+            sliderContent(Modifier.clearAndSetSemantics {})
+            Row(modifier = Modifier.matchParentSize()) {
+                if (lowerThumbLabel != null) {
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxHeight()
+                            .rangeThumbSemantics(
+                                label = lowerThumbLabel,
+                                currentValue = value.start,
+                                valueRange = minValue..maxValue,
+                                steps = steps,
+                                enabled = enabled,
+                                onValueChange = { newStart ->
+                                    onValueChange(newStart..value.endInclusive)
+                                    onValueChangeFinished?.invoke()
+                                },
+                            ),
+                    )
+                }
+                if (upperThumbLabel != null) {
+                    Box(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxHeight()
+                            .rangeThumbSemantics(
+                                label = upperThumbLabel,
+                                currentValue = value.endInclusive,
+                                valueRange = minValue..maxValue,
+                                steps = steps,
+                                enabled = enabled,
+                                onValueChange = { newEnd ->
+                                    onValueChange(value.start..newEnd)
+                                    onValueChangeFinished?.invoke()
+                                },
+                            ),
+                    )
+                }
             }
-        },
-        endThumb = {
-            if (isUpperThumbBeingTouched && upperThumbLabel != null) {
-                SlideRangeLabel(
-                    label = upperThumbLabel,
-                    enabled = enabled,
-                    interactionSource = endInteractionSource,
-                )
-            } else {
-                SliderThumb(
-                    interactionSource = endInteractionSource,
-                    enabled = enabled,
-                )
-            }
-        },
-        track = { rangeSliderState ->
-            RangeSliderTrack(
-                enabled = enabled,
-                rangeSliderState = rangeSliderState,
-            )
-        },
-        colors = sliderColors(),
-    )
+        }
+    } else {
+        sliderContent(modifier)
+    }
 }
 
 @OptIn(ExperimentalComposeUiApi::class)
@@ -141,7 +199,7 @@ private fun SlideRangeLabel(
                 textAlign = TextAlign.Center,
                 maxLines = 1,
                 modifier = Modifier
-                    .semantics { invisibleToUser() },
+                    .semantics { hideFromAccessibility() },
             )
         }
         SliderThumb(
@@ -176,6 +234,29 @@ private fun LabelLayout(
         }
     }
 }
+
+private fun Modifier.rangeThumbSemantics(
+    label: String,
+    currentValue: Float,
+    valueRange: ClosedFloatingPointRange<Float>,
+    steps: Int,
+    enabled: Boolean,
+    onValueChange: (Float) -> Unit,
+): Modifier = semantics {
+    stateDescription = label
+    if (!enabled) disabled()
+    setProgress { targetValue ->
+        val newValue = targetValue.coerceIn(valueRange.start, valueRange.endInclusive)
+        if (newValue != currentValue) {
+            onValueChange(newValue)
+            true
+        } else false
+    }
+}.progressSemantics(
+    value = currentValue,
+    valueRange = valueRange,
+    steps = steps,
+)
 
 private val FlareHeight = 6.dp
 private val BorderRadius = 6.dp


### PR DESCRIPTION
**Jira ticket with more details and videos explaining the change is [WASABI-11050](https://skyscanner.atlassian.net/browse/WASABI-11050)**

**Changes:**
BpkRangeSliderImpl changes:                                                                                                                                                                                                            
  - RangeSlider is extracted into a sliderContent lambda that accepts a Modifier — avoids duplicating the full call in both branches                                                                                                     
  - When needsA11yProxy: outer Box(modifier) holds the slider with Modifier.clearAndSetSemantics {} (suppresses all M3 nodes) + two zero-size sibling proxy Boxes                                                                        
  - When no labels: sliderContent(modifier) — unchanged path, no overhead                                                                                                                                                                
                                                                                                                                                                                                                                         
  New rangeThumbSemantics extension (follows nudgerSemantics pattern):                                                                                                                                                                   
  - stateDescription = label set first so it wins over progressSemantics's percentage override                                                                                                                                           
  - disabled() when not enabled                                                                                                                                                                                                          
  - setProgress delegates to onValueChange callback                                                                                                                                                                                      
  - .progressSemantics(currentValue, valueRange, steps) chained for progressBarRangeInfo + volume key support                                                                                                                            
                                                                                                                                                                                                                                         
Result: 2 TalkBack focus stops (one per thumb), each combining stateDescription + setProgress in the same node — the problem that M3's two-node design made impossible from within the thumb slots. 


**Example of current behaviour**
| Filghts Filter Screen | Hotels Filter Screen |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/a6c795d9-4118-4294-870f-f13c07e5f7ac" /> | <video src="https://github.com/user-attachments/assets/2c7c6307-49d9-473e-8f0c-265c38f62f28" /> |

**Example after this changes**
| Filghts Filter Screen | Hotels Filter Screen |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/ded5198f-2c1b-4100-bf35-b2235d5937c8" /> | <video src="https://github.com/user-attachments/assets/8af31d7e-9d74-44d9-a4e1-e9a382490e15" /> |



<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)


[WASABI-11050]: https://skyscanner.atlassian.net/browse/WASABI-11050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ