### PR TITLE
Use PREFER_SETTINGS for dependency resolution repository mode

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,7 +27,7 @@ pluginManagement {
 }
 
 dependencyResolutionManagement {
-    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
     repositories {
         mavenCentral()
         google()


### PR DESCRIPTION
## What

Change `repositoriesMode` in `dependencyResolutionManagement` from `FAIL_ON_PROJECT_REPOS` to `PREFER_SETTINGS`.

## Why

`FAIL_ON_PROJECT_REPOS` causes the build to fail when any repository is added outside of `settings.gradle.kts`, such as via a Gradle init script in `~/.gradle/init.d/`. `PREFER_SETTINGS` allows such externally-configured repositories to coexist while still giving precedence to the repositories declared in settings — preserving the intended resolution order.

## Impact

No change to which repositories are used for builds on CI or for contributors who do not have additional init scripts. Contributors who have init scripts adding repositories will no longer see a build failure.

**Note:** for internal engineers relying on an Artifactory-backed init script to resolve dependencies through a firewall, this alone is not sufficient — `PREFER_SETTINGS` still only consults the repositories declared in `settings.gradle.kts` (public `mavenCentral`/`google`/`plugins.gradle.org` here) unless the init script also configures `dependencyResolutionManagement`. That gap is fixed upstream in [Skyscanner/configure-artifactory-credentials#188](https://github.com/Skyscanner/configure-artifactory-credentials/pull/188).