### PR TITLE
[MUON-1865] Rename BpkGraphicPromo image param to background

### DIFF
--- a/app/src/main/java/net/skyscanner/backpack/demo/compose/GraphicPromoStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/compose/GraphicPromoStory.kt
@@ -33,9 +33,13 @@ import net.skyscanner.backpack.compose.graphicpromotion.BpkGraphicsPromoSponsor
 import net.skyscanner.backpack.compose.graphicpromotion.BpkGraphicPromoVerticalAlignment
 import net.skyscanner.backpack.compose.overlay.BpkOverlayType
 import net.skyscanner.backpack.compose.tokens.BpkSpacing
+import net.skyscanner.backpack.compose.videoplayer.BpkVideoPlayer
+import net.skyscanner.backpack.compose.videoplayer.BpkVideoPlayerConfig
+import net.skyscanner.backpack.compose.videoplayer.rememberBpkVideoPlayerController
 import net.skyscanner.backpack.demo.R
 import net.skyscanner.backpack.demo.components.GraphicPromoComponent
 import net.skyscanner.backpack.demo.meta.ComposeStory
+import net.skyscanner.backpack.meta.StoryKind
 
 @Composable
 @GraphicPromoComponent
@@ -101,6 +105,57 @@ internal fun GraphicPromoStorySponsoredWithLongTitle() {
     )
 }
 
