### PR TITLE
[MUON-2024] Fix removeObserver called on non-main thread in BpkVideoPlayer

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayer.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayer.kt
@@ -18,6 +18,8 @@
 
 package net.skyscanner.backpack.compose.videoplayer
 
+import android.os.Handler
+import android.os.Looper
 import androidx.annotation.OptIn
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
@@ -25,11 +27,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.media3.common.ForwardingPlayer
+import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.ui.compose.ContentFrame
 import net.skyscanner.backpack.compose.videoplayer.internal.rememberReducedMotionEnabled
@@ -49,15 +54,40 @@ fun BpkVideoPlayer(
         }
     }
 
+    // Wrap the player so removeListener is always dispatched to the main thread.
+    // ContentFrame uses player.listen { } whose invokeOnCancellation fires on whatever thread
+    // cancels the coroutine scope (e.g. the instrumentation thread in tests), causing ExoPlayer's
+    // thread check to crash. Intercepting removeListener here and posting to main fixes that
+    // without losing ContentFrame's resizeWithContentScale layout behavior.
+    val mainThreadPlayer = remember(controller.player) { MainThreadRemoveListenerPlayer(controller.player) }
+
     Box(
         modifier = modifier
             .background(Color.Black)
             .semantics { contentDescription = controller.config.accessibilityLabel },
     ) {
         ContentFrame(
-            player = controller.player,
+            player = mainThreadPlayer,
             contentScale = if (scaleToFill) ContentScale.Crop else ContentScale.Fit,
             modifier = Modifier.fillMaxSize(),
         )
+    }
+}
+
+@OptIn(UnstableApi::class)
+private class MainThreadRemoveListenerPlayer(player: Player) : ForwardingPlayer(player) {
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    override fun removeListener(listener: Player.Listener) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            super.removeListener(listener)
+        } else {
+            mainHandler.post {
+                // In case the player was released while this was queued.
+                runCatching {
+                    super.removeListener(listener)
+                }
+            }
+        }
     }
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/internal/ReducedMotion.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/internal/ReducedMotion.kt
@@ -21,8 +21,10 @@ package net.skyscanner.backpack.compose.videoplayer.internal
 import android.content.Context
 import android.provider.Settings
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.State
-import androidx.compose.runtime.produceState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -32,15 +34,17 @@ import androidx.lifecycle.compose.LocalLifecycleOwner
 internal fun rememberReducedMotionEnabled(): State<Boolean> {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
-    return produceState(initialValue = isReducedMotionEnabled(context), lifecycleOwner) {
+    val state = remember { mutableStateOf(isReducedMotionEnabled(context)) }
+    DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
             if (event == Lifecycle.Event.ON_RESUME) {
-                value = isReducedMotionEnabled(context)
+                state.value = isReducedMotionEnabled(context)
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
-        awaitDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
+    return state
 }
 
 internal fun isReducedMotionEnabled(context: Context): Boolean {


### PR DESCRIPTION
## Summary
Includes fix for https://skyscanner.atlassian.net/browse/DON-3575 too.
- `rememberReducedMotionEnabled` used `produceState` + `awaitDispose` to remove the lifecycle observer on disposal
- `awaitDispose` runs in the coroutine's context, which can be a non-main thread during test teardown
- `LifecycleRegistry.removeObserver` enforces main-thread access, causing the crash
- Fix replaces `produceState`/`awaitDispose` with `DisposableEffect`/`onDispose`, which is always called on the main thread by the Compose runtime

Fixes: https://skyscanner.atlassian.net/browse/MUON-2024

## Test plan

- [ ] Verify the failing instrumentation test `givenUnauthenticatedMarketingOptInIsVisibleAndPrimaryButtonTextIsCorrect_whenButtonIsClicked_thenNavigateToLogin` passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)