### PR TITLE
[Android] BpkVideoPlayer: controller testability (MUON-1847)

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlaybackState.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlaybackState.kt
@@ -19,7 +19,6 @@
 package net.skyscanner.backpack.compose.videoplayer
 
 sealed class BpkVideoPlaybackState {
-    data object Idle : BpkVideoPlaybackState()
     data object Loading : BpkVideoPlaybackState()
     data object ReadyToPlay : BpkVideoPlaybackState()
     data object Buffering : BpkVideoPlaybackState()

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerController.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerController.kt
@@ -35,8 +35,10 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import net.skyscanner.backpack.compose.videoplayer.internal.PlaybackEvent
 import net.skyscanner.backpack.compose.videoplayer.internal.PlayerFactory
 import net.skyscanner.backpack.compose.videoplayer.internal.isReducedMotionEnabled
+import net.skyscanner.backpack.compose.videoplayer.internal.reducePlaybackState
 
 @Stable
 class BpkVideoPlayerController internal constructor(
@@ -44,7 +46,7 @@ class BpkVideoPlayerController internal constructor(
     private val scope: CoroutineScope,
     context: Context,
 ) {
-    private val _playbackState = mutableStateOf<BpkVideoPlaybackState>(BpkVideoPlaybackState.Idle)
+    private val _playbackState = mutableStateOf<BpkVideoPlaybackState>(BpkVideoPlaybackState.Loading)
     val playbackState: State<BpkVideoPlaybackState> get() = _playbackState
 
     private val _isMuted = mutableStateOf(config.startsMuted)
@@ -61,7 +63,6 @@ class BpkVideoPlayerController internal constructor(
         player.addListener(playerListener())
         player.setMediaItem(MediaItem.fromUri(config.videoUrl.value))
         player.prepare()
-        _playbackState.value = BpkVideoPlaybackState.Loading
         startLoadTimeout()
     }
 
@@ -86,6 +87,9 @@ class BpkVideoPlayerController internal constructor(
 
     fun resetToStart() {
         player.seekTo(0)
+        if (_playbackState.value is BpkVideoPlaybackState.Ended) {
+            _playbackState.value = BpkVideoPlaybackState.ReadyToPlay
+        }
     }
 
     fun dispose() {
@@ -104,38 +108,30 @@ class BpkVideoPlayerController internal constructor(
         }
     }
 
+    private fun apply(event: PlaybackEvent) {
+        _playbackState.value = reducePlaybackState(_playbackState.value, event)
+    }
+
     private fun playerListener() = object : Player.Listener {
         override fun onPlaybackStateChanged(playbackState: Int) {
             when (playbackState) {
                 Player.STATE_READY -> {
                     timeoutJob?.cancel()
-                    _playbackState.value =
-                        if (player.isPlaying) BpkVideoPlaybackState.Playing
-                        else BpkVideoPlaybackState.ReadyToPlay
+                    apply(PlaybackEvent.Ready(isPlaying = player.isPlaying))
                 }
-                Player.STATE_BUFFERING -> {
-                    if (_playbackState.value is BpkVideoPlaybackState.Playing ||
-                        _playbackState.value is BpkVideoPlaybackState.ReadyToPlay
-                    ) {
-                        _playbackState.value = BpkVideoPlaybackState.Buffering
-                    }
-                }
-                Player.STATE_ENDED -> _playbackState.value = BpkVideoPlaybackState.Ended
+                Player.STATE_BUFFERING -> apply(PlaybackEvent.Buffering)
+                Player.STATE_ENDED -> apply(PlaybackEvent.Ended)
                 Player.STATE_IDLE -> Unit
             }
         }
 
         override fun onIsPlayingChanged(isPlaying: Boolean) {
-            if (isPlaying) {
-                _playbackState.value = BpkVideoPlaybackState.Playing
-            } else if (_playbackState.value is BpkVideoPlaybackState.Playing) {
-                _playbackState.value = BpkVideoPlaybackState.Paused
-            }
+            apply(PlaybackEvent.IsPlayingChanged(isPlaying))
         }
 
         override fun onPlayerError(error: PlaybackException) {
             timeoutJob?.cancel()
-            _playbackState.value = BpkVideoPlaybackState.Failed(BpkVideoPlayerError.PlaybackFailed(error))
+            apply(PlaybackEvent.Error(error))
         }
     }
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerController.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerController.kt
@@ -18,7 +18,6 @@
 
 package net.skyscanner.backpack.compose.videoplayer
 
-import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.Stable

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerController.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerController.kt
@@ -27,16 +27,15 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
-import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
-import androidx.media3.exoplayer.ExoPlayer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import net.skyscanner.backpack.compose.videoplayer.internal.PlaybackEvent
 import net.skyscanner.backpack.compose.videoplayer.internal.PlayerFactory
+import net.skyscanner.backpack.compose.videoplayer.internal.VideoPlayerHandle
 import net.skyscanner.backpack.compose.videoplayer.internal.isReducedMotionEnabled
 import net.skyscanner.backpack.compose.videoplayer.internal.reducePlaybackState
 
@@ -44,7 +43,8 @@ import net.skyscanner.backpack.compose.videoplayer.internal.reducePlaybackState
 class BpkVideoPlayerController internal constructor(
     val config: BpkVideoPlayerConfig,
     private val scope: CoroutineScope,
-    context: Context,
+    private val handle: VideoPlayerHandle,
+    reducedMotionEnabled: Boolean,
 ) {
     private val _playbackState = mutableStateOf<BpkVideoPlaybackState>(BpkVideoPlaybackState.Loading)
     val playbackState: State<BpkVideoPlaybackState> get() = _playbackState
@@ -52,28 +52,28 @@ class BpkVideoPlayerController internal constructor(
     private val _isMuted = mutableStateOf(config.startsMuted)
     val isMuted: State<Boolean> get() = _isMuted
 
-    internal val player: ExoPlayer = PlayerFactory.build(context)
+    internal val player: Player get() = handle.player
 
     private var timeoutJob: Job? = null
 
     init {
-        player.repeatMode = if (config.loop) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
-        player.volume = if (config.startsMuted) 0f else 1f
-        player.playWhenReady = config.autoPlay && !(config.respectsReducedMotion && isReducedMotionEnabled(context))
-        player.addListener(playerListener())
-        player.setMediaItem(MediaItem.fromUri(config.videoUrl.value))
-        player.prepare()
+        handle.repeatMode = if (config.loop) Player.REPEAT_MODE_ONE else Player.REPEAT_MODE_OFF
+        handle.volume = if (config.startsMuted) 0f else 1f
+        handle.playWhenReady = config.autoPlay && !(config.respectsReducedMotion && reducedMotionEnabled)
+        handle.addListener(playerListener())
+        handle.setMediaItem(config.videoUrl.value)
+        handle.prepare()
         startLoadTimeout()
     }
 
     fun play() {
         if (_playbackState.value is BpkVideoPlaybackState.Failed) return
-        if (_playbackState.value is BpkVideoPlaybackState.Ended) player.seekTo(0)
-        player.play()
+        if (_playbackState.value is BpkVideoPlaybackState.Ended) handle.seekTo(0)
+        handle.play()
     }
 
     fun pause() {
-        player.pause()
+        handle.pause()
     }
 
     fun toggle() {
@@ -82,11 +82,11 @@ class BpkVideoPlayerController internal constructor(
 
     fun setMuted(muted: Boolean) {
         _isMuted.value = muted
-        player.volume = if (muted) 0f else 1f
+        handle.volume = if (muted) 0f else 1f
     }
 
     fun resetToStart() {
-        player.seekTo(0)
+        handle.seekTo(0)
         if (_playbackState.value is BpkVideoPlaybackState.Ended) {
             _playbackState.value = BpkVideoPlaybackState.ReadyToPlay
         }
@@ -94,7 +94,7 @@ class BpkVideoPlayerController internal constructor(
 
     fun dispose() {
         timeoutJob?.cancel()
-        player.release()
+        handle.release()
     }
 
     private fun startLoadTimeout() {
@@ -103,7 +103,7 @@ class BpkVideoPlayerController internal constructor(
             delay(config.loadTimeoutMs)
             if (_playbackState.value == BpkVideoPlaybackState.Loading) {
                 _playbackState.value = BpkVideoPlaybackState.Failed(BpkVideoPlayerError.LoadTimeout)
-                player.stop()
+                handle.stop()
             }
         }
     }
@@ -117,7 +117,7 @@ class BpkVideoPlayerController internal constructor(
             when (playbackState) {
                 Player.STATE_READY -> {
                     timeoutJob?.cancel()
-                    apply(PlaybackEvent.Ready(isPlaying = player.isPlaying))
+                    apply(PlaybackEvent.Ready(isPlaying = handle.isPlaying))
                 }
                 Player.STATE_BUFFERING -> apply(PlaybackEvent.Buffering)
                 Player.STATE_ENDED -> apply(PlaybackEvent.Ended)
@@ -141,7 +141,12 @@ fun rememberBpkVideoPlayerController(config: BpkVideoPlayerConfig): BpkVideoPlay
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val controller = remember(config) {
-        BpkVideoPlayerController(config = config, scope = scope, context = context)
+        BpkVideoPlayerController(
+            config = config,
+            scope = scope,
+            handle = PlayerFactory.build(context),
+            reducedMotionEnabled = isReducedMotionEnabled(context),
+        )
     }
     DisposableEffect(controller) {
         onDispose { controller.dispose() }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/internal/BpkVideoPlaybackReducer.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/internal/BpkVideoPlaybackReducer.kt
@@ -1,0 +1,69 @@
+/**
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018 - 2026 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.skyscanner.backpack.compose.videoplayer.internal
+
+import net.skyscanner.backpack.compose.videoplayer.BpkVideoPlaybackState
+import net.skyscanner.backpack.compose.videoplayer.BpkVideoPlayerError
+
+/**
+ * A player signal, decoupled from the Media3 `Player.Listener` callbacks so the state machine can be
+ * exercised without an [androidx.media3.exoplayer.ExoPlayer] instance.
+ */
+internal sealed interface PlaybackEvent {
+    /** The player reached `STATE_READY`. [isPlaying] mirrors `Player.isPlaying` at that moment. */
+    data class Ready(val isPlaying: Boolean) : PlaybackEvent
+    data object Buffering : PlaybackEvent
+    data object Ended : PlaybackEvent
+    data class IsPlayingChanged(val isPlaying: Boolean) : PlaybackEvent
+    data class Error(val cause: Exception) : PlaybackEvent
+}
+
+/**
+ * Pure playback-state transition function. Returns [current] unchanged when an event should be ignored,
+ * so the caller can assign the result unconditionally.
+ */
+internal fun reducePlaybackState(
+    current: BpkVideoPlaybackState,
+    event: PlaybackEvent,
+): BpkVideoPlaybackState =
+    when (event) {
+        is PlaybackEvent.Ready ->
+            if (event.isPlaying) BpkVideoPlaybackState.Playing else BpkVideoPlaybackState.ReadyToPlay
+
+        PlaybackEvent.Buffering ->
+            if (current is BpkVideoPlaybackState.Playing || current is BpkVideoPlaybackState.ReadyToPlay) {
+                BpkVideoPlaybackState.Buffering
+            } else {
+                current
+            }
+
+        PlaybackEvent.Ended -> BpkVideoPlaybackState.Ended
+
+        is PlaybackEvent.IsPlayingChanged ->
+            if (event.isPlaying) {
+                BpkVideoPlaybackState.Playing
+            } else if (current is BpkVideoPlaybackState.Playing) {
+                BpkVideoPlaybackState.Paused
+            } else {
+                current
+            }
+
+        is PlaybackEvent.Error ->
+            BpkVideoPlaybackState.Failed(BpkVideoPlayerError.PlaybackFailed(event.cause))
+    }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/internal/PlayerFactory.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/internal/PlayerFactory.kt
@@ -20,6 +20,8 @@ package net.skyscanner.backpack.compose.videoplayer.internal
 
 import android.content.Context
 import androidx.annotation.OptIn
+import androidx.media3.common.MediaItem
+import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
@@ -27,10 +29,37 @@ import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 
 internal object PlayerFactory {
     @OptIn(UnstableApi::class)
-    fun build(context: Context): ExoPlayer =
-        ExoPlayer.Builder(context)
+    fun build(context: Context): VideoPlayerHandle {
+        val exoPlayer = ExoPlayer.Builder(context)
             .setMediaSourceFactory(
                 DefaultMediaSourceFactory(context).setDataSourceFactory(DefaultHttpDataSource.Factory()),
             )
             .build()
+        return ExoPlayerHandle(exoPlayer)
+    }
+}
+
+private class ExoPlayerHandle(override val player: ExoPlayer) : VideoPlayerHandle {
+    override var repeatMode: Int
+        get() = player.repeatMode
+        set(value) { player.repeatMode = value }
+
+    override var volume: Float
+        get() = player.volume
+        set(value) { player.volume = value }
+
+    override var playWhenReady: Boolean
+        get() = player.playWhenReady
+        set(value) { player.playWhenReady = value }
+
+    override val isPlaying: Boolean get() = player.isPlaying
+
+    override fun addListener(listener: Player.Listener) = player.addListener(listener)
+    override fun setMediaItem(uri: String) = player.setMediaItem(MediaItem.fromUri(uri))
+    override fun prepare() = player.prepare()
+    override fun play() = player.play()
+    override fun pause() = player.pause()
+    override fun seekTo(positionMs: Long) = player.seekTo(positionMs)
+    override fun stop() = player.stop()
+    override fun release() = player.release()
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/internal/VideoPlayerHandle.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/internal/VideoPlayerHandle.kt
@@ -1,0 +1,43 @@
+/**
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018 - 2026 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.skyscanner.backpack.compose.videoplayer.internal
+
+import androidx.media3.common.Player
+
+/**
+ * A narrow seam over the media player, exposing only the members [net.skyscanner.backpack.compose.videoplayer.BpkVideoPlayerController]
+ * needs. This keeps the concrete `ExoPlayer` out of the controller's logic so it can be driven by a
+ * fake in JVM unit tests, while [player] still hands the render surface a real [Player] for
+ * `ContentFrame`.
+ */
+internal interface VideoPlayerHandle {
+    val player: Player
+    var repeatMode: Int
+    var volume: Float
+    var playWhenReady: Boolean
+    val isPlaying: Boolean
+    fun addListener(listener: Player.Listener)
+    fun setMediaItem(uri: String)
+    fun prepare()
+    fun play()
+    fun pause()
+    fun seekTo(positionMs: Long)
+    fun stop()
+    fun release()
+}

--- a/backpack-compose/src/test/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlaybackStateTest.kt
+++ b/backpack-compose/src/test/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlaybackStateTest.kt
@@ -27,7 +27,6 @@ class BpkVideoPlaybackStateTest {
     @Test
     fun `isPlaying is true only for Playing state`() {
         assertTrue(BpkVideoPlaybackState.Playing.isPlaying)
-        assertFalse(BpkVideoPlaybackState.Idle.isPlaying)
         assertFalse(BpkVideoPlaybackState.Loading.isPlaying)
         assertFalse(BpkVideoPlaybackState.ReadyToPlay.isPlaying)
         assertFalse(BpkVideoPlaybackState.Buffering.isPlaying)
@@ -40,7 +39,6 @@ class BpkVideoPlaybackStateTest {
     fun `isLoading is true for Loading and Buffering states`() {
         assertTrue(BpkVideoPlaybackState.Loading.isLoading)
         assertTrue(BpkVideoPlaybackState.Buffering.isLoading)
-        assertFalse(BpkVideoPlaybackState.Idle.isLoading)
         assertFalse(BpkVideoPlaybackState.ReadyToPlay.isLoading)
         assertFalse(BpkVideoPlaybackState.Playing.isLoading)
         assertFalse(BpkVideoPlaybackState.Paused.isLoading)

--- a/backpack-compose/src/test/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerControllerTest.kt
+++ b/backpack-compose/src/test/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerControllerTest.kt
@@ -1,0 +1,199 @@
+/*
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018 - 2026 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.skyscanner.backpack.compose.videoplayer
+
+import androidx.media3.common.Player
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BpkVideoPlayerControllerTest {
+
+    private fun config(
+        loop: Boolean = false,
+        startsMuted: Boolean = true,
+        autoPlay: Boolean = true,
+        respectsReducedMotion: Boolean = true,
+        loadTimeoutMs: Long = 7_000L,
+    ) = BpkVideoPlayerConfig(
+        videoUrl = BpkVideoUrl("https://example.com/video.mp4"),
+        loop = loop,
+        startsMuted = startsMuted,
+        autoPlay = autoPlay,
+        respectsReducedMotion = respectsReducedMotion,
+        loadTimeoutMs = loadTimeoutMs,
+        accessibilityLabel = "Test video",
+    )
+
+    private fun controller(
+        scope: CoroutineScope,
+        handle: FakeVideoPlayerHandle = FakeVideoPlayerHandle(),
+        config: BpkVideoPlayerConfig = config(),
+        reducedMotionEnabled: Boolean = false,
+    ) = BpkVideoPlayerController(
+        config = config,
+        scope = scope,
+        handle = handle,
+        reducedMotionEnabled = reducedMotionEnabled,
+    )
+
+    @Test
+    fun `init prepares the player with the configured media item`() = runTest {
+        val handle = FakeVideoPlayerHandle()
+        controller(this, handle)
+        assertEquals("https://example.com/video.mp4", handle.mediaUri)
+        assertTrue(handle.prepared)
+        assertEquals(1, handle.listeners.size)
+    }
+
+    @Test
+    fun `loop config maps to repeat mode`() = runTest {
+        val looping = FakeVideoPlayerHandle()
+        controller(this, looping, config(loop = true))
+        assertEquals(Player.REPEAT_MODE_ONE, looping.repeatMode)
+
+        val once = FakeVideoPlayerHandle()
+        controller(this, once, config(loop = false))
+        assertEquals(Player.REPEAT_MODE_OFF, once.repeatMode)
+    }
+
+    @Test
+    fun `startsMuted config maps to volume`() = runTest {
+        val muted = FakeVideoPlayerHandle()
+        controller(this, muted, config(startsMuted = true))
+        assertEquals(0f, muted.volume, 0f)
+
+        val loud = FakeVideoPlayerHandle()
+        controller(this, loud, config(startsMuted = false))
+        assertEquals(1f, loud.volume, 0f)
+    }
+
+    @Test
+    fun `playWhenReady honours autoPlay and reduced motion`() = runTest {
+        // autoPlay on, no reduced motion -> plays
+        val a = FakeVideoPlayerHandle()
+        controller(this, a, config(autoPlay = true), reducedMotionEnabled = false)
+        assertTrue(a.playWhenReady)
+
+        // autoPlay on, reduced motion respected -> blocked
+        val b = FakeVideoPlayerHandle()
+        controller(this, b, config(autoPlay = true, respectsReducedMotion = true), reducedMotionEnabled = true)
+        assertFalse(b.playWhenReady)
+
+        // autoPlay on, reduced motion NOT respected -> plays despite reduced motion
+        val c = FakeVideoPlayerHandle()
+        controller(this, c, config(autoPlay = true, respectsReducedMotion = false), reducedMotionEnabled = true)
+        assertTrue(c.playWhenReady)
+
+        // autoPlay off -> never plays
+        val d = FakeVideoPlayerHandle()
+        controller(this, d, config(autoPlay = false), reducedMotionEnabled = false)
+        assertFalse(d.playWhenReady)
+    }
+
+    @Test
+    fun `play from Ended seeks to start`() = runTest {
+        val handle = FakeVideoPlayerHandle()
+        val controller = controller(this, handle)
+        handle.emitEnded()
+        assertTrue(controller.playbackState.value is BpkVideoPlaybackState.Ended)
+
+        controller.play()
+        assertEquals(0L, handle.lastSeekMs)
+        assertTrue(handle.playCalled)
+    }
+
+    @Test
+    fun `play is a no-op when Failed`() = runTest {
+        val handle = FakeVideoPlayerHandle()
+        val controller = controller(this, handle, config(loadTimeoutMs = 100L))
+        advanceTimeBy(150L)
+        advanceUntilIdle()
+        assertTrue(controller.playbackState.value is BpkVideoPlaybackState.Failed)
+
+        controller.play()
+        assertFalse(handle.playCalled)
+    }
+
+    @Test
+    fun `setMuted toggles volume and state`() = runTest {
+        val handle = FakeVideoPlayerHandle()
+        val controller = controller(this, handle)
+
+        controller.setMuted(false)
+        assertFalse(controller.isMuted.value)
+        assertEquals(1f, handle.volume, 0f)
+
+        controller.setMuted(true)
+        assertTrue(controller.isMuted.value)
+        assertEquals(0f, handle.volume, 0f)
+    }
+
+    @Test
+    fun `resetToStart seeks and clears Ended`() = runTest {
+        val handle = FakeVideoPlayerHandle()
+        val controller = controller(this, handle)
+        handle.emitEnded()
+
+        controller.resetToStart()
+        assertEquals(0L, handle.lastSeekMs)
+        assertTrue(controller.playbackState.value is BpkVideoPlaybackState.ReadyToPlay)
+    }
+
+    @Test
+    fun `load timeout transitions to Failed and stops the player`() = runTest {
+        val handle = FakeVideoPlayerHandle()
+        val controller = controller(this, handle, config(loadTimeoutMs = 500L))
+
+        assertTrue(controller.playbackState.value is BpkVideoPlaybackState.Loading)
+        advanceTimeBy(600L)
+        advanceUntilIdle()
+
+        val state = controller.playbackState.value
+        assertTrue(state is BpkVideoPlaybackState.Failed)
+        assertEquals(BpkVideoPlayerError.LoadTimeout, (state as BpkVideoPlaybackState.Failed).cause)
+        assertTrue(handle.stopped)
+    }
+
+    @Test
+    fun `ready before timeout cancels the timeout`() = runTest(StandardTestDispatcher()) {
+        val handle = FakeVideoPlayerHandle()
+        val controller = controller(this, handle, config(loadTimeoutMs = 500L))
+
+        handle.emitReady(isPlaying = false)
+        advanceTimeBy(600L)
+        advanceUntilIdle()
+
+        assertTrue(controller.playbackState.value is BpkVideoPlaybackState.ReadyToPlay)
+    }
+
+    @Test
+    fun `dispose releases the player`() = runTest {
+        val handle = FakeVideoPlayerHandle()
+        val controller = controller(this, handle)
+        controller.dispose()
+        assertTrue(handle.released)
+    }
+}

--- a/backpack-compose/src/test/kotlin/net/skyscanner/backpack/compose/videoplayer/FakeVideoPlayerHandle.kt
+++ b/backpack-compose/src/test/kotlin/net/skyscanner/backpack/compose/videoplayer/FakeVideoPlayerHandle.kt
@@ -1,0 +1,96 @@
+/*
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018 - 2026 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.skyscanner.backpack.compose.videoplayer
+
+import androidx.media3.common.Player
+import net.skyscanner.backpack.compose.videoplayer.internal.VideoPlayerHandle
+
+/**
+ * A recording fake of [VideoPlayerHandle] for JVM unit tests. It captures the calls the controller
+ * makes and lets a test drive the registered [Player.Listener] via the `emit*` helpers, without any
+ * ExoPlayer or Android framework dependency.
+ */
+class FakeVideoPlayerHandle : VideoPlayerHandle {
+
+    val listeners = mutableListOf<Player.Listener>()
+
+    var mediaUri: String? = null
+        private set
+    var prepared = false
+        private set
+    var playCalled = false
+        private set
+    var pauseCalled = false
+        private set
+    var stopped = false
+        private set
+    var released = false
+        private set
+    var lastSeekMs: Long? = null
+        private set
+
+    override var repeatMode: Int = Player.REPEAT_MODE_OFF
+    override var volume: Float = 1f
+    override var playWhenReady: Boolean = false
+    override var isPlaying: Boolean = false
+
+    // The render surface never runs in these tests, so the concrete Player is not needed.
+    override val player: Player get() = error("player is not available in FakeVideoPlayerHandle")
+
+    override fun addListener(listener: Player.Listener) {
+        listeners += listener
+    }
+
+    override fun setMediaItem(uri: String) {
+        mediaUri = uri
+    }
+
+    override fun prepare() {
+        prepared = true
+    }
+
+    override fun play() {
+        playCalled = true
+    }
+
+    override fun pause() {
+        pauseCalled = true
+    }
+
+    override fun seekTo(positionMs: Long) {
+        lastSeekMs = positionMs
+    }
+
+    override fun stop() {
+        stopped = true
+    }
+
+    override fun release() {
+        released = true
+    }
+
+    fun emitReady(isPlaying: Boolean) {
+        this.isPlaying = isPlaying
+        listeners.forEach { it.onPlaybackStateChanged(Player.STATE_READY) }
+    }
+
+    fun emitEnded() {
+        listeners.forEach { it.onPlaybackStateChanged(Player.STATE_ENDED) }
+    }
+}

--- a/backpack-compose/src/test/kotlin/net/skyscanner/backpack/compose/videoplayer/FakeVideoPlayerHandle.kt
+++ b/backpack-compose/src/test/kotlin/net/skyscanner/backpack/compose/videoplayer/FakeVideoPlayerHandle.kt
@@ -26,7 +26,7 @@ import net.skyscanner.backpack.compose.videoplayer.internal.VideoPlayerHandle
  * makes and lets a test drive the registered [Player.Listener] via the `emit*` helpers, without any
  * ExoPlayer or Android framework dependency.
  */
-class FakeVideoPlayerHandle : VideoPlayerHandle {
+internal class FakeVideoPlayerHandle : VideoPlayerHandle {
 
     val listeners = mutableListOf<Player.Listener>()
 

--- a/backpack-compose/src/test/kotlin/net/skyscanner/backpack/compose/videoplayer/internal/BpkVideoPlaybackReducerTest.kt
+++ b/backpack-compose/src/test/kotlin/net/skyscanner/backpack/compose/videoplayer/internal/BpkVideoPlaybackReducerTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018 - 2026 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.skyscanner.backpack.compose.videoplayer.internal
+
+import net.skyscanner.backpack.compose.videoplayer.BpkVideoPlaybackState
+import net.skyscanner.backpack.compose.videoplayer.BpkVideoPlayerError
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BpkVideoPlaybackReducerTest {
+
+    @Test
+    fun `Ready while playing resolves to Playing`() {
+        val result = reducePlaybackState(BpkVideoPlaybackState.Loading, PlaybackEvent.Ready(isPlaying = true))
+        assertEquals(BpkVideoPlaybackState.Playing, result)
+    }
+
+    @Test
+    fun `Ready while not playing resolves to ReadyToPlay`() {
+        val result = reducePlaybackState(BpkVideoPlaybackState.Loading, PlaybackEvent.Ready(isPlaying = false))
+        assertEquals(BpkVideoPlaybackState.ReadyToPlay, result)
+    }
+
+    @Test
+    fun `Buffering from Playing resolves to Buffering`() {
+        val result = reducePlaybackState(BpkVideoPlaybackState.Playing, PlaybackEvent.Buffering)
+        assertEquals(BpkVideoPlaybackState.Buffering, result)
+    }
+
+    @Test
+    fun `Buffering from ReadyToPlay resolves to Buffering`() {
+        val result = reducePlaybackState(BpkVideoPlaybackState.ReadyToPlay, PlaybackEvent.Buffering)
+        assertEquals(BpkVideoPlaybackState.Buffering, result)
+    }
+
+    @Test
+    fun `Buffering from other states is ignored`() {
+        assertEquals(
+            BpkVideoPlaybackState.Loading,
+            reducePlaybackState(BpkVideoPlaybackState.Loading, PlaybackEvent.Buffering),
+        )
+        assertEquals(
+            BpkVideoPlaybackState.Paused,
+            reducePlaybackState(BpkVideoPlaybackState.Paused, PlaybackEvent.Buffering),
+        )
+    }
+
+    @Test
+    fun `Ended always resolves to Ended`() {
+        assertEquals(
+            BpkVideoPlaybackState.Ended,
+            reducePlaybackState(BpkVideoPlaybackState.Playing, PlaybackEvent.Ended),
+        )
+    }
+
+    @Test
+    fun `IsPlayingChanged true resolves to Playing`() {
+        val result = reducePlaybackState(BpkVideoPlaybackState.ReadyToPlay, PlaybackEvent.IsPlayingChanged(true))
+        assertEquals(BpkVideoPlaybackState.Playing, result)
+    }
+
+    @Test
+    fun `IsPlayingChanged false from Playing resolves to Paused`() {
+        val result = reducePlaybackState(BpkVideoPlaybackState.Playing, PlaybackEvent.IsPlayingChanged(false))
+        assertEquals(BpkVideoPlaybackState.Paused, result)
+    }
+
+    @Test
+    fun `IsPlayingChanged false from non-Playing is ignored`() {
+        assertEquals(
+            BpkVideoPlaybackState.Buffering,
+            reducePlaybackState(BpkVideoPlaybackState.Buffering, PlaybackEvent.IsPlayingChanged(false)),
+        )
+    }
+
+    @Test
+    fun `Error resolves to Failed with PlaybackFailed cause`() {
+        val cause = IllegalStateException("boom")
+        val result = reducePlaybackState(BpkVideoPlaybackState.Playing, PlaybackEvent.Error(cause))
+        assertTrue(result is BpkVideoPlaybackState.Failed)
+        val error = (result as BpkVideoPlaybackState.Failed).cause
+        assertTrue(error is BpkVideoPlayerError.PlaybackFailed)
+        assertEquals(cause, (error as BpkVideoPlayerError.PlaybackFailed).cause)
+    }
+}

--- a/docs/compose/VideoPlayer/README.md
+++ b/docs/compose/VideoPlayer/README.md
@@ -129,7 +129,6 @@ when (playbackState) {
 
 | State | Meaning |
 | --- | --- |
-| `Idle` | Player not yet prepared |
 | `Loading` | Asset is being fetched or decoded |
 | `ReadyToPlay` | Asset ready — `autoPlay` will call `play()` if enabled |
 | `Playing` | Playback active |


### PR DESCRIPTION
## Context

Follow-up to #2740 (merged). Improves the testability of `BpkVideoPlayerController` in response to review feedback, and re-lands reducer work that did not make it into the squash-merged PR.

## What's here

**1. Reducer + state fixes (re-landed from #2740's branch)**
- Extract player state transitions into a pure `reducePlaybackState(current, event)` function driven by a `PlaybackEvent` model, covered by JVM unit tests.
- Remove the unreachable `Idle` state (`init` went straight to `Loading`, so no observer ever saw it) from the sealed class, README, and tests.
- `resetToStart()` now synchronously moves `Ended -> ReadyToPlay` so callers reading `playbackState` immediately after don't observe a stale `Ended`.

> Note: these three changes were made on the original PR branch but were **not included in the squash-merge** of #2740, so they are re-included here.

**2. Player handle seam for controller testability (new)**
- Introduce a narrow internal `VideoPlayerHandle` interface (only the ~12 members the controller uses), with `val player: Player` for the render surface.
- `PlayerFactory.build()` returns an `ExoPlayerHandle` delegating to a real `ExoPlayer`.
- The controller now takes `handle: VideoPlayerHandle` + `reducedMotionEnabled: Boolean` injected (defaults wired in `rememberBpkVideoPlayerController`). **No public API change** — `controller.player` still works because `ContentFrame` accepts the `Player` interface.
- Add `BpkVideoPlayerControllerTest` (+ `FakeVideoPlayerHandle`): 11 pure JVM unit tests covering config→player mapping (`repeatMode`, `volume`, `playWhenReady × reduced-motion`), `play`/`pause`/`setMuted`/`resetToStart`, load-timeout, and `dispose`. No ExoPlayer, no Robolectric, no new dependencies.

## Verification
- `./gradlew :backpack-compose:compileDebugKotlin :backpack-compose:compileDebugAndroidTestKotlin :app:compileOssDebugKotlin`
- `./gradlew :backpack-compose:testDebugUnitTest --tests "net.skyscanner.backpack.compose.videoplayer.*"` — 23 tests pass (11 controller + 10 reducer + 2 state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)