+private const val GRAPHIC_PROMO_VIDEO_URL =
+    "https://content.skyscnr.com/media/68afbd83-d09a-48e8-9821-90c117b8f842/593d0fe4-5459-4c43-beb9-49f9ce79d365.m3u8"
+
+@Composable
+@GraphicPromoComponent
+@ComposeStory(name = "Sponsored with video background", kind = StoryKind.DemoOnly)
+internal fun GraphicPromoStorySponsoredWithVideoBackground() {
+    val controller = rememberBpkVideoPlayerController(
+        config = BpkVideoPlayerConfig(
+            videoUrl = GRAPHIC_PROMO_VIDEO_URL,
+            loop = true,
+            startsMuted = true,
+            accessibilityLabel = "Sample video",
+        ),
+    )
+    BpkGraphicPromo(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(BpkSpacing.Base),
+        headline = "Three Parks Challenge",
+        verticalAlignment = BpkGraphicPromoVerticalAlignment.Bottom,
+        overlayType = BpkOverlayType.SolidHigh,
+        sponsor = BpkGraphicsPromoSponsor(
+            accessibilityLabel = "In partnership with Skyland",
+            logo = "https://images.kiwi.com/airlines/64/FR.png",
+            title = "In partnership with Skyland",
+            callToAction = BpkGraphicPromoSponsorCTA(
+                accessibilityLabel = "Learn more about our sponsor",
+                onClick = {},
+            ),
+        ),
+        background = {
+            BpkVideoPlayer(
+                controller = controller,
+                modifier = Modifier.matchParentSize(),
+                scaleToFill = true,
+            )
+        },
+        sponsorLogo = {
+            Image(
+                painter = painterResource(id = R.drawable.skyland),
+                contentDescription = "Image",
+                contentScale = ContentScale.Fit,
+            )
+        },
+        tapAction = {
+            Log.d("BpkGraphicPromo", "Tap on graphic promo")
+        },
+    )
+}
+
 @Composable
 internal fun BpkGraphicPromoSample(
     modifier: Modifier = Modifier,
@@ -121,7 +176,7 @@ internal fun BpkGraphicPromoSample(
         verticalAlignment = verticalAlignment,
         overlayType = overlayType,
         sponsor = sponsor,
-        image = {
+        background = {
             Image(
                 modifier = Modifier.matchParentSize(),
                 painter = painterResource(

--- a/app/src/main/java/net/skyscanner/backpack/demo/compose/GraphicPromoStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/compose/GraphicPromoStory.kt
@@ -35,6 +35,7 @@ import net.skyscanner.backpack.compose.overlay.BpkOverlayType
 import net.skyscanner.backpack.compose.tokens.BpkSpacing
 import net.skyscanner.backpack.compose.videoplayer.BpkVideoPlayer
 import net.skyscanner.backpack.compose.videoplayer.BpkVideoPlayerConfig
+import net.skyscanner.backpack.compose.videoplayer.BpkVideoUrl
 import net.skyscanner.backpack.compose.videoplayer.rememberBpkVideoPlayerController
 import net.skyscanner.backpack.demo.R
 import net.skyscanner.backpack.demo.components.GraphicPromoComponent
@@ -114,7 +115,7 @@ private const val GRAPHIC_PROMO_VIDEO_URL =
 internal fun GraphicPromoStorySponsoredWithVideoBackground() {
     val controller = rememberBpkVideoPlayerController(
         config = BpkVideoPlayerConfig(
-            videoUrl = GRAPHIC_PROMO_VIDEO_URL,
+            videoUrl = BpkVideoUrl(GRAPHIC_PROMO_VIDEO_URL),
             loop = true,
             startsMuted = true,
             accessibilityLabel = "Sample video",

--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/graphicpromotion/BpkGraphicPromoTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/graphicpromotion/BpkGraphicPromoTest.kt
@@ -55,7 +55,7 @@ class BpkGraphicPromoTest {
                     subHeadline = subHeadline,
                     sponsor = sponsor,
                     sponsorLogo = sponsorLogo,
-                    image = { Box(Modifier.fillMaxSize()) },
+                    background = { Box(Modifier.fillMaxSize()) },
                 )
             }
         }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/graphicpromotion/BpkGraphicPromo.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/graphicpromotion/BpkGraphicPromo.kt
@@ -46,7 +46,7 @@ data class BpkGraphicsPromoSponsor(
 @Composable
 fun BpkGraphicPromo(
     headline: String,
-    image: @Composable BoxScope.() -> Unit,
+    background: @Composable BoxScope.() -> Unit,
     modifier: Modifier = Modifier,
     kicker: String? = null,
     subHeadline: String? = null,
@@ -68,7 +68,7 @@ fun BpkGraphicPromo(
         variant = variant,
         verticalAlignment = verticalAlignment,
         sponsor = sponsor,
-        image = image,
+        background = background,
         sponsorLogo = sponsorLogo,
         interactionSource = interactionSource,
         tapAction = tapAction,

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/graphicpromotion/internal/BpkGraphicPromoImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/graphicpromotion/internal/BpkGraphicPromoImpl.kt
@@ -89,7 +89,7 @@ import net.skyscanner.backpack.compose.utils.isTablet
 @Composable
 internal fun BpkGraphicPromoImpl(
     headline: String,
-    image: @Composable BoxScope.() -> Unit,
+    background: @Composable BoxScope.() -> Unit,
     interactionSource: MutableInteractionSource,
     modifier: Modifier = Modifier,
     kicker: String? = null,
@@ -139,14 +139,14 @@ internal fun BpkGraphicPromoImpl(
                         sponsorLogo = sponsorLogo,
                     )
                 },
-                content = image,
+                content = background,
             )
         } else {
             Box(
                 modifier = Modifier
                     .matchParentSize()
                     .semantics { hideFromAccessibility() },
-                content = image,
+                content = background,
             )
             ForegroundContent(
                 headline = headline,

--- a/docs/compose/GraphicPromo/README.md
+++ b/docs/compose/GraphicPromo/README.md
@@ -70,7 +70,7 @@ BpkGraphicPromo(
             onClick = { /* open sponsor info modal */ },
         ),
     ),
-    image = {
+    background = {
         Image(
             modifier = Modifier.matchParentSize(),
             painter = painterResource(id = R.drawable.graphic_promo),
@@ -87,5 +87,59 @@ BpkGraphicPromo(
     tapAction = {
         Log.d("TAG", "Tap on graphic promo")
     },
+)
+```
+
+### Sponsored with a video background
+
+The `background` parameter accepts any composable, so a [`BpkVideoPlayer`](https://github.com/skyscanner/backpack-android/tree/main/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer) can be used in place of a static image:
+
+```Kotlin
+import net.skyscanner.backpack.compose.graphicpromotion.BpkGraphicPromo
+import net.skyscanner.backpack.compose.graphicpromotion.BpkGraphicPromoSponsorCTA
+import net.skyscanner.backpack.compose.graphicpromotion.BpkGraphicsPromoSponsor
+import net.skyscanner.backpack.compose.graphicpromotion.BpkGraphicPromoVerticalAlignment
+import net.skyscanner.backpack.compose.overlay.BpkOverlayType
+import net.skyscanner.backpack.compose.videoplayer.BpkVideoPlayer
+import net.skyscanner.backpack.compose.videoplayer.BpkVideoPlayerConfig
+import net.skyscanner.backpack.compose.videoplayer.rememberBpkVideoPlayerController
+
+val controller = rememberBpkVideoPlayerController(
+    config = BpkVideoPlayerConfig(
+        videoUrl = "https://example.com/video.m3u8",
+        loop = true,
+        startsMuted = true,
+        accessibilityLabel = "Sample video",
+    ),
+)
+
+BpkGraphicPromo(
+    headline = "Three Parks Challenge",
+    verticalAlignment = BpkGraphicPromoVerticalAlignment.Bottom,
+    overlayType = BpkOverlayType.SolidHigh,
+    sponsor = BpkGraphicsPromoSponsor(
+        accessibilityLabel = "Sponsored",
+        logo = "https://images.kiwi.com/airlines/64/FR.png",
+        title = "Sponsored",
+        callToAction = BpkGraphicPromoSponsorCTA(
+            accessibilityLabel = "Learn more about our sponsor",
+            onClick = { /* open sponsor info modal */ },
+        ),
+    ),
+    background = {
+        BpkVideoPlayer(
+            controller = controller,
+            modifier = Modifier.matchParentSize(),
+            scaleToFill = true,
+        )
+    },
+    sponsorLogo = {
+        Image(
+            painter = painterResource(id = R.drawable.skyland),
+            contentDescription = "Image",
+            contentScale = ContentScale.Fit,
+        )
+    },
+    tapAction = { /* handle tap */ },
 )
 ```

--- a/docs/compose/GraphicPromo/README.md
+++ b/docs/compose/GraphicPromo/README.md
@@ -90,56 +90,27 @@ BpkGraphicPromo(
 )
 ```
 
-### Sponsored with a video background
+### Background content
 
-The `background` parameter accepts any composable, so a [`BpkVideoPlayer`](https://github.com/skyscanner/backpack-android/tree/main/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer) can be used in place of a static image:
+`background` accepts any composable, so it can be a static image or a [`BpkVideoPlayer`](https://github.com/skyscanner/backpack-android/tree/main/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer):
 
 ```Kotlin
-import net.skyscanner.backpack.compose.graphicpromotion.BpkGraphicPromo
-import net.skyscanner.backpack.compose.graphicpromotion.BpkGraphicPromoSponsorCTA
-import net.skyscanner.backpack.compose.graphicpromotion.BpkGraphicsPromoSponsor
-import net.skyscanner.backpack.compose.graphicpromotion.BpkGraphicPromoVerticalAlignment
-import net.skyscanner.backpack.compose.overlay.BpkOverlayType
-import net.skyscanner.backpack.compose.videoplayer.BpkVideoPlayer
-import net.skyscanner.backpack.compose.videoplayer.BpkVideoPlayerConfig
-import net.skyscanner.backpack.compose.videoplayer.rememberBpkVideoPlayerController
+// Image
+background = {
+    Image(
+        modifier = Modifier.matchParentSize(),
+        painter = painterResource(id = R.drawable.graphic_promo),
+        contentDescription = "Image",
+        contentScale = ContentScale.Crop,
+    )
+}
 
-val controller = rememberBpkVideoPlayerController(
-    config = BpkVideoPlayerConfig(
-        videoUrl = "https://example.com/video.m3u8",
-        loop = true,
-        startsMuted = true,
-        accessibilityLabel = "Sample video",
-    ),
-)
-
-BpkGraphicPromo(
-    headline = "Three Parks Challenge",
-    verticalAlignment = BpkGraphicPromoVerticalAlignment.Bottom,
-    overlayType = BpkOverlayType.SolidHigh,
-    sponsor = BpkGraphicsPromoSponsor(
-        accessibilityLabel = "Sponsored",
-        logo = "https://images.kiwi.com/airlines/64/FR.png",
-        title = "Sponsored",
-        callToAction = BpkGraphicPromoSponsorCTA(
-            accessibilityLabel = "Learn more about our sponsor",
-            onClick = { /* open sponsor info modal */ },
-        ),
-    ),
-    background = {
-        BpkVideoPlayer(
-            controller = controller,
-            modifier = Modifier.matchParentSize(),
-            scaleToFill = true,
-        )
-    },
-    sponsorLogo = {
-        Image(
-            painter = painterResource(id = R.drawable.skyland),
-            contentDescription = "Image",
-            contentScale = ContentScale.Fit,
-        )
-    },
-    tapAction = { /* handle tap */ },
-)
+// Video
+background = {
+    BpkVideoPlayer(
+        controller = controller,
+        modifier = Modifier.matchParentSize(),
+        scaleToFill = true,
+    )
+}
 ```


### PR DESCRIPTION
## Summary

- Renames `BpkGraphicPromo`'s `image: @Composable BoxScope.() -> Unit` parameter to `background`. The parameter already accepted any composable, so it was never actually limited to images the way iOS's `BPKGraphicPromo` was prior to [backpack-ios#2593](https://github.com/Skyscanner/backpack-ios/pull/2593) — this rename aligns naming with iOS's `Background: View` generic and makes it explicit that the slot supports `BpkVideoPlayer` ([backpack-ios#2606](https://github.com/Skyscanner/backpack-ios/pull/2606) on iOS, `BpkVideoPlayer` from `muon-1847-bpkvideo` on Android).
- Adds a new demo story (`GraphicPromoStorySponsoredWithVideoBackground`) showing a sponsored `BpkGraphicPromo` using `BpkVideoPlayer` as its background, mirroring iOS's example app use case from #2606.
- Updates `docs/compose/GraphicPromo/README.md` with the renamed parameter and a new "Sponsored with a video background" section.

## Breaking change

`BpkGraphicPromo`'s `image` parameter is renamed to `background`. Kotlin doesn't support two overloads that differ only by parameter name with identical types, so there's no backward-compatible way to keep `image` working — existing callers need a one-line rename (`image = { ... }` → `background = { ... }`).

## Base branch

Stacked on top of `muon-1847-bpkvideo` (not yet merged) since it uses `BpkVideoPlayer` in the new demo story. Do not merge before `muon-1847-bpkvideo`.

## Test plan
- [x] `:backpack-compose:compileDebugKotlin`, `:app:compileOssDebugKotlin` compile cleanly
- [x] `:backpack-compose:compileDebugAndroidTestKotlin`, `:app:compileOssDebugUnitTestKotlin` compile cleanly
- [ ] Manually verify the new "Sponsored with video background" story in the demo app

🤖 Generated with [Claude Code](https://claude.com/claude-code)