### PR TITLE
spike: Figma token sync — native JSON approach (no DTCG, no Style Dictionary)

### DIFF
--- a/token-sync/package-lock.json
+++ b/token-sync/package-lock.json
@@ -1,0 +1,562 @@
+{
+  "name": "backpack-android-token-sync",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "backpack-android-token-sync",
+      "version": "0.0.0",
+      "devDependencies": {
+        "dotenv": "^16.4.7",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.3"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://artifactory.skyscannertools.net/artifactory/api/npm/npm/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.3.tgz",
+      "integrity": "sha512-mdoNxBC/cSQObGGVQ5Bpn5i+yv7j68gk3Nfm3wFjcJg3Z0Mix9jzAFfP12prmm5eVGmDKtp0yyArrs0Q+8gZHg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/token-sync/package.json
+++ b/token-sync/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "backpack-android-token-sync",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "tokens:fetch": "tsx src/fetch.ts"
+  },
+  "devDependencies": {
+    "dotenv": "^16.4.7",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.3"
+  }
+}

--- a/token-sync/src/fetch.ts
+++ b/token-sync/src/fetch.ts
@@ -1,0 +1,363 @@
+/**
+ * Fetch design tokens from the Figma Variables API and write them in the
+ * bpk-foundations-android JSON format that the existing buildSrc Kotlin
+ * pipeline already understands — no DTCG, no Style Dictionary required.
+ *
+ * Output: token-sync/tokens/base.raw.android.json
+ *
+ * Run: npm run tokens:fetch
+ */
+
+import { createRequire } from 'module';
+import { mkdirSync, writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const require = createRequire(import.meta.url);
+const dotenv = require('dotenv');
+dotenv.config({ path: resolve(__dirname, '../.env') });
+
+const FIGMA_TOKEN = process.env.FIGMA_TOKEN;
+const FIGMA_FILE_KEY = process.env.FIGMA_FILE_KEY ?? 'KXf2gHNLDe2cXWUoHl4cTX';
+const OUTPUT_DIR = process.env.TOKENS_DIR ?? resolve(__dirname, '../tokens');
+
+// ─── Figma API types ──────────────────────────────────────────────────────────
+
+interface FigmaColor { r: number; g: number; b: number; a: number }
+interface FigmaAlias { type: 'VARIABLE_ALIAS'; id: string }
+type FigmaValue = number | string | boolean | FigmaColor | FigmaAlias;
+
+interface FigmaVariable {
+  id: string;
+  name: string;
+  resolvedType: 'COLOR' | 'FLOAT' | 'STRING' | 'BOOLEAN';
+  variableCollectionId: string;
+  valuesByMode: Record<string, FigmaValue>;
+  scopes: string[];
+}
+
+interface FigmaCollection {
+  id: string;
+  name: string;
+  modes: Array<{ modeId: string; name: string }>;
+  variableIds: string[];
+}
+
+// ─── bpk-foundations-android JSON types ──────────────────────────────────────
+
+interface BpkProp {
+  type: 'color' | 'size' | 'font-size' | 'letter-spacing' | 'duration' | 'string' | 'font';
+  category: string;
+  value: string;
+  originalValue?: string;
+  name: string;
+  darkValue?: string;
+  originalDarkValue?: string;
+  deprecated?: boolean;
+}
+
+interface BpkFoundationsJson {
+  aliases: Record<string, string>;
+  props: Record<string, BpkProp>;
+  propKeys: string[];
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function isFigmaAlias(v: FigmaValue): v is FigmaAlias {
+  return typeof v === 'object' && v !== null && (v as FigmaAlias).type === 'VARIABLE_ALIAS';
+}
+
+function isFigmaColor(v: FigmaValue): v is FigmaColor {
+  return typeof v === 'object' && v !== null && 'r' in v;
+}
+
+function figmaColorToHex({ r, g, b, a }: FigmaColor): string {
+  const hex = (n: number) => Math.round(n * 255).toString(16).padStart(2, '0');
+  return `#${hex(r)}${hex(g)}${hex(b)}${hex(a)}`;
+}
+
+function figmaNameToKey(name: string): string {
+  return name
+    .replace(/[^a-zA-Z0-9/]/g, '_')
+    .replace(/\//g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_|_$/g, '')
+    .toUpperCase();
+}
+
+function findCollection(collections: FigmaCollection[], name: string): FigmaCollection | undefined {
+  return collections
+    .filter(c => c.name === name)
+    .sort((a, b) => b.variableIds.length - a.variableIds.length)[0];
+}
+
+function getModeId(collection: FigmaCollection, preferred: string[]): string {
+  const found = collection.modes.find(m => preferred.includes(m.name));
+  return found?.modeId ?? collection.modes[0].modeId;
+}
+
+// Resolve a Figma value — follows one level of alias to get the primitive value
+// and returns both the resolved hex/number and the original reference key.
+function resolveValue(
+  raw: FigmaValue,
+  variables: Record<string, FigmaVariable>,
+  primitivesModeId: string,
+): { value: string; originalValue: string } | null {
+  if (isFigmaAlias(raw)) {
+    const target = variables[raw.id];
+    if (!target) return null;
+    const aliasKey = figmaNameToKey(target.name);
+    const targetRaw = target.valuesByMode[primitivesModeId] ??
+      target.valuesByMode[Object.keys(target.valuesByMode)[0]];
+    if (!targetRaw || isFigmaAlias(targetRaw)) {
+      // Two-level alias — resolve further
+      if (isFigmaAlias(targetRaw)) {
+        return resolveValue(targetRaw, variables, primitivesModeId);
+      }
+      return null;
+    }
+    if (isFigmaColor(targetRaw)) {
+      return { value: figmaColorToHex(targetRaw), originalValue: `{!${aliasKey}}` };
+    }
+    return { value: String(targetRaw), originalValue: `{!${aliasKey}}` };
+  }
+  if (isFigmaColor(raw)) {
+    return { value: figmaColorToHex(raw), originalValue: figmaColorToHex(raw) };
+  }
+  return { value: String(raw), originalValue: String(raw) };
+}
+
+// ─── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  if (!FIGMA_TOKEN) {
+    console.error('Error: FIGMA_TOKEN is not set.');
+    console.error('Copy token-sync/.env.example to token-sync/.env and add your token.');
+    process.exit(1);
+  }
+
+  console.log(`Fetching variables from Figma file: ${FIGMA_FILE_KEY}`);
+
+  const res = await fetch(
+    `https://api.figma.com/v1/files/${encodeURIComponent(FIGMA_FILE_KEY)}/variables/local`,
+    { headers: { 'X-Figma-Token': FIGMA_TOKEN, Accept: 'application/json' } },
+  );
+
+  if (!res.ok) {
+    const body = await res.text();
+    console.error(`Figma API error ${res.status}: ${body}`);
+    process.exit(1);
+  }
+
+  const { meta } = (await res.json()) as {
+    meta: {
+      variables: Record<string, FigmaVariable>;
+      variableCollections: Record<string, FigmaCollection>;
+    };
+  };
+
+  const { variables, variableCollections } = meta;
+  const collections = Object.values(variableCollections);
+
+  console.log(`\nFound ${collections.length} collection(s):`);
+  for (const c of collections) {
+    const modes = c.modes.map(m => m.name).join(', ');
+    console.log(`  • "${c.name}" — ${c.variableIds.length} vars, modes: [${modes}]`);
+  }
+
+  const props: Record<string, BpkProp> = {};
+  const aliases: Record<string, string> = {};
+
+  // ── Primitives (Colours, Spacing, Radius, Border, Type etc.) ─────────────────
+  const primColl = findCollection(collections, 'Primitives');
+  if (!primColl) { console.warn('⚠  No Primitives collection found'); process.exit(1); }
+  const primModeId = getModeId(primColl, ['Value', 'Hex']);
+
+  // Category mapping: Figma top-level group → bpk-foundations category + prop type
+  const PRIMITIVES_CATEGORY_MAP: Record<string, { category: string; type: BpkProp['type'] }> = {
+    'Spacing':       { category: 'spacings',       type: 'size' },
+    'Radius':        { category: 'radii',           type: 'size' },
+    'Border':        { category: 'borders',         type: 'size' },
+    'Heights':       { category: 'spacings',        type: 'size' },
+    'Modal':         { category: 'spacings',        type: 'size' },
+    'Type/Size':     { category: 'typesettings',    type: 'font-size' },
+    'Type/Line-height': { category: 'typesettings', type: 'size' },
+    'Type/Letter-spacing': { category: 'letter-spacings', type: 'letter-spacing' },
+    'Type/Weight':   { category: 'font-weights',   type: 'string' },
+    'Type/Family':   { category: 'typesettings',   type: 'font' },
+  };
+
+  for (const varId of primColl.variableIds) {
+    const variable = variables[varId];
+    if (!variable) continue;
+    const raw = variable.valuesByMode[primModeId];
+    if (raw === undefined || isFigmaAlias(raw)) continue;
+
+    const key = figmaNameToKey(variable.name);
+    const value = isFigmaColor(raw) ? figmaColorToHex(raw) : String(raw);
+
+    // Find matching category
+    let mappedCategory: { category: string; type: BpkProp['type'] } | undefined;
+    for (const [prefix, cat] of Object.entries(PRIMITIVES_CATEGORY_MAP)) {
+      if (variable.name.startsWith(prefix + '/') || variable.name === prefix) {
+        mappedCategory = cat;
+        break;
+      }
+    }
+
+    if (mappedCategory) {
+      props[key] = { type: mappedCategory.type, category: mappedCategory.category, value, name: key };
+    }
+
+    // Always add to aliases map so semantic tokens can reference them
+    aliases[key] = value;
+  }
+
+  console.log(`✓ Primitives: ${primColl.variableIds.length} variables processed`);
+
+  // ── Semantic tokens (Backpack 368 — colors + typography) ─────────────────────
+  const backpackColl = findCollection(collections, 'Backpack');
+  if (!backpackColl) { console.warn('⚠  No Backpack collection found'); process.exit(1); }
+  const lightModeId = getModeId(backpackColl, ['Day', 'Light']);
+  const darkModeId  = getModeId(backpackColl, ['Night', 'Dark']);
+
+  // Semantic color group → bpk-foundations category
+  const SEMANTIC_COLOR_GROUPS: Record<string, string> = {
+    'Canvas':    'canvas-colors',
+    'Core':      'core-colors',
+    'Text':      'text-colors',
+    'Surface':   'surface-colors',
+    'Status':    'status-colors',
+    'Other':     'line-colors',
+  };
+
+  // Typography property suffix → bpk-foundations category + type
+  const TYPOGRAPHY_SUFFIX_MAP: Record<string, { category: string; type: BpkProp['type'] }> = {
+    'Size':           { category: 'typesettings',   type: 'font-size' },
+    'Line-height':    { category: 'typesettings',   type: 'size' },
+    'Letter-spacing': { category: 'letter-spacings', type: 'letter-spacing' },
+    'Weight':         { category: 'font-weights',   type: 'string' },
+    'Family':         { category: 'typesettings',   type: 'font' },
+  };
+
+  // Animation duration tokens — these aren't in Figma variables so we keep the
+  // hardcoded values from the existing foundations package
+  const ANIMATION_TOKENS: Record<string, number> = {
+    ANIMATION_DURATION_XS:   50,
+    ANIMATION_DURATION_SM:   200,
+    ANIMATION_DURATION_BASE: 400,
+  };
+  for (const [key, ms] of Object.entries(ANIMATION_TOKENS)) {
+    props[key] = { type: 'duration', category: 'animations', value: `${ms}ms`, name: key };
+  }
+
+  // Elevation tokens — also not in Figma variables, keep hardcoded
+  const ELEVATION_TOKENS: Record<string, number> = {
+    ELEVATION_XS: 1, ELEVATION_SM: 2, ELEVATION_BASE: 4,
+    ELEVATION_LG: 8, ELEVATION_XL: 16, ELEVATION_XXL: 24,
+  };
+  for (const [key, val] of Object.entries(ELEVATION_TOKENS)) {
+    props[key] = { type: 'size', category: 'elevation', value: String(val), name: key };
+  }
+
+  let semanticCount = 0;
+  let typographyCount = 0;
+
+  for (const varId of backpackColl.variableIds) {
+    const variable = variables[varId];
+    if (!variable) continue;
+
+    const lightRaw = variable.valuesByMode[lightModeId];
+    const darkRaw  = variable.valuesByMode[darkModeId];
+    if (lightRaw === undefined) continue;
+
+    const key = figmaNameToKey(variable.name);
+    const topGroup = variable.name.split('/')[0].trim();
+    const lastSegment = variable.name.split('/').pop()?.trim() ?? '';
+
+    // ── Semantic colors ───────────────────────────────────────────────────────
+    if (variable.resolvedType === 'COLOR' && SEMANTIC_COLOR_GROUPS[topGroup]) {
+      const category = SEMANTIC_COLOR_GROUPS[topGroup];
+      const light = resolveValue(lightRaw, variables, primModeId);
+      if (!light) continue;
+
+      const prop: BpkProp = {
+        type: 'color',
+        category,
+        value: light.value,
+        originalValue: light.originalValue,
+        name: key,
+      };
+
+      if (darkRaw !== undefined) {
+        const dark = resolveValue(darkRaw, variables, primModeId);
+        if (dark) {
+          prop.darkValue = dark.value;
+          prop.originalDarkValue = dark.originalValue;
+        }
+      }
+
+      props[key] = prop;
+      semanticCount++;
+      continue;
+    }
+
+    // ── Typography tokens ─────────────────────────────────────────────────────
+    if (topGroup === 'Typography') {
+      const mapped = TYPOGRAPHY_SUFFIX_MAP[lastSegment];
+      if (!mapped) continue;
+
+      const light = resolveValue(lightRaw, variables, primModeId);
+      if (!light) continue;
+
+      // For letter-spacing, convert from px (Figma) to em ratio
+      // Figma stores letter-spacing in px; foundations uses em (relative to font size)
+      // We map tight/loose values directly
+      let value = light.value;
+      if (mapped.type === 'letter-spacing') {
+        const numVal = parseFloat(value);
+        if (!isNaN(numVal)) {
+          // Convert px offset to em: divide by a reference size of 16
+          const emVal = Math.round((numVal / 16) * 100) / 100;
+          value = String(emVal === 0 ? 0 : emVal);
+        }
+      }
+
+      props[key] = {
+        type: mapped.type,
+        category: mapped.category,
+        value,
+        originalValue: light.originalValue,
+        name: key,
+      };
+      typographyCount++;
+      continue;
+    }
+  }
+
+  console.log(`✓ Semantic colors: ${semanticCount} tokens`);
+  console.log(`✓ Typography: ${typographyCount} tokens`);
+  console.log(`✓ Animations: ${Object.keys(ANIMATION_TOKENS).length} tokens (hardcoded)`);
+  console.log(`✓ Elevation: ${Object.keys(ELEVATION_TOKENS).length} tokens (hardcoded)`);
+
+  // ── Write output ──────────────────────────────────────────────────────────────
+  const output: BpkFoundationsJson = {
+    aliases,
+    props,
+    propKeys: Object.keys(props),
+  };
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+  const outPath = `${OUTPUT_DIR}/base.raw.android.json`;
+  writeFileSync(outPath, JSON.stringify(output, null, 2) + '\n');
+
+  console.log(`\n✓ Written ${Object.keys(props).length} total tokens to ${outPath}`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/token-sync/tokens/base.raw.android.json
+++ b/token-sync/tokens/base.raw.android.json
@@ -1,0 +1,2302 @@
+{
+  "aliases": {
+    "COLOUR_BRAND_BLUE_BRIGHT": "#a1eeffff",
+    "COLOUR_BRAND_BLUE_MUTED": "#d9f8ffff",
+    "COLOUR_MIDNIGHT_SKY": "#04182dff",
+    "COLOUR_DARK_BLUE_100": "#002b4bff",
+    "COLOUR_BRAND_GREEN_BRIGHT": "#93ffdeff",
+    "COLOUR_DARK_SKY": "#05203cff",
+    "COLOUR_DARK_SKY_85": "#154679ff",
+    "COLOUR_SKY_BLUE": "#0062e3ff",
+    "COLOUR_SKY_BLUE_85": "#024dafff",
+    "COLOUR_TWILIGHT": "#054184ff",
+    "COLOUR_TWILIGHT_85": "#024dafff",
+    "COLOUR_BRIGHT_BLUE": "#84e9ffff",
+    "COLOUR_BRIGHT_BLUE_20": "#d1f7ffff",
+    "COLOUR_LIGHT_BLUE": "#a1eeffff",
+    "COLOUR_MUTED_BLUE": "#d9f8ffff",
+    "COLOUR_BABY_BLUE": "#e3f0ffff",
+    "COLOUR_BABY_BLUE_40": "#94c3ffff",
+    "COLOUR_BABY_BLUE_30": "#b4d7ffff",
+    "COLOUR_BABY_BLUE_20": "#cfe4ffff",
+    "COLOUR_GREEN": "#0c838aff",
+    "COLOUR_MUTED_GREEN": "#d4fff2ff",
+    "COLOUR_BRIGHT_GREEN": "#62f1c6ff",
+    "COLOUR_BRIGHT_GREEN_30": "#93ffdeff",
+    "COLOUR_BRIGHT_GREEN_20": "#b1ffe7ff",
+    "COLOUR_AMBER": "#f55d42ff",
+    "COLOUR_ORANGE": "#ff7b59ff",
+    "COLOUR_YELLOW": "#feeb87ff",
+    "COLOUR_MUTED_YELLOW": "#fff7cfff",
+    "COLOUR_BRIGHT_YELLOW": "#fbf1bbff",
+    "COLOUR_BERRY": "#e70866ff",
+    "COLOUR_BERRY_75": "#c80456ff",
+    "COLOUR_BRIGHT_BERRY": "#ff649cff",
+    "COLOUR_PINK": "#ffa3e5ff",
+    "COLOUR_BRIGHT_PINK": "#ffcaddff",
+    "COLOUR_MUTED_PINK": "#ffe9f9ff",
+    "COLOUR_PURPLE": "#8e47baff",
+    "COLOUR_BRAND_PINK": "#ffa3e5ff",
+    "COLOUR_ECO_GREEN": "#0fa1a9ff",
+    "COLOUR_BRAND_ORANGE": "#ff7b59ff",
+    "COLOUR_BRAND_YELLOW": "#feeb87ff",
+    "NEUTRAL_NIGHT_NIGHT_SKY": "#054184ff",
+    "NEUTRAL_NIGHT_NIGHT_GREEN_SPOT": "#62f1c6ff",
+    "NEUTRAL_NIGHT_NIGHT_GREEN_FILL": "#b1ffe7ff",
+    "NEUTRAL_NIGHT_NIGHT_YELLOW_FILL": "#fbf1bbff",
+    "NEUTRAL_NIGHT_NIGHT_BERRY": "#ff649cff",
+    "NEUTRAL_NIGHT_NIGHT_PINK": "#ffcaddff",
+    "NEUTRAL_NIGHT_NIGHT_GREY_10": "#010913ff",
+    "NEUTRAL_NIGHT_NIGHT_BLUE": "#84e9ffff",
+    "NEUTRAL_NIGHT_NIGHT_GREY_20": "#131d2bff",
+    "NEUTRAL_NIGHT_NIGHT_GREY_25": "#243346ff",
+    "NEUTRAL_NIGHT_NIGHT_GREY_30": "#44505fff",
+    "NEUTRAL_NIGHT_NIGHT_GREY_40": "#bdc4cbff",
+    "NEUTRAL_CHARCOAL": "#161616ff",
+    "NEUTRAL_GREY_40": "#626971ff",
+    "NEUTRAL_GREY_30": "#c1c7cfff",
+    "NEUTRAL_GREY_20": "#e0e4e9ff",
+    "NEUTRAL_GREY_10": "#eff3f8ff",
+    "NEUTRAL_GREY_05": "#f5f7faff",
+    "NEUTRAL_WHITE": "#ffffffff",
+    "NEUTRAL_DARK_GREY_00": "#0b121dff",
+    "NEUTRAL_DARK_GREY_10": "#010913ff",
+    "NEUTRAL_DARK_GREY_20": "#131d2bff",
+    "NEUTRAL_DARK_GREY_25": "#243346ff",
+    "NEUTRAL_DARK_GREY_30": "#44505fff",
+    "NEUTRAL_DARK_GREY_40": "#bdc4cbff",
+    "ALPHA_BLACK_ALPHA_80": "#000000cc",
+    "ALPHA_BLACK_ALPHA_70": "#000000b2",
+    "ALPHA_BLACK_ALPHA_50": "#00000080",
+    "ALPHA_BLACK_ALPHA_25": "#16161640",
+    "ALPHA_BLACK_ALPHA_20": "#00000033",
+    "ALPHA_WHITE_ALPHA_80": "#ffffffcc",
+    "ALPHA_WHITE_ALPHA_50": "#ffffff80",
+    "ALPHA_WHITE_ALPHA_20": "#ffffff33",
+    "ALPHA_WHITE_ALPHA_10": "#ffffff1a",
+    "ALPHA_TRANSPARENT": "#ffffff00",
+    "RADIUS_NONE": "0",
+    "RADIUS_XS": "4",
+    "RADIUS_SM": "8",
+    "RADIUS_MD": "12",
+    "RADIUS_NAV_TABS": "18",
+    "RADIUS_LG": "24",
+    "RADIUS_XL": "48",
+    "RADIUS_FULL": "999",
+    "SPACING_NONE": "0",
+    "SPACING_XXS": "1",
+    "SPACING_XS": "2",
+    "SPACING_SM": "4",
+    "SPACING_MD": "8",
+    "SPACING_BASE": "16",
+    "SPACING_LG": "24",
+    "SPACING_XL": "32",
+    "SPACING_XXL": "40",
+    "SPACING_XXXL": "64",
+    "SPACING_XXXXL": "96",
+    "HEIGHTS_16": "16",
+    "HEIGHTS_20": "20",
+    "HEIGHTS_24": "24",
+    "HEIGHTS_32": "32",
+    "HEIGHTS_36": "36",
+    "HEIGHTS_40": "40",
+    "HEIGHTS_44": "44",
+    "HEIGHTS_48": "48",
+    "HEIGHTS_52": "52",
+    "HEIGHTS_56": "56",
+    "HEIGHTS_64": "64",
+    "BORDER_1": "1",
+    "BORDER_2": "2",
+    "BORDER_3": "3",
+    "MODAL_200": "200",
+    "MODAL_400": "400",
+    "MODAL_512": "512",
+    "MODAL_600": "600",
+    "MODAL_800": "800",
+    "MODAL_1000": "1000",
+    "MODAL_1024": "1024",
+    "TYPE_FAMILY_SKYSCANNER_RELATIVE": "Skyscanner Relative",
+    "TYPE_FAMILY_LARKEN": "Larken",
+    "TYPE_SIZE_12": "12",
+    "TYPE_SIZE_14": "14",
+    "TYPE_SIZE_16": "16",
+    "TYPE_SIZE_20": "20",
+    "TYPE_SIZE_24": "24",
+    "TYPE_SIZE_32": "32",
+    "TYPE_SIZE_40": "40",
+    "TYPE_SIZE_48": "48",
+    "TYPE_SIZE_64": "64",
+    "TYPE_SIZE_76": "76",
+    "TYPE_SIZE_96": "96",
+    "TYPE_SIZE_120": "120",
+    "TYPE_SIZE_144": "144",
+    "TYPE_SIZE_192": "192",
+    "TYPE_SIZE_240": "240",
+    "TYPE_LINE_HEIGHT_16": "16",
+    "TYPE_LINE_HEIGHT_20": "20",
+    "TYPE_LINE_HEIGHT_22": "22",
+    "TYPE_LINE_HEIGHT_24": "24",
+    "TYPE_LINE_HEIGHT_28": "28",
+    "TYPE_LINE_HEIGHT_32": "32",
+    "TYPE_LINE_HEIGHT_40": "40",
+    "TYPE_LINE_HEIGHT_48": "48",
+    "TYPE_LINE_HEIGHT_56": "56",
+    "TYPE_LINE_HEIGHT_64": "64",
+    "TYPE_LINE_HEIGHT_76": "76",
+    "TYPE_LINE_HEIGHT_82": "82",
+    "TYPE_LINE_HEIGHT_96": "96",
+    "TYPE_LINE_HEIGHT_115": "115",
+    "TYPE_LINE_HEIGHT_120": "120",
+    "TYPE_LINE_HEIGHT_153": "153",
+    "TYPE_LINE_HEIGHT_192": "192",
+    "TYPE_LETTER_SPACING_LOOSE_20": "1",
+    "TYPE_LETTER_SPACING_LOOSE_10": "0.6000000238418579",
+    "TYPE_LETTER_SPACING_DEFAULT": "0",
+    "TYPE_WEIGHT_900": "900",
+    "TYPE_WEIGHT_700": "700",
+    "TYPE_WEIGHT_400": "400",
+    "TYPE_WEIGHT_300": "300",
+    "TYPE_LETTER_SPACING_TIGHT_10": "-0.6000000238418579",
+    "TYPE_LETTER_SPACING_TIGHT_20": "-1",
+    "TYPE_LETTER_SPACING_TIGHT_30": "-1.2000000476837158",
+    "TYPE_LETTER_SPACING_TIGHT_40": "-2",
+    "TYPE_LETTER_SPACING_TIGHT_50": "-3.5"
+  },
+  "props": {
+    "RADIUS_NONE": {
+      "type": "size",
+      "category": "radii",
+      "value": "0",
+      "name": "RADIUS_NONE"
+    },
+    "RADIUS_XS": {
+      "type": "size",
+      "category": "radii",
+      "value": "4",
+      "name": "RADIUS_XS"
+    },
+    "RADIUS_SM": {
+      "type": "size",
+      "category": "radii",
+      "value": "8",
+      "name": "RADIUS_SM"
+    },
+    "RADIUS_MD": {
+      "type": "size",
+      "category": "radii",
+      "value": "12",
+      "name": "RADIUS_MD"
+    },
+    "RADIUS_NAV_TABS": {
+      "type": "size",
+      "category": "radii",
+      "value": "18",
+      "name": "RADIUS_NAV_TABS"
+    },
+    "RADIUS_LG": {
+      "type": "size",
+      "category": "radii",
+      "value": "24",
+      "name": "RADIUS_LG"
+    },
+    "RADIUS_XL": {
+      "type": "size",
+      "category": "radii",
+      "value": "48",
+      "name": "RADIUS_XL"
+    },
+    "RADIUS_FULL": {
+      "type": "size",
+      "category": "radii",
+      "value": "999",
+      "name": "RADIUS_FULL"
+    },
+    "SPACING_NONE": {
+      "type": "size",
+      "category": "spacings",
+      "value": "0",
+      "name": "SPACING_NONE"
+    },
+    "SPACING_XXS": {
+      "type": "size",
+      "category": "spacings",
+      "value": "1",
+      "name": "SPACING_XXS"
+    },
+    "SPACING_XS": {
+      "type": "size",
+      "category": "spacings",
+      "value": "2",
+      "name": "SPACING_XS"
+    },
+    "SPACING_SM": {
+      "type": "size",
+      "category": "spacings",
+      "value": "4",
+      "name": "SPACING_SM"
+    },
+    "SPACING_MD": {
+      "type": "size",
+      "category": "spacings",
+      "value": "8",
+      "name": "SPACING_MD"
+    },
+    "SPACING_BASE": {
+      "type": "size",
+      "category": "spacings",
+      "value": "16",
+      "name": "SPACING_BASE"
+    },
+    "SPACING_LG": {
+      "type": "size",
+      "category": "spacings",
+      "value": "24",
+      "name": "SPACING_LG"
+    },
+    "SPACING_XL": {
+      "type": "size",
+      "category": "spacings",
+      "value": "32",
+      "name": "SPACING_XL"
+    },
+    "SPACING_XXL": {
+      "type": "size",
+      "category": "spacings",
+      "value": "40",
+      "name": "SPACING_XXL"
+    },
+    "SPACING_XXXL": {
+      "type": "size",
+      "category": "spacings",
+      "value": "64",
+      "name": "SPACING_XXXL"
+    },
+    "SPACING_XXXXL": {
+      "type": "size",
+      "category": "spacings",
+      "value": "96",
+      "name": "SPACING_XXXXL"
+    },
+    "HEIGHTS_16": {
+      "type": "size",
+      "category": "spacings",
+      "value": "16",
+      "name": "HEIGHTS_16"
+    },
+    "HEIGHTS_20": {
+      "type": "size",
+      "category": "spacings",
+      "value": "20",
+      "name": "HEIGHTS_20"
+    },
+    "HEIGHTS_24": {
+      "type": "size",
+      "category": "spacings",
+      "value": "24",
+      "name": "HEIGHTS_24"
+    },
+    "HEIGHTS_32": {
+      "type": "size",
+      "category": "spacings",
+      "value": "32",
+      "name": "HEIGHTS_32"
+    },
+    "HEIGHTS_36": {
+      "type": "size",
+      "category": "spacings",
+      "value": "36",
+      "name": "HEIGHTS_36"
+    },
+    "HEIGHTS_40": {
+      "type": "size",
+      "category": "spacings",
+      "value": "40",
+      "name": "HEIGHTS_40"
+    },
+    "HEIGHTS_44": {
+      "type": "size",
+      "category": "spacings",
+      "value": "44",
+      "name": "HEIGHTS_44"
+    },
+    "HEIGHTS_48": {
+      "type": "size",
+      "category": "spacings",
+      "value": "48",
+      "name": "HEIGHTS_48"
+    },
+    "HEIGHTS_52": {
+      "type": "size",
+      "category": "spacings",
+      "value": "52",
+      "name": "HEIGHTS_52"
+    },
+    "HEIGHTS_56": {
+      "type": "size",
+      "category": "spacings",
+      "value": "56",
+      "name": "HEIGHTS_56"
+    },
+    "HEIGHTS_64": {
+      "type": "size",
+      "category": "spacings",
+      "value": "64",
+      "name": "HEIGHTS_64"
+    },
+    "BORDER_1": {
+      "type": "size",
+      "category": "borders",
+      "value": "1",
+      "name": "BORDER_1"
+    },
+    "BORDER_2": {
+      "type": "size",
+      "category": "borders",
+      "value": "2",
+      "name": "BORDER_2"
+    },
+    "BORDER_3": {
+      "type": "size",
+      "category": "borders",
+      "value": "3",
+      "name": "BORDER_3"
+    },
+    "MODAL_200": {
+      "type": "size",
+      "category": "spacings",
+      "value": "200",
+      "name": "MODAL_200"
+    },
+    "MODAL_400": {
+      "type": "size",
+      "category": "spacings",
+      "value": "400",
+      "name": "MODAL_400"
+    },
+    "MODAL_512": {
+      "type": "size",
+      "category": "spacings",
+      "value": "512",
+      "name": "MODAL_512"
+    },
+    "MODAL_600": {
+      "type": "size",
+      "category": "spacings",
+      "value": "600",
+      "name": "MODAL_600"
+    },
+    "MODAL_800": {
+      "type": "size",
+      "category": "spacings",
+      "value": "800",
+      "name": "MODAL_800"
+    },
+    "MODAL_1000": {
+      "type": "size",
+      "category": "spacings",
+      "value": "1000",
+      "name": "MODAL_1000"
+    },
+    "MODAL_1024": {
+      "type": "size",
+      "category": "spacings",
+      "value": "1024",
+      "name": "MODAL_1024"
+    },
+    "TYPE_FAMILY_SKYSCANNER_RELATIVE": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "name": "TYPE_FAMILY_SKYSCANNER_RELATIVE"
+    },
+    "TYPE_FAMILY_LARKEN": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Larken",
+      "name": "TYPE_FAMILY_LARKEN"
+    },
+    "TYPE_SIZE_12": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "12",
+      "name": "TYPE_SIZE_12"
+    },
+    "TYPE_SIZE_14": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "14",
+      "name": "TYPE_SIZE_14"
+    },
+    "TYPE_SIZE_16": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "16",
+      "name": "TYPE_SIZE_16"
+    },
+    "TYPE_SIZE_20": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "20",
+      "name": "TYPE_SIZE_20"
+    },
+    "TYPE_SIZE_24": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "24",
+      "name": "TYPE_SIZE_24"
+    },
+    "TYPE_SIZE_32": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "32",
+      "name": "TYPE_SIZE_32"
+    },
+    "TYPE_SIZE_40": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "40",
+      "name": "TYPE_SIZE_40"
+    },
+    "TYPE_SIZE_48": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "48",
+      "name": "TYPE_SIZE_48"
+    },
+    "TYPE_SIZE_64": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "64",
+      "name": "TYPE_SIZE_64"
+    },
+    "TYPE_SIZE_76": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "76",
+      "name": "TYPE_SIZE_76"
+    },
+    "TYPE_SIZE_96": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "96",
+      "name": "TYPE_SIZE_96"
+    },
+    "TYPE_SIZE_120": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "120",
+      "name": "TYPE_SIZE_120"
+    },
+    "TYPE_SIZE_144": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "144",
+      "name": "TYPE_SIZE_144"
+    },
+    "TYPE_SIZE_192": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "192",
+      "name": "TYPE_SIZE_192"
+    },
+    "TYPE_SIZE_240": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "240",
+      "name": "TYPE_SIZE_240"
+    },
+    "TYPE_LINE_HEIGHT_16": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "16",
+      "name": "TYPE_LINE_HEIGHT_16"
+    },
+    "TYPE_LINE_HEIGHT_20": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "20",
+      "name": "TYPE_LINE_HEIGHT_20"
+    },
+    "TYPE_LINE_HEIGHT_22": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "22",
+      "name": "TYPE_LINE_HEIGHT_22"
+    },
+    "TYPE_LINE_HEIGHT_24": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "24",
+      "name": "TYPE_LINE_HEIGHT_24"
+    },
+    "TYPE_LINE_HEIGHT_28": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "28",
+      "name": "TYPE_LINE_HEIGHT_28"
+    },
+    "TYPE_LINE_HEIGHT_32": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "32",
+      "name": "TYPE_LINE_HEIGHT_32"
+    },
+    "TYPE_LINE_HEIGHT_40": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "40",
+      "name": "TYPE_LINE_HEIGHT_40"
+    },
+    "TYPE_LINE_HEIGHT_48": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "48",
+      "name": "TYPE_LINE_HEIGHT_48"
+    },
+    "TYPE_LINE_HEIGHT_56": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "56",
+      "name": "TYPE_LINE_HEIGHT_56"
+    },
+    "TYPE_LINE_HEIGHT_64": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "64",
+      "name": "TYPE_LINE_HEIGHT_64"
+    },
+    "TYPE_LINE_HEIGHT_76": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "76",
+      "name": "TYPE_LINE_HEIGHT_76"
+    },
+    "TYPE_LINE_HEIGHT_82": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "82",
+      "name": "TYPE_LINE_HEIGHT_82"
+    },
+    "TYPE_LINE_HEIGHT_96": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "96",
+      "name": "TYPE_LINE_HEIGHT_96"
+    },
+    "TYPE_LINE_HEIGHT_115": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "115",
+      "name": "TYPE_LINE_HEIGHT_115"
+    },
+    "TYPE_LINE_HEIGHT_120": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "120",
+      "name": "TYPE_LINE_HEIGHT_120"
+    },
+    "TYPE_LINE_HEIGHT_153": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "153",
+      "name": "TYPE_LINE_HEIGHT_153"
+    },
+    "TYPE_LINE_HEIGHT_192": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "192",
+      "name": "TYPE_LINE_HEIGHT_192"
+    },
+    "TYPE_LETTER_SPACING_LOOSE_20": {
+      "type": "letter-spacing",
+      "category": "letter-spacings",
+      "value": "1",
+      "name": "TYPE_LETTER_SPACING_LOOSE_20"
+    },
+    "TYPE_LETTER_SPACING_LOOSE_10": {
+      "type": "letter-spacing",
+      "category": "letter-spacings",
+      "value": "0.6000000238418579",
+      "name": "TYPE_LETTER_SPACING_LOOSE_10"
+    },
+    "TYPE_LETTER_SPACING_DEFAULT": {
+      "type": "letter-spacing",
+      "category": "letter-spacings",
+      "value": "0",
+      "name": "TYPE_LETTER_SPACING_DEFAULT"
+    },
+    "TYPE_WEIGHT_900": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "900",
+      "name": "TYPE_WEIGHT_900"
+    },
+    "TYPE_WEIGHT_700": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "700",
+      "name": "TYPE_WEIGHT_700"
+    },
+    "TYPE_WEIGHT_400": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "400",
+      "name": "TYPE_WEIGHT_400"
+    },
+    "TYPE_WEIGHT_300": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "300",
+      "name": "TYPE_WEIGHT_300"
+    },
+    "TYPE_LETTER_SPACING_TIGHT_10": {
+      "type": "letter-spacing",
+      "category": "letter-spacings",
+      "value": "-0.6000000238418579",
+      "name": "TYPE_LETTER_SPACING_TIGHT_10"
+    },
+    "TYPE_LETTER_SPACING_TIGHT_20": {
+      "type": "letter-spacing",
+      "category": "letter-spacings",
+      "value": "-1",
+      "name": "TYPE_LETTER_SPACING_TIGHT_20"
+    },
+    "TYPE_LETTER_SPACING_TIGHT_30": {
+      "type": "letter-spacing",
+      "category": "letter-spacings",
+      "value": "-1.2000000476837158",
+      "name": "TYPE_LETTER_SPACING_TIGHT_30"
+    },
+    "TYPE_LETTER_SPACING_TIGHT_40": {
+      "type": "letter-spacing",
+      "category": "letter-spacings",
+      "value": "-2",
+      "name": "TYPE_LETTER_SPACING_TIGHT_40"
+    },
+    "TYPE_LETTER_SPACING_TIGHT_50": {
+      "type": "letter-spacing",
+      "category": "letter-spacings",
+      "value": "-3.5",
+      "name": "TYPE_LETTER_SPACING_TIGHT_50"
+    },
+    "ANIMATION_DURATION_XS": {
+      "type": "duration",
+      "category": "animations",
+      "value": "50ms",
+      "name": "ANIMATION_DURATION_XS"
+    },
+    "ANIMATION_DURATION_SM": {
+      "type": "duration",
+      "category": "animations",
+      "value": "200ms",
+      "name": "ANIMATION_DURATION_SM"
+    },
+    "ANIMATION_DURATION_BASE": {
+      "type": "duration",
+      "category": "animations",
+      "value": "400ms",
+      "name": "ANIMATION_DURATION_BASE"
+    },
+    "ELEVATION_XS": {
+      "type": "size",
+      "category": "elevation",
+      "value": "1",
+      "name": "ELEVATION_XS"
+    },
+    "ELEVATION_SM": {
+      "type": "size",
+      "category": "elevation",
+      "value": "2",
+      "name": "ELEVATION_SM"
+    },
+    "ELEVATION_BASE": {
+      "type": "size",
+      "category": "elevation",
+      "value": "4",
+      "name": "ELEVATION_BASE"
+    },
+    "ELEVATION_LG": {
+      "type": "size",
+      "category": "elevation",
+      "value": "8",
+      "name": "ELEVATION_LG"
+    },
+    "ELEVATION_XL": {
+      "type": "size",
+      "category": "elevation",
+      "value": "16",
+      "name": "ELEVATION_XL"
+    },
+    "ELEVATION_XXL": {
+      "type": "size",
+      "category": "elevation",
+      "value": "24",
+      "name": "ELEVATION_XXL"
+    },
+    "TYPOGRAPHY_DISPLAY_1_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_DISPLAY_1_FAMILY"
+    },
+    "TEXT_PRIMARY": {
+      "type": "color",
+      "category": "text-colors",
+      "value": "#161616ff",
+      "originalValue": "{!NEUTRAL_CHARCOAL}",
+      "name": "TEXT_PRIMARY",
+      "darkValue": "#ffffffff",
+      "originalDarkValue": "{!NEUTRAL_WHITE}"
+    },
+    "TEXT_SECONDARY": {
+      "type": "color",
+      "category": "text-colors",
+      "value": "#626971ff",
+      "originalValue": "{!NEUTRAL_GREY_40}",
+      "name": "TEXT_SECONDARY",
+      "darkValue": "#bdc4cbff",
+      "originalDarkValue": "{!NEUTRAL_DARK_GREY_40}"
+    },
+    "TEXT_SECONDARY_ON_CONTRAST": {
+      "type": "color",
+      "category": "text-colors",
+      "value": "#ffffff80",
+      "originalValue": "{!ALPHA_WHITE_ALPHA_50}",
+      "name": "TEXT_SECONDARY_ON_CONTRAST",
+      "darkValue": "#ffffff80",
+      "originalDarkValue": "{!ALPHA_WHITE_ALPHA_50}"
+    },
+    "TEXT_INVERSE": {
+      "type": "color",
+      "category": "text-colors",
+      "value": "#ffffffff",
+      "originalValue": "{!NEUTRAL_WHITE}",
+      "name": "TEXT_INVERSE",
+      "darkValue": "#010913ff",
+      "originalDarkValue": "{!NEUTRAL_DARK_GREY_10}"
+    },
+    "TEXT_HERO": {
+      "type": "color",
+      "category": "text-colors",
+      "value": "#0062e3ff",
+      "originalValue": "{!COLOUR_SKY_BLUE}",
+      "name": "TEXT_HERO",
+      "darkValue": "#010913ff",
+      "originalDarkValue": "{!NEUTRAL_NIGHT_NIGHT_GREY_10}"
+    },
+    "TEXT_DISABLED": {
+      "type": "color",
+      "category": "text-colors",
+      "value": "#00000033",
+      "originalValue": "{!ALPHA_BLACK_ALPHA_20}",
+      "name": "TEXT_DISABLED",
+      "darkValue": "#ffffff33",
+      "originalDarkValue": "{!ALPHA_WHITE_ALPHA_20}"
+    },
+    "TEXT_DISABLED_ON_DARK": {
+      "type": "color",
+      "category": "text-colors",
+      "value": "#ffffff80",
+      "originalValue": "{!ALPHA_WHITE_ALPHA_50}",
+      "name": "TEXT_DISABLED_ON_DARK",
+      "darkValue": "#ffffff80",
+      "originalDarkValue": "{!ALPHA_WHITE_ALPHA_50}"
+    },
+    "TEXT_ERROR": {
+      "type": "color",
+      "category": "text-colors",
+      "value": "#e70866ff",
+      "originalValue": "{!COLOUR_BERRY}",
+      "name": "TEXT_ERROR",
+      "darkValue": "#ff649cff",
+      "originalDarkValue": "{!COLOUR_BRIGHT_BERRY}"
+    },
+    "TEXT_SUCCESS": {
+      "type": "color",
+      "category": "text-colors",
+      "value": "#0c838aff",
+      "originalValue": "{!COLOUR_GREEN}",
+      "name": "TEXT_SUCCESS",
+      "darkValue": "#62f1c6ff",
+      "originalDarkValue": "{!COLOUR_BRIGHT_GREEN}"
+    },
+    "TEXT_ON_DARK": {
+      "type": "color",
+      "category": "text-colors",
+      "value": "#ffffffff",
+      "originalValue": "{!NEUTRAL_WHITE}",
+      "name": "TEXT_ON_DARK",
+      "darkValue": "#ffffffff",
+      "originalDarkValue": "{!NEUTRAL_WHITE}"
+    },
+    "TEXT_ON_LIGHT": {
+      "type": "color",
+      "category": "text-colors",
+      "value": "#161616ff",
+      "originalValue": "{!NEUTRAL_CHARCOAL}",
+      "name": "TEXT_ON_LIGHT",
+      "darkValue": "#010913ff",
+      "originalDarkValue": "{!NEUTRAL_DARK_GREY_10}"
+    },
+    "TYPOGRAPHY_DISPLAY_2_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_DISPLAY_2_FAMILY"
+    },
+    "TYPOGRAPHY_DISPLAY_2_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "900",
+      "originalValue": "{!TYPE_WEIGHT_900}",
+      "name": "TYPOGRAPHY_DISPLAY_2_WEIGHT"
+    },
+    "TYPOGRAPHY_DISPLAY_2_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "192",
+      "originalValue": "{!TYPE_SIZE_192}",
+      "name": "TYPOGRAPHY_DISPLAY_2_SIZE"
+    },
+    "TYPOGRAPHY_DISPLAY_2_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "0.800000011920929",
+      "originalValue": "0.800000011920929",
+      "name": "TYPOGRAPHY_DISPLAY_2_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_DISPLAY_2_LETTER_SPACING": {
+      "type": "letter-spacing",
+      "category": "letter-spacings",
+      "value": "-0.22",
+      "originalValue": "{!TYPE_LETTER_SPACING_TIGHT_50}",
+      "name": "TYPOGRAPHY_DISPLAY_2_LETTER_SPACING"
+    },
+    "TYPOGRAPHY_DISPLAY_3_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_DISPLAY_3_FAMILY"
+    },
+    "TYPOGRAPHY_DISPLAY_3_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "900",
+      "originalValue": "{!TYPE_WEIGHT_900}",
+      "name": "TYPOGRAPHY_DISPLAY_3_WEIGHT"
+    },
+    "TYPOGRAPHY_DISPLAY_3_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "144",
+      "originalValue": "{!TYPE_SIZE_144}",
+      "name": "TYPOGRAPHY_DISPLAY_3_SIZE"
+    },
+    "TYPOGRAPHY_DISPLAY_3_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "0.800000011920929",
+      "originalValue": "0.800000011920929",
+      "name": "TYPOGRAPHY_DISPLAY_3_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_DISPLAY_3_LETTER_SPACING": {
+      "type": "letter-spacing",
+      "category": "letter-spacings",
+      "value": "-0.22",
+      "originalValue": "{!TYPE_LETTER_SPACING_TIGHT_50}",
+      "name": "TYPOGRAPHY_DISPLAY_3_LETTER_SPACING"
+    },
+    "TYPOGRAPHY_DISPLAY_1_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "900",
+      "originalValue": "{!TYPE_WEIGHT_900}",
+      "name": "TYPOGRAPHY_DISPLAY_1_WEIGHT"
+    },
+    "TYPOGRAPHY_DISPLAY_4_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_DISPLAY_4_FAMILY"
+    },
+    "TYPOGRAPHY_DISPLAY_1_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "240",
+      "originalValue": "{!TYPE_SIZE_240}",
+      "name": "TYPOGRAPHY_DISPLAY_1_SIZE"
+    },
+    "TYPOGRAPHY_DISPLAY_5_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_DISPLAY_5_FAMILY"
+    },
+    "TYPOGRAPHY_DISPLAY_4_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "900",
+      "originalValue": "{!TYPE_WEIGHT_900}",
+      "name": "TYPOGRAPHY_DISPLAY_4_WEIGHT"
+    },
+    "TYPOGRAPHY_DISPLAY_6_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_DISPLAY_6_FAMILY"
+    },
+    "TYPOGRAPHY_DISPLAY_4_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "96",
+      "originalValue": "{!TYPE_SIZE_96}",
+      "name": "TYPOGRAPHY_DISPLAY_4_SIZE"
+    },
+    "TYPOGRAPHY_DISPLAY_1_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "0.800000011920929",
+      "originalValue": "0.800000011920929",
+      "name": "TYPOGRAPHY_DISPLAY_1_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_DISPLAY_5_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "900",
+      "originalValue": "{!TYPE_WEIGHT_900}",
+      "name": "TYPOGRAPHY_DISPLAY_5_WEIGHT"
+    },
+    "TYPOGRAPHY_DISPLAY_5_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "76",
+      "originalValue": "{!TYPE_SIZE_76}",
+      "name": "TYPOGRAPHY_DISPLAY_5_SIZE"
+    },
+    "TYPOGRAPHY_DISPLAY_4_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "0.8500000238418579",
+      "originalValue": "0.8500000238418579",
+      "name": "TYPOGRAPHY_DISPLAY_4_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_DISPLAY_1_LETTER_SPACING": {
+      "type": "letter-spacing",
+      "category": "letter-spacings",
+      "value": "-0.22",
+      "originalValue": "{!TYPE_LETTER_SPACING_TIGHT_50}",
+      "name": "TYPOGRAPHY_DISPLAY_1_LETTER_SPACING"
+    },
+    "TYPOGRAPHY_DISPLAY_6_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "900",
+      "originalValue": "{!TYPE_WEIGHT_900}",
+      "name": "TYPOGRAPHY_DISPLAY_6_WEIGHT"
+    },
+    "TYPOGRAPHY_HERO_1_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_HERO_1_FAMILY"
+    },
+    "TYPOGRAPHY_DISPLAY_4_LETTER_SPACING": {
+      "type": "letter-spacing",
+      "category": "letter-spacings",
+      "value": "-0.22",
+      "originalValue": "{!TYPE_LETTER_SPACING_TIGHT_50}",
+      "name": "TYPOGRAPHY_DISPLAY_4_LETTER_SPACING"
+    },
+    "TYPOGRAPHY_DISPLAY_5_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "0.8500000238418579",
+      "originalValue": "0.8500000238418579",
+      "name": "TYPOGRAPHY_DISPLAY_5_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_HERO_1_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "900",
+      "originalValue": "{!TYPE_WEIGHT_900}",
+      "name": "TYPOGRAPHY_HERO_1_WEIGHT"
+    },
+    "TYPOGRAPHY_DISPLAY_6_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "48",
+      "originalValue": "{!TYPE_SIZE_48}",
+      "name": "TYPOGRAPHY_DISPLAY_6_SIZE"
+    },
+    "TYPOGRAPHY_DISPLAY_6_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "0.8500000238418579",
+      "originalValue": "0.8500000238418579",
+      "name": "TYPOGRAPHY_DISPLAY_6_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_DISPLAY_5_LETTER_SPACING": {
+      "type": "letter-spacing",
+      "category": "letter-spacings",
+      "value": "-0.22",
+      "originalValue": "{!TYPE_LETTER_SPACING_TIGHT_50}",
+      "name": "TYPOGRAPHY_DISPLAY_5_LETTER_SPACING"
+    },
+    "TYPOGRAPHY_HERO_1_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "120",
+      "originalValue": "{!TYPE_SIZE_120}",
+      "name": "TYPOGRAPHY_HERO_1_SIZE"
+    },
+    "TYPOGRAPHY_DISPLAY_6_LETTER_SPACING": {
+      "type": "letter-spacing",
+      "category": "letter-spacings",
+      "value": "-0.22",
+      "originalValue": "{!TYPE_LETTER_SPACING_TIGHT_50}",
+      "name": "TYPOGRAPHY_DISPLAY_6_LETTER_SPACING"
+    },
+    "TYPOGRAPHY_HERO_1_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1",
+      "originalValue": "1",
+      "name": "TYPOGRAPHY_HERO_1_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_HERO_1_LETTER_SPACING": {
+      "type": "letter-spacing",
+      "category": "letter-spacings",
+      "value": "-0.22",
+      "originalValue": "{!TYPE_LETTER_SPACING_TIGHT_50}",
+      "name": "TYPOGRAPHY_HERO_1_LETTER_SPACING"
+    },
+    "TYPOGRAPHY_HERO_2_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_HERO_2_FAMILY"
+    },
+    "TYPOGRAPHY_HERO_2_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "900",
+      "originalValue": "{!TYPE_WEIGHT_900}",
+      "name": "TYPOGRAPHY_HERO_2_WEIGHT"
+    },
+    "TYPOGRAPHY_HERO_2_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "96",
+      "originalValue": "{!TYPE_SIZE_96}",
+      "name": "TYPOGRAPHY_HERO_2_SIZE"
+    },
+    "TYPOGRAPHY_HERO_2_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1",
+      "originalValue": "1",
+      "name": "TYPOGRAPHY_HERO_2_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_HERO_2_LETTER_SPACING": {
+      "type": "letter-spacing",
+      "category": "letter-spacings",
+      "value": "-0.22",
+      "originalValue": "{!TYPE_LETTER_SPACING_TIGHT_50}",
+      "name": "TYPOGRAPHY_HERO_2_LETTER_SPACING"
+    },
+    "TYPOGRAPHY_HERO_3_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_HERO_3_FAMILY"
+    },
+    "TYPOGRAPHY_HERO_3_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "900",
+      "originalValue": "{!TYPE_WEIGHT_900}",
+      "name": "TYPOGRAPHY_HERO_3_WEIGHT"
+    },
+    "TYPOGRAPHY_HERO_3_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "76",
+      "originalValue": "{!TYPE_SIZE_76}",
+      "name": "TYPOGRAPHY_HERO_3_SIZE"
+    },
+    "TYPOGRAPHY_HERO_3_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1",
+      "originalValue": "1",
+      "name": "TYPOGRAPHY_HERO_3_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_HERO_3_LETTER_SPACING": {
+      "type": "letter-spacing",
+      "category": "letter-spacings",
+      "value": "-0.22",
+      "originalValue": "{!TYPE_LETTER_SPACING_TIGHT_50}",
+      "name": "TYPOGRAPHY_HERO_3_LETTER_SPACING"
+    },
+    "TYPOGRAPHY_HERO_4_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_HERO_4_FAMILY"
+    },
+    "TYPOGRAPHY_HERO_4_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "900",
+      "originalValue": "{!TYPE_WEIGHT_900}",
+      "name": "TYPOGRAPHY_HERO_4_WEIGHT"
+    },
+    "TYPOGRAPHY_HERO_4_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "64",
+      "originalValue": "{!TYPE_SIZE_64}",
+      "name": "TYPOGRAPHY_HERO_4_SIZE"
+    },
+    "TYPOGRAPHY_HERO_4_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1",
+      "originalValue": "1",
+      "name": "TYPOGRAPHY_HERO_4_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_HERO_4_LETTER_SPACING": {
+      "type": "letter-spacing",
+      "category": "letter-spacings",
+      "value": "-0.12",
+      "originalValue": "{!TYPE_LETTER_SPACING_TIGHT_40}",
+      "name": "TYPOGRAPHY_HERO_4_LETTER_SPACING"
+    },
+    "TYPOGRAPHY_HERO_5_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_HERO_5_FAMILY"
+    },
+    "TYPOGRAPHY_HERO_5_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "900",
+      "originalValue": "{!TYPE_WEIGHT_900}",
+      "name": "TYPOGRAPHY_HERO_5_WEIGHT"
+    },
+    "TYPOGRAPHY_HERO_6_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_HERO_6_FAMILY"
+    },
+    "TYPOGRAPHY_HERO_5_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "48",
+      "originalValue": "{!TYPE_SIZE_48}",
+      "name": "TYPOGRAPHY_HERO_5_SIZE"
+    },
+    "TYPOGRAPHY_HERO_6_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "900",
+      "originalValue": "{!TYPE_WEIGHT_900}",
+      "name": "TYPOGRAPHY_HERO_6_WEIGHT"
+    },
+    "TYPOGRAPHY_HERO_6_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "40",
+      "originalValue": "{!TYPE_SIZE_40}",
+      "name": "TYPOGRAPHY_HERO_6_SIZE"
+    },
+    "TYPOGRAPHY_HERO_6_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1",
+      "originalValue": "1",
+      "name": "TYPOGRAPHY_HERO_6_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_HERO_6_LETTER_SPACING": {
+      "type": "letter-spacing",
+      "category": "letter-spacings",
+      "value": "-0.08",
+      "originalValue": "{!TYPE_LETTER_SPACING_TIGHT_30}",
+      "name": "TYPOGRAPHY_HERO_6_LETTER_SPACING"
+    },
+    "TYPOGRAPHY_HERO_5_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1",
+      "originalValue": "1",
+      "name": "TYPOGRAPHY_HERO_5_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_HERO_5_LETTER_SPACING": {
+      "type": "letter-spacing",
+      "category": "letter-spacings",
+      "value": "-0.12",
+      "originalValue": "{!TYPE_LETTER_SPACING_TIGHT_40}",
+      "name": "TYPOGRAPHY_HERO_5_LETTER_SPACING"
+    },
+    "TYPOGRAPHY_HEADING_1_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_HEADING_1_FAMILY"
+    },
+    "TYPOGRAPHY_HEADING_1_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "700",
+      "originalValue": "{!TYPE_WEIGHT_700}",
+      "name": "TYPOGRAPHY_HEADING_1_WEIGHT"
+    },
+    "TYPOGRAPHY_HEADING_1_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "40",
+      "originalValue": "{!TYPE_SIZE_40}",
+      "name": "TYPOGRAPHY_HEADING_1_SIZE"
+    },
+    "TYPOGRAPHY_HEADING_1_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1.2000000476837158",
+      "originalValue": "1.2000000476837158",
+      "name": "TYPOGRAPHY_HEADING_1_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_HEADING_2_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_HEADING_2_FAMILY"
+    },
+    "TYPOGRAPHY_HEADING_3_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_HEADING_3_FAMILY"
+    },
+    "TYPOGRAPHY_HEADING_3_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "700",
+      "originalValue": "{!TYPE_WEIGHT_700}",
+      "name": "TYPOGRAPHY_HEADING_3_WEIGHT"
+    },
+    "TYPOGRAPHY_HEADING_3_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "24",
+      "originalValue": "{!TYPE_SIZE_24}",
+      "name": "TYPOGRAPHY_HEADING_3_SIZE"
+    },
+    "TYPOGRAPHY_HEADING_3_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1.159999966621399",
+      "originalValue": "1.159999966621399",
+      "name": "TYPOGRAPHY_HEADING_3_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_HEADING_4_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_HEADING_4_FAMILY"
+    },
+    "TYPOGRAPHY_HEADING_4_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "700",
+      "originalValue": "{!TYPE_WEIGHT_700}",
+      "name": "TYPOGRAPHY_HEADING_4_WEIGHT"
+    },
+    "TYPOGRAPHY_HEADING_4_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "20",
+      "originalValue": "{!TYPE_SIZE_20}",
+      "name": "TYPOGRAPHY_HEADING_4_SIZE"
+    },
+    "TYPOGRAPHY_HEADING_4_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1.2000000476837158",
+      "originalValue": "1.2000000476837158",
+      "name": "TYPOGRAPHY_HEADING_4_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_HEADING_5_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_HEADING_5_FAMILY"
+    },
+    "TYPOGRAPHY_HEADING_5_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "700",
+      "originalValue": "{!TYPE_WEIGHT_700}",
+      "name": "TYPOGRAPHY_HEADING_5_WEIGHT"
+    },
+    "TYPOGRAPHY_HEADING_5_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "16",
+      "originalValue": "{!TYPE_SIZE_16}",
+      "name": "TYPOGRAPHY_HEADING_5_SIZE"
+    },
+    "TYPOGRAPHY_HEADING_5_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1.25",
+      "originalValue": "1.25",
+      "name": "TYPOGRAPHY_HEADING_5_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_SUBHEADING_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_SUBHEADING_FAMILY"
+    },
+    "TYPOGRAPHY_SUBHEADING_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "300",
+      "originalValue": "{!TYPE_WEIGHT_300}",
+      "name": "TYPOGRAPHY_SUBHEADING_WEIGHT"
+    },
+    "TYPOGRAPHY_SUBHEADING_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "24",
+      "originalValue": "{!TYPE_SIZE_24}",
+      "name": "TYPOGRAPHY_SUBHEADING_SIZE"
+    },
+    "TYPOGRAPHY_SUBHEADING_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1.3300000429153442",
+      "originalValue": "1.3300000429153442",
+      "name": "TYPOGRAPHY_SUBHEADING_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_BODY_LONGFORM_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_BODY_LONGFORM_FAMILY"
+    },
+    "TYPOGRAPHY_BODY_LONGFORM_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "400",
+      "originalValue": "{!TYPE_WEIGHT_400}",
+      "name": "TYPOGRAPHY_BODY_LONGFORM_WEIGHT"
+    },
+    "TYPOGRAPHY_BODY_LONGFORM_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "20",
+      "originalValue": "{!TYPE_SIZE_20}",
+      "name": "TYPOGRAPHY_BODY_LONGFORM_SIZE"
+    },
+    "TYPOGRAPHY_BODY_LONGFORM_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1.399999976158142",
+      "originalValue": "1.399999976158142",
+      "name": "TYPOGRAPHY_BODY_LONGFORM_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_HEADING_2_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "700",
+      "originalValue": "{!TYPE_WEIGHT_700}",
+      "name": "TYPOGRAPHY_HEADING_2_WEIGHT"
+    },
+    "TYPOGRAPHY_HEADING_2_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "32",
+      "originalValue": "{!TYPE_SIZE_32}",
+      "name": "TYPOGRAPHY_HEADING_2_SIZE"
+    },
+    "TYPOGRAPHY_HEADING_2_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1.25",
+      "originalValue": "1.25",
+      "name": "TYPOGRAPHY_HEADING_2_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_BODY_DEFAULT_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_BODY_DEFAULT_FAMILY"
+    },
+    "TYPOGRAPHY_BODY_DEFAULT_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "400",
+      "originalValue": "{!TYPE_WEIGHT_400}",
+      "name": "TYPOGRAPHY_BODY_DEFAULT_WEIGHT"
+    },
+    "TYPOGRAPHY_BODY_DEFAULT_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "16",
+      "originalValue": "{!TYPE_SIZE_16}",
+      "name": "TYPOGRAPHY_BODY_DEFAULT_SIZE"
+    },
+    "TYPOGRAPHY_BODY_DEFAULT_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1.5",
+      "originalValue": "1.5",
+      "name": "TYPOGRAPHY_BODY_DEFAULT_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_FOOTNOTE_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_FOOTNOTE_FAMILY"
+    },
+    "TYPOGRAPHY_FOOTNOTE_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "400",
+      "originalValue": "{!TYPE_WEIGHT_400}",
+      "name": "TYPOGRAPHY_FOOTNOTE_WEIGHT"
+    },
+    "TYPOGRAPHY_FOOTNOTE_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "14",
+      "originalValue": "{!TYPE_SIZE_14}",
+      "name": "TYPOGRAPHY_FOOTNOTE_SIZE"
+    },
+    "TYPOGRAPHY_FOOTNOTE_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1.4279999732971191",
+      "originalValue": "1.4279999732971191",
+      "name": "TYPOGRAPHY_FOOTNOTE_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_CAPTION_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_CAPTION_FAMILY"
+    },
+    "TYPOGRAPHY_CAPTION_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "400",
+      "originalValue": "{!TYPE_WEIGHT_400}",
+      "name": "TYPOGRAPHY_CAPTION_WEIGHT"
+    },
+    "TYPOGRAPHY_CAPTION_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "12",
+      "originalValue": "{!TYPE_SIZE_12}",
+      "name": "TYPOGRAPHY_CAPTION_SIZE"
+    },
+    "TYPOGRAPHY_CAPTION_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1.3300000429153442",
+      "originalValue": "1.3300000429153442",
+      "name": "TYPOGRAPHY_CAPTION_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_LABEL_1_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_LABEL_1_FAMILY"
+    },
+    "TYPOGRAPHY_LABEL_1_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "700",
+      "originalValue": "{!TYPE_WEIGHT_700}",
+      "name": "TYPOGRAPHY_LABEL_1_WEIGHT"
+    },
+    "TYPOGRAPHY_LABEL_1_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "16",
+      "originalValue": "{!TYPE_SIZE_16}",
+      "name": "TYPOGRAPHY_LABEL_1_SIZE"
+    },
+    "TYPOGRAPHY_LABEL_1_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1.5",
+      "originalValue": "1.5",
+      "name": "TYPOGRAPHY_LABEL_1_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_LABEL_2_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_LABEL_2_FAMILY"
+    },
+    "TYPOGRAPHY_LABEL_2_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "700",
+      "originalValue": "{!TYPE_WEIGHT_700}",
+      "name": "TYPOGRAPHY_LABEL_2_WEIGHT"
+    },
+    "TYPOGRAPHY_LABEL_3_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Skyscanner Relative",
+      "originalValue": "{!TYPE_FAMILY_SKYSCANNER_RELATIVE}",
+      "name": "TYPOGRAPHY_LABEL_3_FAMILY"
+    },
+    "TYPOGRAPHY_LABEL_3_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "700",
+      "originalValue": "{!TYPE_WEIGHT_700}",
+      "name": "TYPOGRAPHY_LABEL_3_WEIGHT"
+    },
+    "TYPOGRAPHY_LABEL_2_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "14",
+      "originalValue": "{!TYPE_SIZE_14}",
+      "name": "TYPOGRAPHY_LABEL_2_SIZE"
+    },
+    "TYPOGRAPHY_LABEL_3_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "12",
+      "originalValue": "{!TYPE_SIZE_12}",
+      "name": "TYPOGRAPHY_LABEL_3_SIZE"
+    },
+    "TYPOGRAPHY_LABEL_2_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1.4199999570846558",
+      "originalValue": "1.4199999570846558",
+      "name": "TYPOGRAPHY_LABEL_2_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_EDITORIAL_1_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Larken",
+      "originalValue": "{!TYPE_FAMILY_LARKEN}",
+      "name": "TYPOGRAPHY_EDITORIAL_1_FAMILY"
+    },
+    "TYPOGRAPHY_EDITORIAL_1_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "300",
+      "originalValue": "{!TYPE_WEIGHT_300}",
+      "name": "TYPOGRAPHY_EDITORIAL_1_WEIGHT"
+    },
+    "TYPOGRAPHY_EDITORIAL_1_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "48",
+      "originalValue": "{!TYPE_SIZE_48}",
+      "name": "TYPOGRAPHY_EDITORIAL_1_SIZE"
+    },
+    "TYPOGRAPHY_EDITORIAL_1_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1.1670000553131104",
+      "originalValue": "1.1670000553131104",
+      "name": "TYPOGRAPHY_EDITORIAL_1_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_LABEL_3_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1.3300000429153442",
+      "originalValue": "1.3300000429153442",
+      "name": "TYPOGRAPHY_LABEL_3_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_EDITORIAL_2_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Larken",
+      "originalValue": "{!TYPE_FAMILY_LARKEN}",
+      "name": "TYPOGRAPHY_EDITORIAL_2_FAMILY"
+    },
+    "TYPOGRAPHY_EDITORIAL_3_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Larken",
+      "originalValue": "{!TYPE_FAMILY_LARKEN}",
+      "name": "TYPOGRAPHY_EDITORIAL_3_FAMILY"
+    },
+    "TYPOGRAPHY_EDITORIAL_3_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "400",
+      "originalValue": "{!TYPE_WEIGHT_400}",
+      "name": "TYPOGRAPHY_EDITORIAL_3_WEIGHT"
+    },
+    "TYPOGRAPHY_EDITORIAL_3_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "20",
+      "originalValue": "{!TYPE_SIZE_20}",
+      "name": "TYPOGRAPHY_EDITORIAL_3_SIZE"
+    },
+    "TYPOGRAPHY_EDITORIAL_3_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1.399999976158142",
+      "originalValue": "1.399999976158142",
+      "name": "TYPOGRAPHY_EDITORIAL_3_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_EDITORIAL_4_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Larken",
+      "originalValue": "{!TYPE_FAMILY_LARKEN}",
+      "name": "TYPOGRAPHY_EDITORIAL_4_FAMILY"
+    },
+    "TYPOGRAPHY_EDITORIAL_5_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Larken",
+      "originalValue": "{!TYPE_FAMILY_LARKEN}",
+      "name": "TYPOGRAPHY_EDITORIAL_5_FAMILY"
+    },
+    "TYPOGRAPHY_EDITORIAL_5_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "400",
+      "originalValue": "{!TYPE_WEIGHT_400}",
+      "name": "TYPOGRAPHY_EDITORIAL_5_WEIGHT"
+    },
+    "TYPOGRAPHY_EDITORIAL_5_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "14",
+      "originalValue": "{!TYPE_SIZE_14}",
+      "name": "TYPOGRAPHY_EDITORIAL_5_SIZE"
+    },
+    "TYPOGRAPHY_EDITORIAL_5_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1.399999976158142",
+      "originalValue": "1.399999976158142",
+      "name": "TYPOGRAPHY_EDITORIAL_5_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_EDITORIAL_4_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "400",
+      "originalValue": "{!TYPE_WEIGHT_400}",
+      "name": "TYPOGRAPHY_EDITORIAL_4_WEIGHT"
+    },
+    "TYPOGRAPHY_EDITORIAL_6_FAMILY": {
+      "type": "font",
+      "category": "typesettings",
+      "value": "Larken",
+      "originalValue": "{!TYPE_FAMILY_LARKEN}",
+      "name": "TYPOGRAPHY_EDITORIAL_6_FAMILY"
+    },
+    "TYPOGRAPHY_EDITORIAL_6_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "400",
+      "originalValue": "{!TYPE_WEIGHT_400}",
+      "name": "TYPOGRAPHY_EDITORIAL_6_WEIGHT"
+    },
+    "TYPOGRAPHY_EDITORIAL_4_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "16",
+      "originalValue": "{!TYPE_SIZE_16}",
+      "name": "TYPOGRAPHY_EDITORIAL_4_SIZE"
+    },
+    "TYPOGRAPHY_EDITORIAL_6_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "12",
+      "originalValue": "{!TYPE_SIZE_12}",
+      "name": "TYPOGRAPHY_EDITORIAL_6_SIZE"
+    },
+    "TYPOGRAPHY_EDITORIAL_4_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1.399999976158142",
+      "originalValue": "1.399999976158142",
+      "name": "TYPOGRAPHY_EDITORIAL_4_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_EDITORIAL_6_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1.399999976158142",
+      "originalValue": "1.399999976158142",
+      "name": "TYPOGRAPHY_EDITORIAL_6_LINE_HEIGHT"
+    },
+    "TYPOGRAPHY_EDITORIAL_2_WEIGHT": {
+      "type": "string",
+      "category": "font-weights",
+      "value": "400",
+      "originalValue": "{!TYPE_WEIGHT_400}",
+      "name": "TYPOGRAPHY_EDITORIAL_2_WEIGHT"
+    },
+    "TEXT_DEPRECATED_LINK": {
+      "type": "color",
+      "category": "text-colors",
+      "value": "#0062e3ff",
+      "originalValue": "{!COLOUR_SKY_BLUE}",
+      "name": "TEXT_DEPRECATED_LINK",
+      "darkValue": "#84e9ffff",
+      "originalDarkValue": "{!COLOUR_BRIGHT_BLUE}"
+    },
+    "TYPOGRAPHY_EDITORIAL_2_SIZE": {
+      "type": "font-size",
+      "category": "typesettings",
+      "value": "32",
+      "originalValue": "{!TYPE_SIZE_32}",
+      "name": "TYPOGRAPHY_EDITORIAL_2_SIZE"
+    },
+    "TYPOGRAPHY_EDITORIAL_2_LINE_HEIGHT": {
+      "type": "size",
+      "category": "typesettings",
+      "value": "1.25",
+      "originalValue": "1.25",
+      "name": "TYPOGRAPHY_EDITORIAL_2_LINE_HEIGHT"
+    },
+    "CORE_PRIMARY": {
+      "type": "color",
+      "category": "core-colors",
+      "value": "#05203cff",
+      "originalValue": "{!COLOUR_DARK_SKY}",
+      "name": "CORE_PRIMARY",
+      "darkValue": "#054184ff",
+      "originalDarkValue": "{!COLOUR_TWILIGHT}"
+    },
+    "CORE_ACCENT": {
+      "type": "color",
+      "category": "core-colors",
+      "value": "#0062e3ff",
+      "originalValue": "{!COLOUR_SKY_BLUE}",
+      "name": "CORE_ACCENT",
+      "darkValue": "#84e9ffff",
+      "originalDarkValue": "{!COLOUR_BRIGHT_BLUE}"
+    },
+    "CORE_ECO": {
+      "type": "color",
+      "category": "core-colors",
+      "value": "#0fa1a9ff",
+      "originalValue": "{!COLOUR_ECO_GREEN}",
+      "name": "CORE_ECO",
+      "darkValue": "#0fa1a9ff",
+      "originalDarkValue": "{!COLOUR_ECO_GREEN}"
+    },
+    "STATUS_SUCCESS_SPOT": {
+      "type": "color",
+      "category": "status-colors",
+      "value": "#0c838aff",
+      "originalValue": "{!COLOUR_GREEN}",
+      "name": "STATUS_SUCCESS_SPOT",
+      "darkValue": "#62f1c6ff",
+      "originalDarkValue": "{!COLOUR_BRIGHT_GREEN}"
+    },
+    "STATUS_WARNING_SPOT": {
+      "type": "color",
+      "category": "status-colors",
+      "value": "#f55d42ff",
+      "originalValue": "{!COLOUR_AMBER}",
+      "name": "STATUS_WARNING_SPOT",
+      "darkValue": "#feeb87ff",
+      "originalDarkValue": "{!COLOUR_YELLOW}"
+    },
+    "STATUS_DANGER_SPOT": {
+      "type": "color",
+      "category": "status-colors",
+      "value": "#e70866ff",
+      "originalValue": "{!COLOUR_BERRY}",
+      "name": "STATUS_DANGER_SPOT",
+      "darkValue": "#ff649cff",
+      "originalDarkValue": "{!COLOUR_BRIGHT_BERRY}"
+    },
+    "SURFACE_DEFAULT": {
+      "type": "color",
+      "category": "surface-colors",
+      "value": "#ffffffff",
+      "originalValue": "{!NEUTRAL_WHITE}",
+      "name": "SURFACE_DEFAULT",
+      "darkValue": "#131d2bff",
+      "originalDarkValue": "{!NEUTRAL_DARK_GREY_20}"
+    },
+    "SURFACE_SUCCESS_FILL": {
+      "type": "color",
+      "category": "surface-colors",
+      "value": "#d4fff2ff",
+      "originalValue": "{!COLOUR_MUTED_GREEN}",
+      "name": "SURFACE_SUCCESS_FILL",
+      "darkValue": "#b1ffe7ff",
+      "originalDarkValue": "{!COLOUR_BRIGHT_GREEN_20}"
+    },
+    "SURFACE_WARNING_FILL": {
+      "type": "color",
+      "category": "surface-colors",
+      "value": "#fff7cfff",
+      "originalValue": "{!COLOUR_MUTED_YELLOW}",
+      "name": "SURFACE_WARNING_FILL",
+      "darkValue": "#fbf1bbff",
+      "originalDarkValue": "{!COLOUR_BRIGHT_YELLOW}"
+    },
+    "SURFACE_DANGER_FILL": {
+      "type": "color",
+      "category": "surface-colors",
+      "value": "#ffe9f9ff",
+      "originalValue": "{!COLOUR_MUTED_PINK}",
+      "name": "SURFACE_DANGER_FILL",
+      "darkValue": "#ffcaddff",
+      "originalDarkValue": "{!COLOUR_BRIGHT_PINK}"
+    },
+    "SURFACE_LOW_CONTRAST": {
+      "type": "color",
+      "category": "surface-colors",
+      "value": "#f5f7faff",
+      "originalValue": "{!NEUTRAL_GREY_05}",
+      "name": "SURFACE_LOW_CONTRAST",
+      "darkValue": "#243346ff",
+      "originalDarkValue": "{!NEUTRAL_DARK_GREY_25}"
+    },
+    "CANVAS_DEFAULT": {
+      "type": "color",
+      "category": "canvas-colors",
+      "value": "#ffffffff",
+      "originalValue": "{!NEUTRAL_WHITE}",
+      "name": "CANVAS_DEFAULT",
+      "darkValue": "#010913ff",
+      "originalDarkValue": "{!NEUTRAL_DARK_GREY_10}"
+    },
+    "SURFACE_ELEVATED": {
+      "type": "color",
+      "category": "surface-colors",
+      "value": "#ffffffff",
+      "originalValue": "{!NEUTRAL_WHITE}",
+      "name": "SURFACE_ELEVATED",
+      "darkValue": "#243346ff",
+      "originalDarkValue": "{!NEUTRAL_DARK_GREY_25}"
+    },
+    "CANVAS_CONTRAST": {
+      "type": "color",
+      "category": "canvas-colors",
+      "value": "#eff3f8ff",
+      "originalValue": "{!NEUTRAL_GREY_10}",
+      "name": "CANVAS_CONTRAST",
+      "darkValue": "#010913ff",
+      "originalDarkValue": "{!NEUTRAL_DARK_GREY_10}"
+    },
+    "SURFACE_TINT": {
+      "type": "color",
+      "category": "surface-colors",
+      "value": "#ffffff1a",
+      "originalValue": "{!ALPHA_WHITE_ALPHA_10}",
+      "name": "SURFACE_TINT",
+      "darkValue": "#ffffff1a",
+      "originalDarkValue": "{!ALPHA_WHITE_ALPHA_10}"
+    },
+    "SURFACE_SUBTLE": {
+      "type": "color",
+      "category": "surface-colors",
+      "value": "#e3f0ffff",
+      "originalValue": "{!COLOUR_BABY_BLUE}",
+      "name": "SURFACE_SUBTLE",
+      "darkValue": "#243346ff",
+      "originalDarkValue": "{!NEUTRAL_DARK_GREY_25}"
+    },
+    "OTHER_LINE_DEFAULT": {
+      "type": "color",
+      "category": "line-colors",
+      "value": "#c1c7cfff",
+      "originalValue": "{!NEUTRAL_GREY_30}",
+      "name": "OTHER_LINE_DEFAULT",
+      "darkValue": "#ffffff33",
+      "originalDarkValue": "{!ALPHA_WHITE_ALPHA_20}"
+    },
+    "OTHER_LINE_SUBTLE": {
+      "type": "color",
+      "category": "line-colors",
+      "value": "#e0e4e9ff",
+      "originalValue": "{!NEUTRAL_GREY_20}",
+      "name": "OTHER_LINE_SUBTLE",
+      "darkValue": "#ffffff1a",
+      "originalDarkValue": "{!ALPHA_WHITE_ALPHA_10}"
+    },
+    "OTHER_LINE_ONCONTRAST": {
+      "type": "color",
+      "category": "line-colors",
+      "value": "#ffffff33",
+      "originalValue": "{!ALPHA_WHITE_ALPHA_20}",
+      "name": "OTHER_LINE_ONCONTRAST",
+      "darkValue": "#ffffff33",
+      "originalDarkValue": "{!ALPHA_WHITE_ALPHA_20}"
+    },
+    "SURFACE_HERO": {
+      "type": "color",
+      "category": "surface-colors",
+      "value": "#0062e3ff",
+      "originalValue": "{!COLOUR_SKY_BLUE}",
+      "name": "SURFACE_HERO",
+      "darkValue": "#010913ff",
+      "originalDarkValue": "{!NEUTRAL_DARK_GREY_10}"
+    },
+    "OTHER_SCRIM": {
+      "type": "color",
+      "category": "line-colors",
+      "value": "#000000b2",
+      "originalValue": "{!ALPHA_BLACK_ALPHA_70}",
+      "name": "OTHER_SCRIM",
+      "darkValue": "#000000b2",
+      "originalDarkValue": "{!ALPHA_BLACK_ALPHA_70}"
+    },
+    "SURFACE_PROMO": {
+      "type": "color",
+      "category": "surface-colors",
+      "value": "#0062e3ff",
+      "originalValue": "{!COLOUR_SKY_BLUE}",
+      "name": "SURFACE_PROMO",
+      "darkValue": "#243346ff",
+      "originalDarkValue": "{!NEUTRAL_DARK_GREY_25}"
+    },
+    "OTHER_OVERLAY": {
+      "type": "color",
+      "category": "line-colors",
+      "value": "#00000033",
+      "originalValue": "{!ALPHA_BLACK_ALPHA_20}",
+      "name": "OTHER_OVERLAY",
+      "darkValue": "#ffffffcc",
+      "originalDarkValue": "{!ALPHA_WHITE_ALPHA_80}"
+    },
+    "SURFACE_CONTRAST": {
+      "type": "color",
+      "category": "surface-colors",
+      "value": "#05203cff",
+      "originalValue": "{!COLOUR_DARK_SKY}",
+      "name": "SURFACE_CONTRAST",
+      "darkValue": "#010913ff",
+      "originalDarkValue": "{!NEUTRAL_DARK_GREY_10}"
+    },
+    "OTHER_SHADOW": {
+      "type": "color",
+      "category": "line-colors",
+      "value": "#16161640",
+      "originalValue": "{!ALPHA_BLACK_ALPHA_25}",
+      "name": "OTHER_SHADOW",
+      "darkValue": "#16161640",
+      "originalDarkValue": "{!ALPHA_BLACK_ALPHA_25}"
+    },
+    "SURFACE_HIGHLIGHT": {
+      "type": "color",
+      "category": "surface-colors",
+      "value": "#e0e4e9ff",
+      "originalValue": "{!NEUTRAL_GREY_20}",
+      "name": "SURFACE_HIGHLIGHT",
+      "darkValue": "#243346ff",
+      "originalDarkValue": "{!NEUTRAL_DARK_GREY_25}"
+    }
+  },
+  "propKeys": [
+    "RADIUS_NONE",
+    "RADIUS_XS",
+    "RADIUS_SM",
+    "RADIUS_MD",
+    "RADIUS_NAV_TABS",
+    "RADIUS_LG",
+    "RADIUS_XL",
+    "RADIUS_FULL",
+    "SPACING_NONE",
+    "SPACING_XXS",
+    "SPACING_XS",
+    "SPACING_SM",
+    "SPACING_MD",
+    "SPACING_BASE",
+    "SPACING_LG",
+    "SPACING_XL",
+    "SPACING_XXL",
+    "SPACING_XXXL",
+    "SPACING_XXXXL",
+    "HEIGHTS_16",
+    "HEIGHTS_20",
+    "HEIGHTS_24",
+    "HEIGHTS_32",
+    "HEIGHTS_36",
+    "HEIGHTS_40",
+    "HEIGHTS_44",
+    "HEIGHTS_48",
+    "HEIGHTS_52",
+    "HEIGHTS_56",
+    "HEIGHTS_64",
+    "BORDER_1",
+    "BORDER_2",
+    "BORDER_3",
+    "MODAL_200",
+    "MODAL_400",
+    "MODAL_512",
+    "MODAL_600",
+    "MODAL_800",
+    "MODAL_1000",
+    "MODAL_1024",
+    "TYPE_FAMILY_SKYSCANNER_RELATIVE",
+    "TYPE_FAMILY_LARKEN",
+    "TYPE_SIZE_12",
+    "TYPE_SIZE_14",
+    "TYPE_SIZE_16",
+    "TYPE_SIZE_20",
+    "TYPE_SIZE_24",
+    "TYPE_SIZE_32",
+    "TYPE_SIZE_40",
+    "TYPE_SIZE_48",
+    "TYPE_SIZE_64",
+    "TYPE_SIZE_76",
+    "TYPE_SIZE_96",
+    "TYPE_SIZE_120",
+    "TYPE_SIZE_144",
+    "TYPE_SIZE_192",
+    "TYPE_SIZE_240",
+    "TYPE_LINE_HEIGHT_16",
+    "TYPE_LINE_HEIGHT_20",
+    "TYPE_LINE_HEIGHT_22",
+    "TYPE_LINE_HEIGHT_24",
+    "TYPE_LINE_HEIGHT_28",
+    "TYPE_LINE_HEIGHT_32",
+    "TYPE_LINE_HEIGHT_40",
+    "TYPE_LINE_HEIGHT_48",
+    "TYPE_LINE_HEIGHT_56",
+    "TYPE_LINE_HEIGHT_64",
+    "TYPE_LINE_HEIGHT_76",
+    "TYPE_LINE_HEIGHT_82",
+    "TYPE_LINE_HEIGHT_96",
+    "TYPE_LINE_HEIGHT_115",
+    "TYPE_LINE_HEIGHT_120",
+    "TYPE_LINE_HEIGHT_153",
+    "TYPE_LINE_HEIGHT_192",
+    "TYPE_LETTER_SPACING_LOOSE_20",
+    "TYPE_LETTER_SPACING_LOOSE_10",
+    "TYPE_LETTER_SPACING_DEFAULT",
+    "TYPE_WEIGHT_900",
+    "TYPE_WEIGHT_700",
+    "TYPE_WEIGHT_400",
+    "TYPE_WEIGHT_300",
+    "TYPE_LETTER_SPACING_TIGHT_10",
+    "TYPE_LETTER_SPACING_TIGHT_20",
+    "TYPE_LETTER_SPACING_TIGHT_30",
+    "TYPE_LETTER_SPACING_TIGHT_40",
+    "TYPE_LETTER_SPACING_TIGHT_50",
+    "ANIMATION_DURATION_XS",
+    "ANIMATION_DURATION_SM",
+    "ANIMATION_DURATION_BASE",
+    "ELEVATION_XS",
+    "ELEVATION_SM",
+    "ELEVATION_BASE",
+    "ELEVATION_LG",
+    "ELEVATION_XL",
+    "ELEVATION_XXL",
+    "TYPOGRAPHY_DISPLAY_1_FAMILY",
+    "TEXT_PRIMARY",
+    "TEXT_SECONDARY",
+    "TEXT_SECONDARY_ON_CONTRAST",
+    "TEXT_INVERSE",
+    "TEXT_HERO",
+    "TEXT_DISABLED",
+    "TEXT_DISABLED_ON_DARK",
+    "TEXT_ERROR",
+    "TEXT_SUCCESS",
+    "TEXT_ON_DARK",
+    "TEXT_ON_LIGHT",
+    "TYPOGRAPHY_DISPLAY_2_FAMILY",
+    "TYPOGRAPHY_DISPLAY_2_WEIGHT",
+    "TYPOGRAPHY_DISPLAY_2_SIZE",
+    "TYPOGRAPHY_DISPLAY_2_LINE_HEIGHT",
+    "TYPOGRAPHY_DISPLAY_2_LETTER_SPACING",
+    "TYPOGRAPHY_DISPLAY_3_FAMILY",
+    "TYPOGRAPHY_DISPLAY_3_WEIGHT",
+    "TYPOGRAPHY_DISPLAY_3_SIZE",
+    "TYPOGRAPHY_DISPLAY_3_LINE_HEIGHT",
+    "TYPOGRAPHY_DISPLAY_3_LETTER_SPACING",
+    "TYPOGRAPHY_DISPLAY_1_WEIGHT",
+    "TYPOGRAPHY_DISPLAY_4_FAMILY",
+    "TYPOGRAPHY_DISPLAY_1_SIZE",
+    "TYPOGRAPHY_DISPLAY_5_FAMILY",
+    "TYPOGRAPHY_DISPLAY_4_WEIGHT",
+    "TYPOGRAPHY_DISPLAY_6_FAMILY",
+    "TYPOGRAPHY_DISPLAY_4_SIZE",
+    "TYPOGRAPHY_DISPLAY_1_LINE_HEIGHT",
+    "TYPOGRAPHY_DISPLAY_5_WEIGHT",
+    "TYPOGRAPHY_DISPLAY_5_SIZE",
+    "TYPOGRAPHY_DISPLAY_4_LINE_HEIGHT",
+    "TYPOGRAPHY_DISPLAY_1_LETTER_SPACING",
+    "TYPOGRAPHY_DISPLAY_6_WEIGHT",
+    "TYPOGRAPHY_HERO_1_FAMILY",
+    "TYPOGRAPHY_DISPLAY_4_LETTER_SPACING",
+    "TYPOGRAPHY_DISPLAY_5_LINE_HEIGHT",
+    "TYPOGRAPHY_HERO_1_WEIGHT",
+    "TYPOGRAPHY_DISPLAY_6_SIZE",
+    "TYPOGRAPHY_DISPLAY_6_LINE_HEIGHT",
+    "TYPOGRAPHY_DISPLAY_5_LETTER_SPACING",
+    "TYPOGRAPHY_HERO_1_SIZE",
+    "TYPOGRAPHY_DISPLAY_6_LETTER_SPACING",
+    "TYPOGRAPHY_HERO_1_LINE_HEIGHT",
+    "TYPOGRAPHY_HERO_1_LETTER_SPACING",
+    "TYPOGRAPHY_HERO_2_FAMILY",
+    "TYPOGRAPHY_HERO_2_WEIGHT",
+    "TYPOGRAPHY_HERO_2_SIZE",
+    "TYPOGRAPHY_HERO_2_LINE_HEIGHT",
+    "TYPOGRAPHY_HERO_2_LETTER_SPACING",
+    "TYPOGRAPHY_HERO_3_FAMILY",
+    "TYPOGRAPHY_HERO_3_WEIGHT",
+    "TYPOGRAPHY_HERO_3_SIZE",
+    "TYPOGRAPHY_HERO_3_LINE_HEIGHT",
+    "TYPOGRAPHY_HERO_3_LETTER_SPACING",
+    "TYPOGRAPHY_HERO_4_FAMILY",
+    "TYPOGRAPHY_HERO_4_WEIGHT",
+    "TYPOGRAPHY_HERO_4_SIZE",
+    "TYPOGRAPHY_HERO_4_LINE_HEIGHT",
+    "TYPOGRAPHY_HERO_4_LETTER_SPACING",
+    "TYPOGRAPHY_HERO_5_FAMILY",
+    "TYPOGRAPHY_HERO_5_WEIGHT",
+    "TYPOGRAPHY_HERO_6_FAMILY",
+    "TYPOGRAPHY_HERO_5_SIZE",
+    "TYPOGRAPHY_HERO_6_WEIGHT",
+    "TYPOGRAPHY_HERO_6_SIZE",
+    "TYPOGRAPHY_HERO_6_LINE_HEIGHT",
+    "TYPOGRAPHY_HERO_6_LETTER_SPACING",
+    "TYPOGRAPHY_HERO_5_LINE_HEIGHT",
+    "TYPOGRAPHY_HERO_5_LETTER_SPACING",
+    "TYPOGRAPHY_HEADING_1_FAMILY",
+    "TYPOGRAPHY_HEADING_1_WEIGHT",
+    "TYPOGRAPHY_HEADING_1_SIZE",
+    "TYPOGRAPHY_HEADING_1_LINE_HEIGHT",
+    "TYPOGRAPHY_HEADING_2_FAMILY",
+    "TYPOGRAPHY_HEADING_3_FAMILY",
+    "TYPOGRAPHY_HEADING_3_WEIGHT",
+    "TYPOGRAPHY_HEADING_3_SIZE",
+    "TYPOGRAPHY_HEADING_3_LINE_HEIGHT",
+    "TYPOGRAPHY_HEADING_4_FAMILY",
+    "TYPOGRAPHY_HEADING_4_WEIGHT",
+    "TYPOGRAPHY_HEADING_4_SIZE",
+    "TYPOGRAPHY_HEADING_4_LINE_HEIGHT",
+    "TYPOGRAPHY_HEADING_5_FAMILY",
+    "TYPOGRAPHY_HEADING_5_WEIGHT",
+    "TYPOGRAPHY_HEADING_5_SIZE",
+    "TYPOGRAPHY_HEADING_5_LINE_HEIGHT",
+    "TYPOGRAPHY_SUBHEADING_FAMILY",
+    "TYPOGRAPHY_SUBHEADING_WEIGHT",
+    "TYPOGRAPHY_SUBHEADING_SIZE",
+    "TYPOGRAPHY_SUBHEADING_LINE_HEIGHT",
+    "TYPOGRAPHY_BODY_LONGFORM_FAMILY",
+    "TYPOGRAPHY_BODY_LONGFORM_WEIGHT",
+    "TYPOGRAPHY_BODY_LONGFORM_SIZE",
+    "TYPOGRAPHY_BODY_LONGFORM_LINE_HEIGHT",
+    "TYPOGRAPHY_HEADING_2_WEIGHT",
+    "TYPOGRAPHY_HEADING_2_SIZE",
+    "TYPOGRAPHY_HEADING_2_LINE_HEIGHT",
+    "TYPOGRAPHY_BODY_DEFAULT_FAMILY",
+    "TYPOGRAPHY_BODY_DEFAULT_WEIGHT",
+    "TYPOGRAPHY_BODY_DEFAULT_SIZE",
+    "TYPOGRAPHY_BODY_DEFAULT_LINE_HEIGHT",
+    "TYPOGRAPHY_FOOTNOTE_FAMILY",
+    "TYPOGRAPHY_FOOTNOTE_WEIGHT",
+    "TYPOGRAPHY_FOOTNOTE_SIZE",
+    "TYPOGRAPHY_FOOTNOTE_LINE_HEIGHT",
+    "TYPOGRAPHY_CAPTION_FAMILY",
+    "TYPOGRAPHY_CAPTION_WEIGHT",
+    "TYPOGRAPHY_CAPTION_SIZE",
+    "TYPOGRAPHY_CAPTION_LINE_HEIGHT",
+    "TYPOGRAPHY_LABEL_1_FAMILY",
+    "TYPOGRAPHY_LABEL_1_WEIGHT",
+    "TYPOGRAPHY_LABEL_1_SIZE",
+    "TYPOGRAPHY_LABEL_1_LINE_HEIGHT",
+    "TYPOGRAPHY_LABEL_2_FAMILY",
+    "TYPOGRAPHY_LABEL_2_WEIGHT",
+    "TYPOGRAPHY_LABEL_3_FAMILY",
+    "TYPOGRAPHY_LABEL_3_WEIGHT",
+    "TYPOGRAPHY_LABEL_2_SIZE",
+    "TYPOGRAPHY_LABEL_3_SIZE",
+    "TYPOGRAPHY_LABEL_2_LINE_HEIGHT",
+    "TYPOGRAPHY_EDITORIAL_1_FAMILY",
+    "TYPOGRAPHY_EDITORIAL_1_WEIGHT",
+    "TYPOGRAPHY_EDITORIAL_1_SIZE",
+    "TYPOGRAPHY_EDITORIAL_1_LINE_HEIGHT",
+    "TYPOGRAPHY_LABEL_3_LINE_HEIGHT",
+    "TYPOGRAPHY_EDITORIAL_2_FAMILY",
+    "TYPOGRAPHY_EDITORIAL_3_FAMILY",
+    "TYPOGRAPHY_EDITORIAL_3_WEIGHT",
+    "TYPOGRAPHY_EDITORIAL_3_SIZE",
+    "TYPOGRAPHY_EDITORIAL_3_LINE_HEIGHT",
+    "TYPOGRAPHY_EDITORIAL_4_FAMILY",
+    "TYPOGRAPHY_EDITORIAL_5_FAMILY",
+    "TYPOGRAPHY_EDITORIAL_5_WEIGHT",
+    "TYPOGRAPHY_EDITORIAL_5_SIZE",
+    "TYPOGRAPHY_EDITORIAL_5_LINE_HEIGHT",
+    "TYPOGRAPHY_EDITORIAL_4_WEIGHT",
+    "TYPOGRAPHY_EDITORIAL_6_FAMILY",
+    "TYPOGRAPHY_EDITORIAL_6_WEIGHT",
+    "TYPOGRAPHY_EDITORIAL_4_SIZE",
+    "TYPOGRAPHY_EDITORIAL_6_SIZE",
+    "TYPOGRAPHY_EDITORIAL_4_LINE_HEIGHT",
+    "TYPOGRAPHY_EDITORIAL_6_LINE_HEIGHT",
+    "TYPOGRAPHY_EDITORIAL_2_WEIGHT",
+    "TEXT_DEPRECATED_LINK",
+    "TYPOGRAPHY_EDITORIAL_2_SIZE",
+    "TYPOGRAPHY_EDITORIAL_2_LINE_HEIGHT",
+    "CORE_PRIMARY",
+    "CORE_ACCENT",
+    "CORE_ECO",
+    "STATUS_SUCCESS_SPOT",
+    "STATUS_WARNING_SPOT",
+    "STATUS_DANGER_SPOT",
+    "SURFACE_DEFAULT",
+    "SURFACE_SUCCESS_FILL",
+    "SURFACE_WARNING_FILL",
+    "SURFACE_DANGER_FILL",
+    "SURFACE_LOW_CONTRAST",
+    "CANVAS_DEFAULT",
+    "SURFACE_ELEVATED",
+    "CANVAS_CONTRAST",
+    "SURFACE_TINT",
+    "SURFACE_SUBTLE",
+    "OTHER_LINE_DEFAULT",
+    "OTHER_LINE_SUBTLE",
+    "OTHER_LINE_ONCONTRAST",
+    "SURFACE_HERO",
+    "OTHER_SCRIM",
+    "SURFACE_PROMO",
+    "OTHER_OVERLAY",
+    "SURFACE_CONTRAST",
+    "OTHER_SHADOW",
+    "SURFACE_HIGHLIGHT"
+  ]
+}


