### PR TITLE
[DON-3428] Align BpkCellItem accessibility and tokens

### DIFF
--- a/app/src/main/java/net/skyscanner/backpack/demo/compose/CellGroupStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/compose/CellGroupStory.kt
@@ -96,6 +96,7 @@ fun CellGroupDefaultStory(modifier: Modifier = Modifier) {
                     icon = BpkIcon.Aircraft,
                     slot = BpkCellItemSlot.Image(
                         imageDrawable = R.drawable.sample_icon,
+                        contentDescription = "British Airways logo",
                     ),
                 ),
             ),

--- a/app/src/main/java/net/skyscanner/backpack/demo/compose/CellItemStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/compose/CellItemStory.kt
@@ -191,7 +191,10 @@ fun CellItemWithImageStory(modifier: Modifier = Modifier) {
             title = "Partner Program",
             body = "Skyland Airlines",
             onClick = {},
-            slot = BpkCellItemSlot.Image(R.drawable.sample_icon),
+            slot = BpkCellItemSlot.Image(
+                imageDrawable = R.drawable.sample_icon,
+                contentDescription = "Skyland Airlines logo",
+            ),
             modifier = Modifier.fillMaxWidth(),
         )
     }

--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/cellitem/BpkCellItemAccessibilityTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/cellitem/BpkCellItemAccessibilityTest.kt
@@ -1,0 +1,52 @@
+/**
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018 - 2026 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.skyscanner.backpack.compose.cellitem
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import net.skyscanner.backpack.compose.theme.BpkTheme
+import org.junit.Rule
+import org.junit.Test
+
+class BpkCellItemAccessibilityTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun givenImageContentDescription_whenBpkCellItemRendered_thenDescriptionIsExposed() {
+        val imageContentDescription = "Partner logo"
+
+        composeTestRule.setContent {
+            BpkTheme {
+                BpkCellItem(
+                    title = "Partner",
+                    slot = BpkCellItemSlot.Image(
+                        imageDrawable = android.R.drawable.ic_menu_gallery,
+                        contentDescription = imageContentDescription,
+                    ),
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription(imageContentDescription)
+            .assertExists()
+    }
+}

--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/cellitem/BpkCellItemAccessibilityTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/cellitem/BpkCellItemAccessibilityTest.kt
@@ -18,7 +18,11 @@
 
 package net.skyscanner.backpack.compose.cellitem
 
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onAllNodes
 import androidx.compose.ui.test.onNodeWithContentDescription
 import net.skyscanner.backpack.compose.theme.BpkTheme
 import org.junit.Rule
@@ -48,5 +52,26 @@ class BpkCellItemAccessibilityTest {
         composeTestRule
             .onNodeWithContentDescription(imageContentDescription)
             .assertExists()
+    }
+
+    @Test
+    fun givenNoImageContentDescription_whenBpkCellItemRendered_thenDescriptionIsNotExposed() {
+        composeTestRule.setContent {
+            BpkTheme {
+                BpkCellItem(
+                    title = "Partner",
+                    slot = BpkCellItemSlot.Image(
+                        imageDrawable = android.R.drawable.ic_menu_gallery,
+                    ),
+                )
+            }
+        }
+
+        composeTestRule
+            .onAllNodes(
+                SemanticsMatcher.keyIsDefined(SemanticsProperties.ContentDescription),
+                useUnmergedTree = true,
+            )
+            .assertCountEquals(0)
     }
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cellitem/BpkCellItem.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cellitem/BpkCellItem.kt
@@ -83,9 +83,12 @@ sealed interface BpkCellItemSlot {
      * Displays an image, typically used for branding or identification.
      *
      * @param imageDrawable The drawable resource ID for the image.
+     * @param contentDescription An optional description announced by TalkBack.
+     * Pass `null` when the image is decorative.
      */
     data class Image(
         @DrawableRes val imageDrawable: Int,
+        val contentDescription: String? = null,
     ) : BpkCellItemSlot
 }
 

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cellitem/internal/BpkCellItemImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cellitem/internal/BpkCellItemImpl.kt
@@ -155,7 +155,7 @@ private fun RenderSlot(slotType: BpkCellItemSlot) {
         is BpkCellItemSlot.Image -> {
             Image(
                 painter = painterResource(slotType.imageDrawable),
-                contentDescription = null,
+                contentDescription = slotType.contentDescription,
                 modifier = Modifier.size(width = BpkSpacing.Xxl, height = BpkSpacing.Lg),
             )
         }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cellitem/internal/BpkCellItemImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cellitem/internal/BpkCellItemImpl.kt
@@ -46,6 +46,7 @@ import net.skyscanner.backpack.compose.link.BpkLinkStyle
 import net.skyscanner.backpack.compose.switch.BpkSwitch
 import net.skyscanner.backpack.compose.text.BpkText
 import net.skyscanner.backpack.compose.theme.BpkTheme
+import net.skyscanner.backpack.compose.tokens.BpkBorderRadius
 import net.skyscanner.backpack.compose.tokens.BpkSpacing
 import net.skyscanner.backpack.compose.tokens.ChevronRight
 import net.skyscanner.backpack.compose.utils.applyIf
@@ -69,7 +70,7 @@ internal fun BpkCellItemImpl(
 
     val shape = when (corner) {
         BpkCellItemCorner.Default -> RoundedCornerShape(0.dp)
-        BpkCellItemCorner.Rounded -> RoundedCornerShape(BpkSpacing.Md)
+        BpkCellItemCorner.Rounded -> RoundedCornerShape(BpkBorderRadius.Sm)
     }
 
     Row(

--- a/docs/compose/CellItem/README.md
+++ b/docs/compose/CellItem/README.md
@@ -119,6 +119,8 @@ BpkCellItem(
 
 Example of a BpkCellItem with Rounded corners:
 
+Rounded CellItems use `BpkBorderRadius.Sm` (8dp), matching the small 8pt radius token used by iOS.
+
 ```Kotlin
 import net.skyscanner.backpack.compose.cellitem.BpkCellItem
 import net.skyscanner.backpack.compose.cellitem.BpkCellItemCorner
@@ -194,15 +196,22 @@ BpkCellItem(
 
 ### Image (Image Display)
 
+Use `contentDescription` to provide a meaningful TalkBack description when the image conveys information. Leave it as `null` when the image is decorative.
+
 ```Kotlin
 import net.skyscanner.backpack.compose.cellitem.BpkCellItem
 import net.skyscanner.backpack.compose.cellitem.BpkCellItemSlot
 
 BpkCellItem(
   title = "Partner",
-  slot = BpkCellItemSlot.Image(R.drawable.partner_logo),
+  slot = BpkCellItemSlot.Image(
+    imageDrawable = R.drawable.partner_logo,
+    contentDescription = "Partner logo",
+  ),
 )
 ```
+
+Android’s image slot accepts a drawable resource ID, while iOS accepts a SwiftUI `Image`. Android retains the resource-based API because the component owns the image’s fixed dimensions and current usages use packaged drawable resources. Supporting arbitrary `Painter` or composable content would widen the API and requires separate decisions about sizing and rendering ownership.
 
 ## Complete Example
 


### PR DESCRIPTION
## Summary

This PR addresses BpkCellItem accessibility and token-alignment gaps on Android:

- Adds an optional `contentDescription` to `BpkCellItemSlot.Image`, allowing callers to make meaningful trailing images accessible to TalkBack.
- Aligns the rounded-corner implementation with the appropriate Backpack border-radius token.
- Documents the intentional difference between the Android and iOS image-slot APIs.

## Changes

- Added `contentDescription: String? = null` to `BpkCellItemSlot.Image`.
- Passed the supplied description to the rendered Compose `Image`.
- Preserved existing behaviour for decorative images and existing call sites by defaulting `contentDescription` to `null`.
- Added a Compose accessibility test confirming that the supplied image description is exposed through the rendered semantics tree.
- Replaced `BpkSpacing.Md` with `BpkBorderRadius.Sm` for rounded CellItems.
  - Both tokens resolve to 8dp, so this is a semantic token correction with no visual change.
- Updated the Cell Item and Cell Group demo stories with meaningful image descriptions.
- Updated the CellItem README to:
  - document the `contentDescription` parameter
  - explain when an image should remain decorative
  - demonstrate an accessible trailing image
  - document the aligned rounded-corner token
  - explain why Android retains its `@DrawableRes Int` image API while iOS accepts a SwiftUI `Image`

## Testing

- Added `BpkCellItemAccessibilityTest`, which verifies that a supplied image description is exposed through Compose accessibility semantics.
- Existing rounded-corner snapshot coverage remains unchanged because the replacement token has the same 8dp value.
- The complete automated test suite will be compiled and run by CI.

## Manual testing

Smoke tested using the Backpack Android demo app with the `ossDebug` build on an Android emulator.

- [x] Confirmed the Cell Item `With Image` story exposes “Skyland Airlines logo” to TalkBack.
- [x] Confirmed the Cell Group story exposes “British Airways logo” to TalkBack.
- [x] Confirmed an image with `contentDescription = null` remains decorative and unannounced.
- [x] Confirmed the rounded CellItem appearance is unchanged.
- [x] Confirmed the chevron, switch, text and link slots continue to render and behave normally.
- [x] No crashes, interaction issues or visual regressions were found.

## Cross-platform alignment

Rounded CellItems now use `BpkBorderRadius.Sm` on Android, matching the small 8pt radius token used by iOS. This changes the semantic token only; the rendered Android radius remains 8dp.

Android continues to accept a drawable resource ID for its image slot, while iOS accepts a SwiftUI `Image`. Android retains the resource-based API because the component owns the image’s fixed dimensions and current usages rely on packaged drawable resources. Supporting arbitrary `Painter` or composable content would widen the API and requires separate decisions about sizing and rendering ownership.

## Notes

These changes are additive and do not require existing call sites to change.

There are no expected visual or snapshot changes. No `skyscanner-app` or iOS changes are included.

+ [ ] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:

+ [x] Component `README.md`
+ [x] Tests

If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)