### PR TITLE
SDBCK-330 Fix BpkPrice rendering blank in recycled lazy-list items

### DIFF
--- a/app/src/test/java/net/skyscanner/backpack/compose/price/BpkPriceTest.kt
+++ b/app/src/test/java/net/skyscanner/backpack/compose/price/BpkPriceTest.kt
@@ -19,6 +19,8 @@
 package net.skyscanner.backpack.compose.price
 
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
 import net.skyscanner.backpack.compose.BpkSnapshotTest
 import net.skyscanner.backpack.compose.icon.BpkIcon
 import net.skyscanner.backpack.compose.tokens.NewWindow
@@ -35,7 +37,9 @@ class BpkPriceTest(flavor: Flavor) : BpkSnapshotTest(listOf(flavor.size, flavor.
 
     @Test
     fun priceOnly() {
-        snap {
+        // Also guards against the price rendering blank when a BpkPrice node is re-used in a lazy
+        // list (regression: the price value must always be present in the semantics tree).
+        snap(assertion = { onNodeWithText(testContext.getString(R.string.price_price)).assertIsDisplayed() }) {
             BpkPrice(
                 price = stringResource(id = R.string.price_price),
                 size = size,
@@ -100,7 +104,8 @@ class BpkPriceTest(flavor: Flavor) : BpkSnapshotTest(listOf(flavor.size, flavor.
 
     @Test
     fun priceClickable() {
-        snap {
+        // Same regression guard for the clickable path, which renders via BpkLink.
+        snap(assertion = { onNodeWithText(testContext.getString(R.string.price_price)).assertIsDisplayed() }) {
             BpkPrice(
                 price = stringResource(id = R.string.price_price),
                 size = size,

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/price/internal/BpkPriceAlignEnd.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/price/internal/BpkPriceAlignEnd.kt
@@ -29,7 +29,6 @@ import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import net.skyscanner.backpack.compose.icon.BpkIcon
 import net.skyscanner.backpack.compose.icon.BpkIconSize
-import net.skyscanner.backpack.compose.link.BpkLink
 import net.skyscanner.backpack.compose.price.BpkPriceSize
 import net.skyscanner.backpack.compose.text.BpkText
 import net.skyscanner.backpack.compose.theme.BpkTheme
@@ -72,10 +71,10 @@ internal fun BpkPriceAlignEnd(
             }
         }
         Row(verticalAlignment = Alignment.CenterVertically) {
-            BpkLink(
-                text = priceAsALink(price, onPriceClicked),
-                onLinkClicked = { _: String -> onPriceClicked?.invoke() },
-                textStyle = size.mainTextStyle(),
+            BpkPriceLabel(
+                price = price,
+                size = size,
+                onPriceClicked = onPriceClicked,
             )
             icon?.let {
                 BpkIcon(

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/price/internal/BpkPriceAlignStart.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/price/internal/BpkPriceAlignStart.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextDecoration
 import net.skyscanner.backpack.compose.icon.BpkIcon
 import net.skyscanner.backpack.compose.icon.BpkIconSize
-import net.skyscanner.backpack.compose.link.BpkLink
 import net.skyscanner.backpack.compose.price.BpkPriceSize
 import net.skyscanner.backpack.compose.text.BpkText
 import net.skyscanner.backpack.compose.theme.BpkTheme
@@ -68,10 +67,10 @@ internal fun BpkPriceAlignStart(
         }
         Row(verticalAlignment = Alignment.Bottom) {
             Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.alignByBaseline()) {
-                BpkLink(
-                    text = priceAsALink(price, onPriceClicked),
-                    onLinkClicked = { _: String -> onPriceClicked?.invoke() },
-                    textStyle = size.mainTextStyle(),
+                BpkPriceLabel(
+                    price = price,
+                    size = size,
+                    onPriceClicked = onPriceClicked,
                 )
                 icon?.let {
                     BpkIcon(
@@ -97,7 +96,4 @@ internal fun BpkPriceAlignStart(
             }
         }
     }
-}
-internal fun priceAsALink(price: String, onPriceClicked: (() -> Unit)?): String {
-    return if (onPriceClicked != null) "[$price]($price)" else price
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/price/internal/BpkPriceLabel.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/price/internal/BpkPriceLabel.kt
@@ -1,0 +1,58 @@
+/**
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018 - 2026 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.skyscanner.backpack.compose.price.internal
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import net.skyscanner.backpack.compose.link.BpkLink
+import net.skyscanner.backpack.compose.price.BpkPriceSize
+import net.skyscanner.backpack.compose.text.BpkText
+import net.skyscanner.backpack.compose.theme.BpkTheme
+
+/**
+ * Renders the main price value shared by every [net.skyscanner.backpack.compose.price.BpkPriceAlign] variant.
+ *
+ * When [onPriceClicked] is null the price is a plain [BpkText] with a stable [String] input, so it can be skipped on
+ * recomposition and re-used cheaply inside lazy lists. Only when a click handler is supplied do we render a [BpkLink],
+ * using the action-only overload which remembers its annotated string rather than rebuilding it (and parsing markdown)
+ * on every recomposition.
+ */
+@Composable
+internal fun BpkPriceLabel(
+    price: String,
+    size: BpkPriceSize,
+    modifier: Modifier = Modifier,
+    onPriceClicked: (() -> Unit)? = null,
+) {
+    if (onPriceClicked != null) {
+        BpkLink(
+            text = price,
+            onClick = onPriceClicked,
+            textStyle = size.mainTextStyle(),
+            modifier = modifier,
+        )
+    } else {
+        BpkText(
+            text = price,
+            color = BpkTheme.colors.textPrimary,
+            style = size.mainTextStyle(),
+            modifier = modifier,
+        )
+    }
+}

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/price/internal/BpkPriceRow.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/price/internal/BpkPriceRow.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextDecoration
 import net.skyscanner.backpack.compose.icon.BpkIcon
 import net.skyscanner.backpack.compose.icon.BpkIconSize
-import net.skyscanner.backpack.compose.link.BpkLink
 import net.skyscanner.backpack.compose.price.BpkPriceSize
 import net.skyscanner.backpack.compose.text.BpkText
 import net.skyscanner.backpack.compose.theme.BpkTheme
@@ -69,10 +68,10 @@ internal fun BpkPriceRow(
             )
         }
         Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.alignByBaseline()) {
-            BpkLink(
-                text = priceAsALink(price, onPriceClicked),
-                onLinkClicked = { _: String -> onPriceClicked?.invoke() },
-                textStyle = size.mainTextStyle(),
+            BpkPriceLabel(
+                price = price,
+                size = size,
+                onPriceClicked = onPriceClicked,
             )
             icon?.let {
                 BpkIcon(


### PR DESCRIPTION
Description                                                                                                                                                                   
                                                                                                                                                                                
  ### Summary                                                                                                                                                                   
                                                                                                                                                                                
  `BpkPrice` could intermittently render a **blank price** when its Composable node                                                                                             
  was re-used in a scrolling list (e.g. hotel Day View cards in a `LazyColumn`).                                                                                                
  The price data was always correct in state — this was purely a rendering issue.                                                                                               
  Scrolling the affected card off-screen and back on repaints it correctly.                                                                                                     
                                                                                                                                                                                
  ### Root cause                                                                                                                                                                
                                                                                                                                                                                
  Since #2408 (Backpack 75.6.0), `BpkPrice` rendered the price through `BpkLink`                                                                                                
  regardless of whether a click handler was set. `BpkLink`'s markdown overload                                                                                                  
  rebuilds a fresh `AnnotatedString` on **every recomposition** (no `remember`),                                                                                                
  and wraps the value via `priceAsALink()` markdown parsing. On nodes re-used by a                                                                                              
  lazy layout this churny text path could paint empty until a relayout was forced.                                                                                              
                                                                                                                                                                                
  Before #2408 the price was a plain `BpkText(price)` with a stable `String` input                                                                                              
  and this did not happen.                                                                                                                                                      
                                                                                                                                                                                
  ### Fix                                                                                                                                                                       
                                                                                                                                                                                
  Introduce a shared internal `BpkPriceLabel` used by all three align variants                                                                                                  
  (`Start` / `End` / `Row`):                                                                                                                                                    
                                                                                                                                                                                
  - **No click handler** → render a plain `BpkText(price)`. Stable `String`,                                                                                                    
    skippable on recomposition — restores the pre-75.6.0 behaviour.                                                                                                             
  - **With click handler** → use the newer `BpkLink(text, onClick)` overload, which                                                                                             
    `remember`s its annotated string and avoids the markdown path entirely.                                                                                                     
                                                                                                                                                                                
  Also removes the `priceAsALink()` markdown helper, which had a latent parsing bug                                                                                             
  for prices containing `)` or `]`.               
  
  ### Testing                                                                                                                                                                   
                                                                                                                                                                                
  - Added an `assertIsDisplayed()` guard to the existing `priceOnly` and                                                                                                        
    `priceClickable` snapshot tests (all 9 size × align flavors) — the price value                                                                                              
    must always be present in the semantics tree.                                                                                                                               
  - `:app:verifyRoborazziOssDebug --tests "*.BpkPriceTest"` → **81 tests, 0 failures,                                                                                           
    0 skipped**; all existing reference screenshots still match (rendering unchanged).                                                                                          
                                                                                                                                                                                
  ### Notes for reviewers                                                                                                                                                       
                                                                                                                                                                                
  Verified at code level + screenshot suite. On-device repro (blank price while                                                                                                 
  fast-scrolling a `LazyColumn` of `BpkPrice` cards) should now be resolved.                                                                                                                               
                                                                                                                                                                                