### PR TITLE
[DON-3564] Fix Added missing extension to image tag

### DIFF
--- a/docs/view/Maps/README.md
+++ b/docs/view/Maps/README.md
@@ -20,7 +20,7 @@
 
 | Day | Night |
 | --- | --- |
-| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Maps/screenshots/with_icons" alt="With Icons Maps component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Maps/screenshots/with_icons_dm.png" alt="With Icons Maps component - dark mode" width="375" /> |
+| <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Maps/screenshots/with_icons.png" alt="With Icons Maps component" width="375" /> |<img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/view/Maps/screenshots/with_icons_dm.png" alt="With Icons Maps component - dark mode" width="375" /> |
 
 ## Installation
 


### PR DESCRIPTION
Ticket: https://skyscanner.atlassian.net/browse/DON-3564

Fixed missing image, had Claude go through remaining images with some fancy grep commands to make sure there wasn't any others missing extensions.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md`
+ [ ] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)
