### PR TITLE
[DON-3492] Add accessibility label to BPKBannerAlert

### DIFF
--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/banneralert/BpkBannerAlertAccessibilityTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/banneralert/BpkBannerAlertAccessibilityTest.kt
@@ -1,0 +1,72 @@
+/**
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018 - 2026 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.skyscanner.backpack.compose.banneralert
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import net.skyscanner.backpack.compose.icon.BpkIcon
+import net.skyscanner.backpack.compose.theme.BpkTheme
+import net.skyscanner.backpack.compose.tokens.Airline
+import org.junit.Rule
+import org.junit.Test
+
+class BpkBannerAlertAccessibilityTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun givenIconContentDescription_whenBpkBannerAlertRendered_thenIconDescriptionIsExposed() {
+        val iconContentDescription = "Airline"
+
+        composeTestRule.setContent {
+            BpkTheme {
+                BpkBannerAlert(
+                    message = "Hello world!",
+                    alertTypeContentDescription = "Information",
+                    icon = BpkIcon.Airline,
+                    iconContentDescription = iconContentDescription,
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription(iconContentDescription)
+            .assertExists()
+    }
+
+    @Test
+    fun givenNoIconContentDescription_whenBpkBannerAlertRendered_thenIconFallsBackToAlertTypeContentDescription() {
+        val alertTypeContentDescription = "Information"
+
+        composeTestRule.setContent {
+            BpkTheme {
+                BpkBannerAlert(
+                    message = "Hello world!",
+                    alertTypeContentDescription = alertTypeContentDescription,
+                    icon = BpkIcon.Airline,
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription(alertTypeContentDescription)
+            .assertExists()
+    }
+}

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/banneralert/BpkBannerAlert.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/banneralert/BpkBannerAlert.kt
@@ -43,6 +43,7 @@ fun BpkBannerAlert(
     type: BpkBannerAlertType = BpkBannerAlertType.Info,
     icon: BpkIcon? = null,
     style: BpkBannerAlertStyle = BpkBannerAlertStyle.Default,
+    iconContentDescription: String? = null,
 ) {
     BpkBannerAlertImpl(
         modifier = modifier,
@@ -51,5 +52,6 @@ fun BpkBannerAlert(
         icon = icon,
         alertTypeContentDescription = alertTypeContentDescription,
         style = style,
+        iconContentDescription = iconContentDescription,
     )
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/banneralert/internal/BpkBannerAlertImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/banneralert/internal/BpkBannerAlertImpl.kt
@@ -53,6 +53,7 @@ internal fun BpkBannerAlertImpl(
     alertTypeContentDescription: String,
     modifier: Modifier = Modifier,
     icon: BpkIcon? = null,
+    iconContentDescription: String? = null,
 ) {
 
     val background = when (style) {
@@ -88,7 +89,7 @@ internal fun BpkBannerAlertImpl(
             BpkIcon(
                 icon = iconFinal,
                 tint = tint,
-                contentDescription = alertTypeContentDescription,
+                contentDescription = iconContentDescription ?: alertTypeContentDescription,
             )
             BpkText(
                 modifier = Modifier

--- a/docs/compose/BannerAlert/README.md
+++ b/docs/compose/BannerAlert/README.md
@@ -64,7 +64,7 @@ BPKBannerAlert(
 
 Example of a BannerAlert with a custom icon and its own accessibility label:
 
-```Kotlin
+```kotlin
 import net.skyscanner.backpack.compose.banneralert.BpkBannerAlert
 import net.skyscanner.backpack.compose.icon.BpkIcon
 import net.skyscanner.backpack.compose.tokens.Airline
@@ -78,5 +78,6 @@ BpkBannerAlert(
 )
 ```
 
-By default, a custom `icon` is announced using `alertTypeContentDescription`. Use `iconContentDescription`
-to give the custom icon its own, more specific accessibility label instead.
+By default, the rendered icon (whether the type's default icon or a custom `icon`) is announced using
+`alertTypeContentDescription`. Use `iconContentDescription` to give it its own, more specific accessibility
+label instead.

--- a/docs/compose/BannerAlert/README.md
+++ b/docs/compose/BannerAlert/README.md
@@ -61,3 +61,22 @@ BPKBannerAlert(
     style = BPKBannerAlertStyle.OnContrast
 )
 ```
+
+Example of a BannerAlert with a custom icon and its own accessibility label:
+
+```Kotlin
+import net.skyscanner.backpack.compose.banneralert.BpkBannerAlert
+import net.skyscanner.backpack.compose.icon.BpkIcon
+import net.skyscanner.backpack.compose.tokens.Airline
+
+BpkBannerAlert(
+    type = BpkBannerAlertType.Info,
+    message = "Hello world!",
+    alertTypeContentDescription = "Information",
+    icon = BpkIcon.Airline,
+    iconContentDescription = "Airline",
+)
+```
+
+By default, a custom `icon` is announced using `alertTypeContentDescription`. Use `iconContentDescription`
+to give the custom icon its own, more specific accessibility label instead.


### PR DESCRIPTION
## Summary

Adds `accessibilityLabel` support for the custom icon in `BpkBannerAlert`, closing the gap identified by the parity audit — previously there was no way to set a custom content description for the icon separate from the banner's `alertTypeContentDescription`.

## Changes

- Added a new optional trailing parameter `iconContentDescription: String? = null` to `BpkBannerAlert` and `BpkBannerAlertImpl`, threaded through to the icon's `contentDescription`.
- The icon's content description now resolves as `iconContentDescription ?: alertTypeContentDescription`, preserving existing behaviour when the new parameter isn't supplied.
- Documented the new parameter in `docs/compose/BannerAlert/README.md` with a usage example showing a custom icon paired with its own accessibility label.
- Added `BpkBannerAlertAccessibilityTest.kt` covering both the explicit `iconContentDescription` case and the fallback-to-`alertTypeContentDescription` case, following the existing `BpkCellItemAccessibilityTest.kt` convention.

## Compatibility

Source- and binary-compatible. The new parameter is appended last and defaults to `null`. All existing call sites in this repo and in `skyscanner-app` (Origami, Wasabi) use named arguments only, so none are affected.

## Verification

- New accessibility tests added and pass locally.
- No visual/behavioural change for existing callers, so no snapshot re-recording was needed.

Remember to include the following changes:
+ [x] `README.md`
+ [x] Tests
+ [ ] [Screenshotting code](https://github.com/Skyscanner/backpack-android/blob/main/app/src/main/java/net/skyscanner/backpack/demo)
+ [ ] Adding a component? Remember to expose it in the main header/index if applicable

_If you are curious about how we review, please read through the [code review guidelines](https://github.com/Skyscanner/backpack/blob/main/CODE_REVIEW_GUIDELINES.md)_