### PR TITLE
[DON-3340][Android] BpkFloatingNotification Accessibility Optimisation

### DIFF
--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/floatingnotification/BpkFloatingNotificationAccessibilityTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/floatingnotification/BpkFloatingNotificationAccessibilityTest.kt
@@ -1,0 +1,186 @@
+/**
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018 - 2026 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.skyscanner.backpack.compose.floatingnotification
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalAccessibilityManager
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.junit4.createComposeRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import net.skyscanner.backpack.compose.icon.BpkIcon
+import net.skyscanner.backpack.compose.theme.BpkTheme
+import net.skyscanner.backpack.compose.tokens.Heart
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BpkFloatingNotificationAccessibilityTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val hasLiveRegionPolite = SemanticsMatcher.expectValue(
+        SemanticsProperties.LiveRegion,
+        LiveRegionMode.Polite,
+    )
+
+    @Test
+    fun liveRegion_isPolite_whenNotificationIsShown() {
+        val state = BpkFloatingNotificationState()
+        val scope = TestScope(UnconfinedTestDispatcher())
+
+        scope.launch {
+            state.show(text = "Saved")
+        }
+
+        composeTestRule.setContent {
+            BpkTheme {
+                BpkFloatingNotification(state = state)
+            }
+        }
+
+        composeTestRule.onNode(hasLiveRegionPolite).assertExists()
+    }
+
+    @Test
+    fun liveRegion_isPolite_whenNoNotificationIsShown() {
+        val state = BpkFloatingNotificationState()
+
+        composeTestRule.setContent {
+            BpkTheme {
+                BpkFloatingNotification(state = state)
+            }
+        }
+
+        // Live region wrapper is always present, not just when content is visible
+        composeTestRule.onNode(hasLiveRegionPolite).assertExists()
+    }
+
+    @Test
+    fun accessibilityManager_recommendedTimeout_isUsedAsDelay() {
+        val state = BpkFloatingNotificationState()
+        val scope = TestScope(UnconfinedTestDispatcher())
+        val recommendedTimeout = 8000L
+
+        val fakeAccessibilityManager = FakeAccessibilityManager(recommendedTimeout)
+
+        scope.launch {
+            state.show(text = "Saved", hideAfter = 4000L)
+        }
+
+        composeTestRule.mainClock.autoAdvance = false
+
+        composeTestRule.setContent {
+            BpkTheme {
+                CompositionLocalProvider(LocalAccessibilityManager provides fakeAccessibilityManager) {
+                    BpkFloatingNotification(state = state)
+                }
+            }
+        }
+
+        composeTestRule.mainClock.advanceTimeByFrame()
+        composeTestRule.waitForIdle()
+
+        // Notification still visible after the original 4000ms timeout because the
+        // accessibility manager extended it to 8000ms
+        composeTestRule.mainClock.advanceTimeBy(5000L)
+        composeTestRule.waitForIdle()
+
+        assert(state.currentData != null) {
+            "Notification should still be visible after original timeout when accessibility manager extends it"
+        }
+    }
+
+    @Test
+    fun accessibilityManager_calculateRecommendedTimeout_receivesCorrectFlags() {
+        val state = BpkFloatingNotificationState()
+        val scope = TestScope(UnconfinedTestDispatcher())
+        val fakeAccessibilityManager = FakeAccessibilityManager(captureArgs = true)
+
+        scope.launch {
+            state.show(
+                text = "Flight saved",
+                icon = BpkIcon.Heart,
+                cta = "View",
+                onClick = {},
+                hideAfter = 4000L,
+            )
+        }
+
+        composeTestRule.setContent {
+            BpkTheme {
+                CompositionLocalProvider(LocalAccessibilityManager provides fakeAccessibilityManager) {
+                    BpkFloatingNotification(state = state)
+                }
+            }
+        }
+
+        composeTestRule.waitForIdle()
+
+        assert(fakeAccessibilityManager.lastOriginalTimeout == 4000L) {
+            "Expected originalTimeoutMillis=4000, got ${fakeAccessibilityManager.lastOriginalTimeout}"
+        }
+        assert(fakeAccessibilityManager.lastContainsIcons) {
+            "Expected containsIcons=true"
+        }
+        assert(fakeAccessibilityManager.lastContainsText) {
+            "Expected containsText=true"
+        }
+        assert(fakeAccessibilityManager.lastContainsControls) {
+            "Expected containsControls=true"
+        }
+    }
+
+    @Test
+    fun accessibilityManager_null_fallsBackToOriginalTimeout() {
+        val state = BpkFloatingNotificationState()
+        val scope = TestScope(UnconfinedTestDispatcher())
+
+        scope.launch {
+            state.show(text = "Saved", hideAfter = 4000L)
+        }
+
+        composeTestRule.mainClock.autoAdvance = false
+
+        composeTestRule.setContent {
+            BpkTheme {
+                // No LocalAccessibilityManager provided — defaults to null
+                CompositionLocalProvider(LocalAccessibilityManager provides null) {
+                    BpkFloatingNotification(state = state)
+                }
+            }
+        }
+
+        composeTestRule.mainClock.advanceTimeByFrame()
+        composeTestRule.waitForIdle()
+
+        // Notification should dismiss after the original timeout
+        composeTestRule.mainClock.advanceTimeBy(4001L)
+        composeTestRule.waitForIdle()
+
+        assert(state.currentData == null) {
+            "Notification should be dismissed after original timeout when no accessibility manager"
+        }
+    }
+}

--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/floatingnotification/BpkFloatingNotificationAccessibilityTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/floatingnotification/BpkFloatingNotificationAccessibilityTest.kt
@@ -46,38 +46,6 @@ class BpkFloatingNotificationAccessibilityTest {
     )
 
     @Test
-    fun liveRegion_isPolite_whenNotificationIsShown() {
-        val state = BpkFloatingNotificationState()
-        val scope = TestScope(UnconfinedTestDispatcher())
-
-        scope.launch {
-            state.show(text = "Saved")
-        }
-
-        composeTestRule.setContent {
-            BpkTheme {
-                BpkFloatingNotification(state = state)
-            }
-        }
-
-        composeTestRule.onNode(hasLiveRegionPolite).assertExists()
-    }
-
-    @Test
-    fun liveRegion_isPolite_whenNoNotificationIsShown() {
-        val state = BpkFloatingNotificationState()
-
-        composeTestRule.setContent {
-            BpkTheme {
-                BpkFloatingNotification(state = state)
-            }
-        }
-
-        // Live region wrapper is always present, not just when content is visible
-        composeTestRule.onNode(hasLiveRegionPolite).assertExists()
-    }
-
-    @Test
     fun accessibilityManager_recommendedTimeout_isUsedAsDelay() {
         val state = BpkFloatingNotificationState()
         val scope = TestScope(UnconfinedTestDispatcher())

--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/floatingnotification/FakeAccessibilityManager.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/floatingnotification/FakeAccessibilityManager.kt
@@ -1,0 +1,51 @@
+/**
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018 - 2026 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.skyscanner.backpack.compose.floatingnotification
+
+import androidx.compose.ui.platform.AccessibilityManager
+
+internal class FakeAccessibilityManager(
+    private val fixedTimeout: Long = 4000L,
+    private val captureArgs: Boolean = false,
+) : AccessibilityManager {
+
+    var lastOriginalTimeout: Long = -1L
+        private set
+    var lastContainsIcons: Boolean = false
+        private set
+    var lastContainsText: Boolean = false
+        private set
+    var lastContainsControls: Boolean = false
+        private set
+
+    override fun calculateRecommendedTimeoutMillis(
+        originalTimeoutMillis: Long,
+        containsIcons: Boolean,
+        containsText: Boolean,
+        containsControls: Boolean,
+    ): Long {
+        if (captureArgs) {
+            lastOriginalTimeout = originalTimeoutMillis
+            lastContainsIcons = containsIcons
+            lastContainsText = containsText
+            lastContainsControls = containsControls
+        }
+        return fixedTimeout
+    }
+}

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/floatingnotification/BpkFloatingNotification.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/floatingnotification/BpkFloatingNotification.kt
@@ -51,7 +51,6 @@ import net.skyscanner.backpack.compose.floatingnotification.internal.BpkFloating
 import net.skyscanner.backpack.compose.floatingnotification.internal.floatingNotificationTransforms
 import net.skyscanner.backpack.compose.icon.BpkIcon
 import net.skyscanner.backpack.compose.tokens.BpkSpacing
-import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
@@ -71,7 +70,7 @@ fun BpkFloatingNotification(
                 containsControls = currentData.cta != null,
             ) ?: currentData.hideAfter
 
-            delay(duration.milliseconds)
+            delay(duration)
             currentData.dismiss()
         }
     }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/floatingnotification/BpkFloatingNotification.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/floatingnotification/BpkFloatingNotification.kt
@@ -38,9 +38,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalAccessibilityManager
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
-import androidx.compose.ui.semantics.LiveRegionMode
-import androidx.compose.ui.semantics.liveRegion
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
@@ -81,27 +78,28 @@ fun BpkFloatingNotification(
         if (widthDp >= TABLET_MIN_WIDTH.dp) DefaultTabletSize.height else DefaultPhoneSize.height
     val slideOffsetPx = with(LocalDensity.current) { BpkSpacing.Lg.toPx().toInt() }
 
-    Box(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(start = BpkSpacing.Base, end = BpkSpacing.Base, bottom = BpkSpacing.Lg)
-            .navigationBarsPadding(),
-        contentAlignment = Alignment.BottomCenter,
-    ) {
-        Box(modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite }) {
-            AnimatedContent(
-                targetState = currentData,
-                transitionSpec = floatingNotificationTransforms(slideOffsetPx),
-                label = "Floating Notification",
-            ) { data ->
-                if (data != null) {
-                    BpkFloatingNotificationImpl(
-                        data = data,
-                        modifier = Modifier
-                            .heightIn(min = componentHeight)
-                            .widthIn(max = DefaultTabletSize.width),
-                    )
-                }
+    AnimatedContent(
+        targetState = currentData,
+        modifier = modifier,
+        transitionSpec = floatingNotificationTransforms(slideOffsetPx),
+        label = "Floating Notification",
+    ) { data ->
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(start = BpkSpacing.Base, end = BpkSpacing.Base, bottom = BpkSpacing.Lg)
+                .navigationBarsPadding(),
+            contentAlignment = Alignment.BottomCenter,
+        ) {
+
+            if (data != null) {
+                BpkFloatingNotificationImpl(
+                    data = data,
+                    modifier = Modifier
+                        .heightIn(min = componentHeight)
+                        .widthIn(max = DefaultTabletSize.width),
+                )
             }
         }
     }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/floatingnotification/BpkFloatingNotification.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/floatingnotification/BpkFloatingNotification.kt
@@ -35,8 +35,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalAccessibilityManager
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
@@ -47,6 +51,7 @@ import net.skyscanner.backpack.compose.floatingnotification.internal.BpkFloating
 import net.skyscanner.backpack.compose.floatingnotification.internal.floatingNotificationTransforms
 import net.skyscanner.backpack.compose.icon.BpkIcon
 import net.skyscanner.backpack.compose.tokens.BpkSpacing
+import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
@@ -54,12 +59,19 @@ fun BpkFloatingNotification(
     state: BpkFloatingNotificationState,
     modifier: Modifier = Modifier,
 ) {
-
+    val accessibilityManager = LocalAccessibilityManager.current
     val currentData = state.currentData
+
     LaunchedEffect(currentData) {
         if (currentData != null) {
-            val duration = currentData.hideAfter
-            delay(duration)
+            val duration = accessibilityManager?.calculateRecommendedTimeoutMillis(
+                originalTimeoutMillis = currentData.hideAfter,
+                containsIcons = currentData.icon != null,
+                containsText = currentData.text.isNotEmpty(),
+                containsControls = currentData.cta != null,
+            ) ?: currentData.hideAfter
+
+            delay(duration.milliseconds)
             currentData.dismiss()
         }
     }
@@ -70,28 +82,30 @@ fun BpkFloatingNotification(
         if (widthDp >= TABLET_MIN_WIDTH.dp) DefaultTabletSize.height else DefaultPhoneSize.height
     val slideOffsetPx = with(LocalDensity.current) { BpkSpacing.Lg.toPx().toInt() }
 
-    AnimatedContent(
-        targetState = currentData,
-        modifier = modifier,
-        transitionSpec = floatingNotificationTransforms(slideOffsetPx),
-        label = "Floating Notification",
-    ) { data ->
+    Box(modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite }) {
+        AnimatedContent(
+            targetState = currentData,
+            modifier = modifier,
+            transitionSpec = floatingNotificationTransforms(slideOffsetPx),
+            label = "Floating Notification",
+        ) { data ->
 
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(start = BpkSpacing.Base, end = BpkSpacing.Base, bottom = BpkSpacing.Lg)
-                .navigationBarsPadding(),
-            contentAlignment = Alignment.BottomCenter,
-        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(start = BpkSpacing.Base, end = BpkSpacing.Base, bottom = BpkSpacing.Lg)
+                    .navigationBarsPadding(),
+                contentAlignment = Alignment.BottomCenter,
+            ) {
 
-            if (data != null) {
-                BpkFloatingNotificationImpl(
-                    data = data,
-                    modifier = Modifier
-                        .heightIn(min = componentHeight)
-                        .widthIn(max = DefaultTabletSize.width),
-                )
+                if (data != null) {
+                    BpkFloatingNotificationImpl(
+                        data = data,
+                        modifier = Modifier
+                            .heightIn(min = componentHeight)
+                            .widthIn(max = DefaultTabletSize.width),
+                    )
+                }
             }
         }
     }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/floatingnotification/BpkFloatingNotification.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/floatingnotification/BpkFloatingNotification.kt
@@ -81,22 +81,19 @@ fun BpkFloatingNotification(
         if (widthDp >= TABLET_MIN_WIDTH.dp) DefaultTabletSize.height else DefaultPhoneSize.height
     val slideOffsetPx = with(LocalDensity.current) { BpkSpacing.Lg.toPx().toInt() }
 
-    Box(modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite }) {
-        AnimatedContent(
-            targetState = currentData,
-            modifier = modifier,
-            transitionSpec = floatingNotificationTransforms(slideOffsetPx),
-            label = "Floating Notification",
-        ) { data ->
-
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(start = BpkSpacing.Base, end = BpkSpacing.Base, bottom = BpkSpacing.Lg)
-                    .navigationBarsPadding(),
-                contentAlignment = Alignment.BottomCenter,
-            ) {
-
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(start = BpkSpacing.Base, end = BpkSpacing.Base, bottom = BpkSpacing.Lg)
+            .navigationBarsPadding(),
+        contentAlignment = Alignment.BottomCenter,
+    ) {
+        Box(modifier = Modifier.semantics { liveRegion = LiveRegionMode.Polite }) {
+            AnimatedContent(
+                targetState = currentData,
+                transitionSpec = floatingNotificationTransforms(slideOffsetPx),
+                label = "Floating Notification",
+            ) { data ->
                 if (data != null) {
                     BpkFloatingNotificationImpl(
                         data = data,


### PR DESCRIPTION
[DON-3340](https://skyscanner.atlassian.net/browse/DON-3340)
Improve BpkFloatingNotification accessibility

- Use `LocalAccessibilityManager` to calculate recommended notification timeouts based on content complexity (text, icons, and controls)
- Wrap notification content in a `liveRegion` with `LiveRegionMode.Polite` to ensure accessibility services announce updates when they occur

<!--
Thanks for contributing to Backpack :pray:

Please include a description of the changes you are introducing and some screenshots if appropriate.

Please ensure your pull request title is clear as it will be used to generate the changelog.

Add `major`, `minor` or `patch` label depending on the change according to [semver](semver.org) or `skip-changelog` if the change shouldn't be added to the changelog (e.g. a change to a test or documentation)
-->

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)


[DON-3340]: https://skyscanner.atlassian.net/browse/DON-3340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