### PR DESCRIPTION
## Summary

- Replaces the DTCG + Style Dictionary approach from the original spike (#2704) with a simpler pipeline
- `fetch.ts` calls the Figma Variables API and writes directly to the existing `bpk-foundations-android` JSON format
- The existing `buildSrc` Kotlin pipeline (KotlinPoet formatters, all Gradle tasks) runs **completely unchanged**
- No DTCG. No Style Dictionary. No changes to any Android source files. Node.js is only needed for the fetch step

**Pipeline:**
```
npm run tokens:fetch
  → fetch.ts: Figma Variables API → base.raw.android.json (bpk-foundations format)
  → ./gradlew generateTokens (existing, unchanged)
  → BpkColors.kt, BpkSpacing.kt, BpkBorderRadius.kt, BpkBorderSize.kt,
    BpkDuration.kt, BpkElevation.kt, BpkFontSize.kt, BpkTypography.kt, .xml files
```

**Token coverage vs old bpk-foundations-android:**
| Category | Old | New |
|---|---|---|
| Semantic colors | 34 | 38 ✅ |
| Spacing | 17 | 29 ✅ |
| Radii | 7 | 8 ✅ |
| Borders | 3 | 3 ✅ |
| Elevation | 6 | 6 ✅ |
| Animations | 3 | 3 ✅ |
| Font sizes | 13 | 46 ✅ |
| Letter spacings | 1 | 20 ✅ |
| Line heights | 15 | 48 ✅ |

Higher counts reflect tokens added to Figma since the package was last published.

## Context

See [PoC doc](https://skyscanner.atlassian.net/wiki/spaces/BPK/pages/2606302753) and [implementation approaches decision](https://skyscanner.atlassian.net/wiki/spaces/BPK/pages/2812346883) for background on why this approach was explored over the original DTCG spike.

## Test plan

- [ ] Run `cd token-sync && npm install && npm run tokens:fetch` — verify `token-sync/tokens/base.raw.android.json` is written
- [ ] Run `./gradlew generateTokens` — verify `BUILD SUCCESSFUL` and all token files regenerated
- [ ] Check `BpkColors.kt`, `BpkSpacing.kt`, `BpkFontSize.kt` have expected values

## Not yet done (next steps)

- Update GitHub Actions workflow to use new pipeline (remove Style Dictionary step)
- Component colours (`BpkButtonColors.kt` etc.)
- Figma webhook integration
- iOS equivalent

🤖 Generated with [Claude Code](https://claude.com/claude-code)