### PR TITLE
Support local files in BpkVideoPlayer

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/internal/PlayerFactory.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/internal/PlayerFactory.kt
@@ -31,10 +31,11 @@ import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 internal object PlayerFactory {
     @OptIn(UnstableApi::class)
     fun build(context: Context): VideoPlayerHandle {
-        val exoPlayer = ExoPlayer.Builder(context)
+        val applicationContext = context.applicationContext
+        val exoPlayer = ExoPlayer.Builder(applicationContext)
             .setMediaSourceFactory(
-                DefaultMediaSourceFactory(context).setDataSourceFactory(
-                    DefaultDataSource.Factory(context, DefaultHttpDataSource.Factory()),
+                DefaultMediaSourceFactory(applicationContext).setDataSourceFactory(
+                    DefaultDataSource.Factory(applicationContext, DefaultHttpDataSource.Factory()),
                 ),
             )
             .build()

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/internal/PlayerFactory.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/internal/PlayerFactory.kt
@@ -23,6 +23,7 @@ import androidx.annotation.OptIn
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.datasource.DefaultHttpDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
@@ -32,7 +33,9 @@ internal object PlayerFactory {
     fun build(context: Context): VideoPlayerHandle {
         val exoPlayer = ExoPlayer.Builder(context)
             .setMediaSourceFactory(
-                DefaultMediaSourceFactory(context).setDataSourceFactory(DefaultHttpDataSource.Factory()),
+                DefaultMediaSourceFactory(context).setDataSourceFactory(
+                    DefaultDataSource.Factory(context, DefaultHttpDataSource.Factory()),
+                ),
             )
             .build()
         return ExoPlayerHandle(exoPlayer)

--- a/docs/compose/VideoPlayer/README.md
+++ b/docs/compose/VideoPlayer/README.md
@@ -176,4 +176,4 @@ controller.setMuted(true)  // mute
 
 - Reduced motion: autoplay is blocked and playback pauses when `ANIMATOR_DURATION_SCALE` or `TRANSITION_ANIMATION_SCALE` is set to 0.
 - `accessibilityLabel` in `BpkVideoPlayerConfig` is applied as a `contentDescription` on the player container.
-- `videoUrl` in `BpkVideoPlayerConfig` is a `BpkVideoUrl` value class — wrap the URL string with `BpkVideoUrl("…")`.
+- `videoUrl` in `BpkVideoPlayerConfig` is a `BpkVideoUrl` value class — wrap an HTTPS URL or local file path with `BpkVideoUrl("…")`.

--- a/docs/compose/VideoPlayer/README.md
+++ b/docs/compose/VideoPlayer/README.md
@@ -176,4 +176,4 @@ controller.setMuted(true)  // mute
 
 - Reduced motion: autoplay is blocked and playback pauses when `ANIMATOR_DURATION_SCALE` or `TRANSITION_ANIMATION_SCALE` is set to 0.
 - `accessibilityLabel` in `BpkVideoPlayerConfig` is applied as a `contentDescription` on the player container.
-- `videoUrl` in `BpkVideoPlayerConfig` is a `BpkVideoUrl` value class — wrap an HTTPS URL or local file path with `BpkVideoUrl("…")`.
+- `videoUrl` in `BpkVideoPlayerConfig` is a `BpkVideoUrl` value class. It supports HTTP(S) URLs, absolute local file paths, and `file:///` URIs, for example `BpkVideoUrl("https://example.com/video.mp4")`, `BpkVideoUrl("/data/user/0/example/cache/video.mp4")`, or `BpkVideoUrl("file:///data/user/0/example/cache/video.mp4")`.


### PR DESCRIPTION
## What changed
- Use Media3 DefaultDataSource so BpkVideoPlayer supports local cached files and HTTPS URLs.
- Document local file-path support.

## Why
The previous HTTP-only data source rejected local cache paths with \`MalformedURLException: no protocol\`.

## Validation
- `detekt` passed.


| Standard animations | Reduced animations |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/91f1816a-43e4-423e-9248-32498520aa9d" controls></video> | <video src="https://github.com/user-attachments/assets/c7def737-1a53-4407-9d5f-48d2e0e2cb86" controls></video> |


