### PR TITLE
[MUON-1999] Add video progress tracking to BpkVideoPlayer

### DIFF
--- a/app/src/main/java/net/skyscanner/backpack/demo/compose/GraphicPromoStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/compose/GraphicPromoStory.kt
@@ -20,18 +20,28 @@ package net.skyscanner.backpack.demo.compose
 
 import android.util.Log
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.flow.filterNotNull
 import net.skyscanner.backpack.compose.graphicpromotion.BpkGraphicPromo
 import net.skyscanner.backpack.compose.graphicpromotion.BpkGraphicPromoSponsorCTA
 import net.skyscanner.backpack.compose.graphicpromotion.BpkGraphicsPromoSponsor
 import net.skyscanner.backpack.compose.graphicpromotion.BpkGraphicPromoVerticalAlignment
 import net.skyscanner.backpack.compose.overlay.BpkOverlayType
+import net.skyscanner.backpack.compose.theme.BpkTheme
 import net.skyscanner.backpack.compose.tokens.BpkSpacing
 import net.skyscanner.backpack.compose.videoplayer.BpkVideoPlayer
 import net.skyscanner.backpack.compose.videoplayer.BpkVideoPlayerConfig
@@ -41,7 +51,6 @@ import net.skyscanner.backpack.demo.R
 import net.skyscanner.backpack.demo.components.GraphicPromoComponent
 import net.skyscanner.backpack.demo.meta.ComposeStory
 import net.skyscanner.backpack.meta.StoryKind
-
 @Composable
 @GraphicPromoComponent
 @ComposeStory
@@ -121,40 +130,74 @@ internal fun GraphicPromoStorySponsoredWithVideoBackground() {
             accessibilityLabel = "Sample video",
         ),
     )
-    BpkGraphicPromo(
+
+    LaunchedEffect(Unit) {
+        val quartilesFired = mutableSetOf<Int>()
+        snapshotFlow { controller.progressState.value }
+            .filterNotNull()
+            .collect { p ->
+                listOf(25, 50, 75, 100).forEach { q ->
+                    if (q !in quartilesFired && p.percentage >= q / 100f) {
+                        Log.d("BpkVideoProgress", "Quartile $q% reached")
+                        quartilesFired.add(q)
+                    }
+                }
+            }
+    }
+
+    Box(
         modifier = Modifier
             .fillMaxSize()
             .padding(BpkSpacing.Base),
-        headline = "Three Parks Challenge",
-        verticalAlignment = BpkGraphicPromoVerticalAlignment.Bottom,
-        overlayType = BpkOverlayType.SolidHigh,
-        sponsor = BpkGraphicsPromoSponsor(
-            accessibilityLabel = "In partnership with Skyland",
-            logo = "https://images.kiwi.com/airlines/64/FR.png",
-            title = "In partnership with Skyland",
-            callToAction = BpkGraphicPromoSponsorCTA(
-                accessibilityLabel = "Learn more about our sponsor",
-                onClick = {},
+    ) {
+        BpkGraphicPromo(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(BpkSpacing.Base),
+            headline = "Three Parks Challenge",
+            verticalAlignment = BpkGraphicPromoVerticalAlignment.Bottom,
+            overlayType = BpkOverlayType.SolidHigh,
+            sponsor = BpkGraphicsPromoSponsor(
+                accessibilityLabel = "In partnership with Skyland",
+                logo = "https://images.kiwi.com/airlines/64/FR.png",
+                title = "In partnership with Skyland",
+                callToAction = BpkGraphicPromoSponsorCTA(
+                    accessibilityLabel = "Learn more about our sponsor",
+                    onClick = {},
+                ),
             ),
-        ),
-        background = {
-            BpkVideoPlayer(
-                controller = controller,
-                modifier = Modifier.matchParentSize(),
-                scaleToFill = true,
+            background = {
+                BpkVideoPlayer(
+                    controller = controller,
+                    modifier = Modifier.matchParentSize(),
+                    scaleToFill = true,
+                )
+            },
+            sponsorLogo = {
+                Image(
+                    painter = painterResource(id = R.drawable.skyland),
+                    contentDescription = "Image",
+                    contentScale = ContentScale.Fit,
+                )
+            },
+            tapAction = {
+                Log.d("BpkGraphicPromo", "Tap on graphic promo")
+            },
+        )
+
+        controller.progressState.value?.let { p ->
+            net.skyscanner.backpack.compose.text.BpkText(
+                text = "${(p.percentage * 100).toInt()}%  •  ${p.positionMs / 1000}s / ${p.durationMs / 1000}s",
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = BpkSpacing.Md)
+                    .background(Color.Black.copy(alpha = 0.6f), RoundedCornerShape(4.dp))
+                    .padding(horizontal = BpkSpacing.Md, vertical = BpkSpacing.Sm),
+                color = Color.White,
+                style = BpkTheme.typography.label1,
             )
-        },
-        sponsorLogo = {
-            Image(
-                painter = painterResource(id = R.drawable.skyland),
-                contentDescription = "Image",
-                contentScale = ContentScale.Fit,
-            )
-        },
-        tapAction = {
-            Log.d("BpkGraphicPromo", "Tap on graphic promo")
-        },
-    )
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/net/skyscanner/backpack/demo/compose/GraphicPromoStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/compose/GraphicPromoStory.kt
@@ -20,28 +20,18 @@ package net.skyscanner.backpack.demo.compose
 
 import android.util.Log
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.snapshotFlow
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.unit.dp
-import kotlinx.coroutines.flow.filterNotNull
 import net.skyscanner.backpack.compose.graphicpromotion.BpkGraphicPromo
 import net.skyscanner.backpack.compose.graphicpromotion.BpkGraphicPromoSponsorCTA
 import net.skyscanner.backpack.compose.graphicpromotion.BpkGraphicsPromoSponsor
 import net.skyscanner.backpack.compose.graphicpromotion.BpkGraphicPromoVerticalAlignment
 import net.skyscanner.backpack.compose.overlay.BpkOverlayType
-import net.skyscanner.backpack.compose.theme.BpkTheme
 import net.skyscanner.backpack.compose.tokens.BpkSpacing
 import net.skyscanner.backpack.compose.videoplayer.BpkVideoPlayer
 import net.skyscanner.backpack.compose.videoplayer.BpkVideoPlayerConfig
@@ -51,6 +41,7 @@ import net.skyscanner.backpack.demo.R
 import net.skyscanner.backpack.demo.components.GraphicPromoComponent
 import net.skyscanner.backpack.demo.meta.ComposeStory
 import net.skyscanner.backpack.meta.StoryKind
+
 @Composable
 @GraphicPromoComponent
 @ComposeStory
@@ -130,74 +121,40 @@ internal fun GraphicPromoStorySponsoredWithVideoBackground() {
             accessibilityLabel = "Sample video",
         ),
     )
-
-    LaunchedEffect(Unit) {
-        val quartilesFired = mutableSetOf<Int>()
-        snapshotFlow { controller.progressState.value }
-            .filterNotNull()
-            .collect { p ->
-                listOf(25, 50, 75, 100).forEach { q ->
-                    if (q !in quartilesFired && p.percentage >= q / 100f) {
-                        Log.d("BpkVideoProgress", "Quartile $q% reached")
-                        quartilesFired.add(q)
-                    }
-                }
-            }
-    }
-
-    Box(
+    BpkGraphicPromo(
         modifier = Modifier
             .fillMaxSize()
             .padding(BpkSpacing.Base),
-    ) {
-        BpkGraphicPromo(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(BpkSpacing.Base),
-            headline = "Three Parks Challenge",
-            verticalAlignment = BpkGraphicPromoVerticalAlignment.Bottom,
-            overlayType = BpkOverlayType.SolidHigh,
-            sponsor = BpkGraphicsPromoSponsor(
-                accessibilityLabel = "In partnership with Skyland",
-                logo = "https://images.kiwi.com/airlines/64/FR.png",
-                title = "In partnership with Skyland",
-                callToAction = BpkGraphicPromoSponsorCTA(
-                    accessibilityLabel = "Learn more about our sponsor",
-                    onClick = {},
-                ),
+        headline = "Three Parks Challenge",
+        verticalAlignment = BpkGraphicPromoVerticalAlignment.Bottom,
+        overlayType = BpkOverlayType.SolidHigh,
+        sponsor = BpkGraphicsPromoSponsor(
+            accessibilityLabel = "In partnership with Skyland",
+            logo = "https://images.kiwi.com/airlines/64/FR.png",
+            title = "In partnership with Skyland",
+            callToAction = BpkGraphicPromoSponsorCTA(
+                accessibilityLabel = "Learn more about our sponsor",
+                onClick = {},
             ),
-            background = {
-                BpkVideoPlayer(
-                    controller = controller,
-                    modifier = Modifier.matchParentSize(),
-                    scaleToFill = true,
-                )
-            },
-            sponsorLogo = {
-                Image(
-                    painter = painterResource(id = R.drawable.skyland),
-                    contentDescription = "Image",
-                    contentScale = ContentScale.Fit,
-                )
-            },
-            tapAction = {
-                Log.d("BpkGraphicPromo", "Tap on graphic promo")
-            },
-        )
-
-        controller.progressState.value?.let { p ->
-            net.skyscanner.backpack.compose.text.BpkText(
-                text = "${(p.percentage * 100).toInt()}%  •  ${p.positionMs / 1000}s / ${p.durationMs / 1000}s",
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .padding(bottom = BpkSpacing.Md)
-                    .background(Color.Black.copy(alpha = 0.6f), RoundedCornerShape(4.dp))
-                    .padding(horizontal = BpkSpacing.Md, vertical = BpkSpacing.Sm),
-                color = Color.White,
-                style = BpkTheme.typography.label1,
+        ),
+        background = {
+            BpkVideoPlayer(
+                controller = controller,
+                modifier = Modifier.matchParentSize(),
+                scaleToFill = true,
             )
-        }
-    }
+        },
+        sponsorLogo = {
+            Image(
+                painter = painterResource(id = R.drawable.skyland),
+                contentDescription = "Image",
+                contentScale = ContentScale.Fit,
+            )
+        },
+        tapAction = {
+            Log.d("BpkGraphicPromo", "Tap on graphic promo")
+        },
+    )
 }
 
 @Composable

--- a/app/src/main/java/net/skyscanner/backpack/demo/compose/VideoPlayerStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/compose/VideoPlayerStory.kt
@@ -22,6 +22,7 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -33,9 +34,11 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
 import net.skyscanner.backpack.compose.icon.BpkIcon
 import net.skyscanner.backpack.compose.theme.BpkTheme
 import net.skyscanner.backpack.compose.icon.BpkIconSize
+import net.skyscanner.backpack.compose.text.BpkText
 import net.skyscanner.backpack.compose.tokens.BpkSpacing
 import net.skyscanner.backpack.compose.tokens.Expand
 import net.skyscanner.backpack.compose.videoplayer.BpkVideoPlayer
@@ -63,22 +66,41 @@ fun VideoPlayerDefaultControlsStory(modifier: Modifier = Modifier) {
             accessibilityLabel = "Sample video",
         ),
     )
-    Box(
+    Column(
         modifier = modifier
             .fillMaxWidth()
-            .aspectRatio(9f / 16f)
             .padding(BpkSpacing.Base),
     ) {
-        BpkVideoPlayer(
-            controller = controller,
-            scaleToFill = false,
-            modifier = Modifier.matchParentSize(),
-        )
-        BpkVideoPlayerDefaultControls(
-            controller = controller,
-            playContentDescription = "Play video",
-            pauseContentDescription = "Pause video",
-            modifier = Modifier.align(Alignment.TopEnd),
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(9f / 16f),
+        ) {
+            BpkVideoPlayer(
+                controller = controller,
+                scaleToFill = false,
+                modifier = Modifier.matchParentSize(),
+            )
+            BpkVideoPlayerDefaultControls(
+                controller = controller,
+                playContentDescription = "Play video",
+                pauseContentDescription = "Pause video",
+                modifier = Modifier.align(Alignment.TopEnd),
+            )
+        }
+
+        val progressText = controller.progressState.value?.let { p ->
+            "\n${(p.percentage * 100).toInt()}%  •  ${p.positionMs / 1000}s / ${p.durationMs / 1000}s"
+        } ?: "\n"
+
+        BpkText(
+            modifier = Modifier
+                .weight(1f)
+                .padding(top = BpkSpacing.Base),
+            text = "Video Progress can be collected inside the controller $progressText",
+            textAlign = TextAlign.Center,
+            color = BpkTheme.colors.textPrimary,
+            style = BpkTheme.typography.heading5,
         )
     }
 }

--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/cellitem/BpkCellItemAccessibilityTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/cellitem/BpkCellItemAccessibilityTest.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.compose.ui.test.onAllNodes
 import androidx.compose.ui.test.onNodeWithContentDescription
 import net.skyscanner.backpack.compose.theme.BpkTheme
 import org.junit.Rule

--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerTest.kt
@@ -524,13 +524,14 @@ class BpkVideoPlayerTest {
             controller.playbackState.value is BpkVideoPlaybackState.Playing
         }
 
-        // When — wait for onPositionDiscontinuity (AUTO_TRANSITION) to emit 1f
-        // waitUntil polls at ~16ms so it will catch the transient 1f value
+        // When — wait for loop boundary to emit final 100% progress
         composeTestRule.waitUntil(timeoutMillis = ENDED_STATE_TIMEOUT_MS) {
-            controller.progressState.value?.percentage == 1f
+            (controller.progressState.value?.percentage ?: 0f) >= 0.99f
         }
 
         // Then
-        assertEquals(1f, controller.progressState.value?.percentage)
+        assertTrue(
+            (controller.progressState.value?.percentage ?: 0f) >= 0.99f,
+        )
     }
 }

--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerTest.kt
@@ -30,6 +30,8 @@ import net.skyscanner.backpack.compose.videoplayer.VideoPlayerTestRule.Companion
 import net.skyscanner.backpack.compose.videoplayer.VideoPlayerTestRule.Companion.PLAYING_STATE_TIMEOUT_MS
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
@@ -404,5 +406,117 @@ class BpkVideoPlayerTest {
 
         // Then
         assertEquals(Player.STATE_IDLE, controller.player.playbackState)
+    }
+
+    @Test
+    fun givenStubConfig_whenRendered_thenProgressIsNull() {
+        // When
+        lateinit var controller: BpkVideoPlayerController
+        composeTestRule.setContent {
+            BpkTheme {
+                controller = rememberBpkVideoPlayerController(stubConfig)
+                BpkVideoPlayer(controller = controller)
+            }
+        }
+
+        // Then
+        assertNull(controller.progressState.value)
+    }
+
+    @Test
+    fun givenAutoPlay_whenStateReachesPlaying_thenProgressIsNotNull() {
+        // Given
+        videoPlayerTestRule.disableReducedMotionSignal()
+        lateinit var controller: BpkVideoPlayerController
+        composeTestRule.setContent {
+            BpkTheme {
+                controller = rememberBpkVideoPlayerController(playableConfig(autoPlay = true))
+                BpkVideoPlayer(controller = controller)
+            }
+        }
+
+        // When
+        composeTestRule.waitUntil(timeoutMillis = PLAYING_STATE_TIMEOUT_MS) {
+            controller.playbackState.value is BpkVideoPlaybackState.Playing
+        }
+
+        // Then
+        composeTestRule.waitUntil(timeoutMillis = PLAYING_STATE_TIMEOUT_MS) {
+            controller.progressState.value != null
+        }
+        assertNotNull(controller.progressState.value)
+    }
+
+    @Test
+    fun givenPlayingVideo_whenPaused_thenProgressRetainsLastValue() {
+        // Given
+        videoPlayerTestRule.disableReducedMotionSignal()
+        lateinit var controller: BpkVideoPlayerController
+        composeTestRule.setContent {
+            BpkTheme {
+                controller = rememberBpkVideoPlayerController(playableConfig(autoPlay = true))
+                BpkVideoPlayer(controller = controller)
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = PLAYING_STATE_TIMEOUT_MS) {
+            controller.progressState.value != null
+        }
+
+        // When
+        composeTestRule.runOnIdle { controller.pause() }
+        composeTestRule.waitUntil(timeoutMillis = PLAYING_STATE_TIMEOUT_MS) {
+            controller.playbackState.value is BpkVideoPlaybackState.Paused
+        }
+        val progressWhenPaused = controller.progressState.value
+
+        // Then — progress is retained (not nulled) and doesn't advance while paused
+        composeTestRule.mainClock.advanceTimeBy(500L)
+        assertEquals(progressWhenPaused, controller.progressState.value)
+    }
+
+    @Test
+    fun givenLoopFalse_whenVideoEnds_thenProgressPercentageIs100() {
+        // Given
+        videoPlayerTestRule.disableReducedMotionSignal()
+        lateinit var controller: BpkVideoPlayerController
+        composeTestRule.setContent {
+            BpkTheme {
+                controller = rememberBpkVideoPlayerController(playableConfig(autoPlay = true, loop = false))
+                BpkVideoPlayer(controller = controller)
+            }
+        }
+
+        // When
+        composeTestRule.waitUntil(timeoutMillis = ENDED_STATE_TIMEOUT_MS) {
+            controller.playbackState.value is BpkVideoPlaybackState.Ended
+        }
+
+        // Then
+        assertEquals(1f, controller.progressState.value?.percentage)
+    }
+
+    @Test
+    fun givenLoopTrue_whenFirstCycleCompletes_thenProgressReaches100Percent() {
+        // Given
+        videoPlayerTestRule.disableReducedMotionSignal()
+        lateinit var controller: BpkVideoPlayerController
+        composeTestRule.setContent {
+            BpkTheme {
+                controller = rememberBpkVideoPlayerController(playableConfig(autoPlay = true, loop = true))
+                BpkVideoPlayer(controller = controller)
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = PLAYING_STATE_TIMEOUT_MS) {
+            controller.playbackState.value is BpkVideoPlaybackState.Playing
+        }
+
+        // When — wait for onPositionDiscontinuity (AUTO_TRANSITION) to emit 1f
+        // waitUntil polls at ~16ms so it will catch the transient 1f value
+        composeTestRule.waitUntil(timeoutMillis = ENDED_STATE_TIMEOUT_MS) {
+            controller.progressState.value?.percentage == 1f
+        }
+
+        // Then
+        assertEquals(1f, controller.progressState.value?.percentage)
     }
 }

--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerTest.kt
@@ -534,4 +534,58 @@ class BpkVideoPlayerTest {
             (controller.progressState.value?.percentage ?: 0f) >= 0.99f,
         )
     }
+
+    @Test
+    fun givenEndedVideo_whenResetToStart_thenProgressResetsToZero() {
+        // Given
+        videoPlayerTestRule.disableReducedMotionSignal()
+        lateinit var controller: BpkVideoPlayerController
+        composeTestRule.setContent {
+            BpkTheme {
+                controller = rememberBpkVideoPlayerController(playableConfig(autoPlay = true, loop = false))
+                BpkVideoPlayer(controller = controller)
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = ENDED_STATE_TIMEOUT_MS) {
+            controller.playbackState.value is BpkVideoPlaybackState.Ended
+        }
+
+        // When
+        composeTestRule.runOnIdle { controller.resetToStart() }
+
+        // Then
+        val progress = controller.progressState.value
+        assertNotNull(progress)
+        assertEquals(0L, progress!!.positionMs)
+        assertTrue(progress.durationMs > 0L)
+        assertEquals(0f, progress.percentage)
+    }
+
+    @Test
+    fun givenEndedVideo_whenPlay_thenProgressResetsToZero() {
+        // Given
+        videoPlayerTestRule.disableReducedMotionSignal()
+        lateinit var controller: BpkVideoPlayerController
+        composeTestRule.setContent {
+            BpkTheme {
+                controller = rememberBpkVideoPlayerController(playableConfig(autoPlay = true, loop = false))
+                BpkVideoPlayer(controller = controller)
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = ENDED_STATE_TIMEOUT_MS) {
+            controller.playbackState.value is BpkVideoPlaybackState.Ended
+        }
+
+        // When
+        composeTestRule.runOnIdle { controller.play() }
+        composeTestRule.waitUntil(timeoutMillis = PLAYING_STATE_TIMEOUT_MS) {
+            controller.playbackState.value is BpkVideoPlaybackState.Playing
+        }
+
+        // Then — progress has reset and is advancing from the beginning
+        val progress = controller.progressState.value
+        assertNotNull(progress)
+        assertTrue(progress!!.durationMs > 0L)
+        assertTrue(progress.percentage < 0.5f)
+    }
 }

--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerTest.kt
@@ -177,7 +177,9 @@ class BpkVideoPlayerTest {
         }
 
         // Then
-        assertEquals(Player.REPEAT_MODE_ONE, controller.player.repeatMode)
+        composeTestRule.runOnIdle {
+            assertEquals(Player.REPEAT_MODE_ONE, controller.player.repeatMode)
+        }
     }
 
     @Test
@@ -192,7 +194,9 @@ class BpkVideoPlayerTest {
         }
 
         // Then
-        assertEquals(Player.REPEAT_MODE_OFF, controller.player.repeatMode)
+        composeTestRule.runOnIdle {
+            assertEquals(Player.REPEAT_MODE_OFF, controller.player.repeatMode)
+        }
     }
 
     @Test
@@ -207,7 +211,9 @@ class BpkVideoPlayerTest {
         }
 
         // Then
-        assertEquals(0f, controller.player.volume, 0f)
+        composeTestRule.runOnIdle {
+            assertEquals(0f, controller.player.volume, 0f)
+        }
     }
 
     @Test
@@ -222,7 +228,9 @@ class BpkVideoPlayerTest {
         }
 
         // Then
-        assertEquals(1f, controller.player.volume, 0f)
+        composeTestRule.runOnIdle {
+            assertEquals(1f, controller.player.volume, 0f)
+        }
     }
 
     @Test
@@ -240,13 +248,17 @@ class BpkVideoPlayerTest {
         composeTestRule.runOnIdle { controller.setMuted(false) }
 
         // Then
-        assertEquals(1f, controller.player.volume, 0f)
+        composeTestRule.runOnIdle {
+            assertEquals(1f, controller.player.volume, 0f)
+        }
 
         // When
         composeTestRule.runOnIdle { controller.setMuted(true) }
 
         // Then
-        assertEquals(0f, controller.player.volume, 0f)
+        composeTestRule.runOnIdle {
+            assertEquals(0f, controller.player.volume, 0f)
+        }
     }
 
     @Test
@@ -405,7 +417,9 @@ class BpkVideoPlayerTest {
         composeTestRule.waitForIdle()
 
         // Then
-        assertEquals(Player.STATE_IDLE, controller.player.playbackState)
+        composeTestRule.runOnIdle {
+            assertEquals(Player.STATE_IDLE, controller.player.playbackState)
+        }
     }
 
     @Test

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerController.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerController.kt
@@ -151,9 +151,13 @@ class BpkVideoPlayerController internal constructor(
         progressJob?.cancel()
         progressJob = scope.launch {
             while (true) {
-                val pos = exoPlayer.currentPosition
-                val dur = exoPlayer.duration
-                progressState.value = if (dur > 0L) BpkVideoPlayerProgress(pos, dur) else null
+                val positionMs = exoPlayer.currentPosition
+                val durationMs = exoPlayer.duration
+                progressState.value = if (durationMs > 0L) {
+                    BpkVideoPlayerProgress(positionMs, durationMs)
+                } else {
+                    null
+                }
                 delay(PROGRESS_POLL_INTERVAL_MS.milliseconds)
             }
         }
@@ -165,8 +169,10 @@ class BpkVideoPlayerController internal constructor(
     }
 
     private fun emitFinalProgress() {
-        val dur = exoPlayer.duration
-        if (dur > 0L) progressState.value = BpkVideoPlayerProgress(dur, dur)
+        val durationMs = exoPlayer.duration
+        if (durationMs > 0L) {
+            progressState.value = BpkVideoPlayerProgress(durationMs, durationMs)
+        }
     }
 
     companion object {

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerController.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerController.kt
@@ -29,7 +29,6 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalContext
 import androidx.media3.common.ForwardingPlayer
 import androidx.media3.common.MediaItem
@@ -43,7 +42,6 @@ import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import net.skyscanner.backpack.compose.videoplayer.internal.PlaybackEvent
 import net.skyscanner.backpack.compose.videoplayer.internal.isReducedMotionEnabled
@@ -58,14 +56,16 @@ class BpkVideoPlayerController internal constructor(
     context: Context,
     reducedMotionEnabled: Boolean,
 ) {
-    private val _playbackState = mutableStateOf<BpkVideoPlaybackState>(BpkVideoPlaybackState.Loading)
-    val playbackState: State<BpkVideoPlaybackState> get() = _playbackState
+    val playbackState: State<BpkVideoPlaybackState>
+        field = mutableStateOf<BpkVideoPlaybackState>(BpkVideoPlaybackState.Loading)
 
-    private val _isMuted = mutableStateOf(config.startsMuted)
-    val isMuted: State<Boolean> get() = _isMuted
+    val isMuted: State<Boolean>
+        field = mutableStateOf(config.startsMuted)
 
-    private val _progressState = mutableStateOf<BpkVideoPlayerProgress?>(null)
-    val progressState: State<BpkVideoPlayerProgress?> get() = _progressState
+    val progressState: State<BpkVideoPlayerProgress?>
+        field = mutableStateOf<BpkVideoPlayerProgress?>(null)
+
+    private var progressJob: Job? = null
 
     private val exoPlayer: ExoPlayer = run {
         val applicationContext = context.applicationContext
@@ -102,33 +102,11 @@ class BpkVideoPlayerController internal constructor(
         player.setMediaItem(MediaItem.fromUri(config.videoUrl.value))
         player.prepare()
         startLoadTimeout()
-
-        scope.launch {
-            snapshotFlow { _playbackState.value }
-                .collect { state ->
-                    if (state is BpkVideoPlaybackState.Playing) {
-                        while (isActive && _playbackState.value is BpkVideoPlaybackState.Playing) {
-                            val pos = exoPlayer.currentPosition
-                            val dur = exoPlayer.duration
-                            _progressState.value = if (dur > 0L) BpkVideoPlayerProgress(pos, dur) else null
-                            delay(PROGRESS_POLL_INTERVAL_MS.milliseconds)
-                        }
-                    } else {
-                        if (state !is BpkVideoPlaybackState.Ended) {
-                            _progressState.value = null
-                        }
-                    }
-                }
-        }
-    }
-
-    private companion object {
-        const val PROGRESS_POLL_INTERVAL_MS = 200L
     }
 
     fun play() {
-        if (_playbackState.value is BpkVideoPlaybackState.Failed) return
-        if (_playbackState.value is BpkVideoPlaybackState.Ended) player.seekTo(0)
+        if (playbackState.value is BpkVideoPlaybackState.Failed) return
+        if (playbackState.value is BpkVideoPlaybackState.Ended) player.seekTo(0)
         player.play()
     }
 
@@ -137,40 +115,66 @@ class BpkVideoPlayerController internal constructor(
     }
 
     fun toggle() {
-        if (_playbackState.value.isPlaying) pause() else play()
+        if (playbackState.value.isPlaying) pause() else play()
     }
 
     fun setMuted(muted: Boolean) {
-        _isMuted.value = muted
+        isMuted.value = muted
         player.volume = if (muted) 0f else 1f
     }
 
     fun resetToStart() {
         player.seekTo(0)
-        if (_playbackState.value is BpkVideoPlaybackState.Ended) {
-            _playbackState.value = BpkVideoPlaybackState.ReadyToPlay
+        if (playbackState.value is BpkVideoPlaybackState.Ended) {
+            playbackState.value = BpkVideoPlaybackState.ReadyToPlay
         }
     }
 
     fun dispose() {
         timeoutJob?.cancel()
+        progressJob?.cancel()
         player.release()
-        _progressState.value = null
     }
 
     private fun startLoadTimeout() {
         timeoutJob?.cancel()
         timeoutJob = scope.launch {
-            delay(config.loadTimeoutMs)
-            if (_playbackState.value == BpkVideoPlaybackState.Loading) {
-                _playbackState.value = BpkVideoPlaybackState.Failed(BpkVideoPlayerError.LoadTimeout)
+            delay(config.loadTimeoutMs.milliseconds)
+            if (playbackState.value == BpkVideoPlaybackState.Loading) {
+                playbackState.value = BpkVideoPlaybackState.Failed(BpkVideoPlayerError.LoadTimeout)
                 player.stop()
             }
         }
     }
 
+    private fun startProgressPolling() {
+        progressJob?.cancel()
+        progressJob = scope.launch {
+            while (true) {
+                val pos = exoPlayer.currentPosition
+                val dur = exoPlayer.duration
+                progressState.value = if (dur > 0L) BpkVideoPlayerProgress(pos, dur) else null
+                delay(PROGRESS_POLL_INTERVAL_MS.milliseconds)
+            }
+        }
+    }
+
+    private fun stopProgressPolling() {
+        progressJob?.cancel()
+        progressJob = null
+    }
+
+    private fun emitFinalProgress() {
+        val dur = exoPlayer.duration
+        if (dur > 0L) progressState.value = BpkVideoPlayerProgress(dur, dur)
+    }
+
+    companion object {
+        private const val PROGRESS_POLL_INTERVAL_MS = 200L
+    }
+
     private fun apply(event: PlaybackEvent) {
-        _playbackState.value = reducePlaybackState(_playbackState.value, event)
+        playbackState.value = reducePlaybackState(playbackState.value, event)
     }
 
     private fun playerListener() = object : Player.Listener {
@@ -181,18 +185,38 @@ class BpkVideoPlayerController internal constructor(
                     apply(PlaybackEvent.Ready(isPlaying = player.isPlaying))
                 }
                 Player.STATE_BUFFERING -> apply(PlaybackEvent.Buffering)
-                Player.STATE_ENDED -> apply(PlaybackEvent.Ended)
+                Player.STATE_ENDED -> {
+                    emitFinalProgress()
+                    stopProgressPolling()
+                    apply(PlaybackEvent.Ended)
+                }
                 Player.STATE_IDLE -> Unit
             }
         }
 
         override fun onIsPlayingChanged(isPlaying: Boolean) {
+            if (isPlaying) {
+                startProgressPolling()
+            } else {
+                stopProgressPolling()
+            }
             apply(PlaybackEvent.IsPlayingChanged(isPlaying))
         }
 
         override fun onPlayerError(error: PlaybackException) {
             timeoutJob?.cancel()
+            stopProgressPolling()
             apply(PlaybackEvent.Error(error))
+        }
+
+        override fun onPositionDiscontinuity(
+            oldPosition: Player.PositionInfo,
+            newPosition: Player.PositionInfo,
+            reason: Int,
+        ) {
+            if (reason == Player.DISCONTINUITY_REASON_AUTO_TRANSITION) {
+                emitFinalProgress()
+            }
         }
     }
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerController.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerController.kt
@@ -42,6 +42,7 @@ import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import net.skyscanner.backpack.compose.videoplayer.internal.PlaybackEvent
 import net.skyscanner.backpack.compose.videoplayer.internal.isReducedMotionEnabled
@@ -56,14 +57,14 @@ class BpkVideoPlayerController internal constructor(
     context: Context,
     reducedMotionEnabled: Boolean,
 ) {
-    val playbackState: State<BpkVideoPlaybackState>
-        field = mutableStateOf<BpkVideoPlaybackState>(BpkVideoPlaybackState.Loading)
+    private val _playbackState = mutableStateOf<BpkVideoPlaybackState>(BpkVideoPlaybackState.Loading)
+    val playbackState: State<BpkVideoPlaybackState> get() = _playbackState
 
-    val isMuted: State<Boolean>
-        field = mutableStateOf(config.startsMuted)
+    private val _isMuted = mutableStateOf(config.startsMuted)
+    val isMuted: State<Boolean> get() = _isMuted
 
-    val progressState: State<BpkVideoPlayerProgress?>
-        field = mutableStateOf<BpkVideoPlayerProgress?>(null)
+    private val _progressState = mutableStateOf<BpkVideoPlayerProgress?>(null)
+    val progressState: State<BpkVideoPlayerProgress?> get() = _progressState
 
     private var progressJob: Job? = null
 
@@ -105,8 +106,8 @@ class BpkVideoPlayerController internal constructor(
     }
 
     fun play() {
-        if (playbackState.value is BpkVideoPlaybackState.Failed) return
-        if (playbackState.value is BpkVideoPlaybackState.Ended) player.seekTo(0)
+        if (_playbackState.value is BpkVideoPlaybackState.Failed) return
+        if (_playbackState.value is BpkVideoPlaybackState.Ended) player.seekTo(0)
         player.play()
     }
 
@@ -115,18 +116,18 @@ class BpkVideoPlayerController internal constructor(
     }
 
     fun toggle() {
-        if (playbackState.value.isPlaying) pause() else play()
+        if (_playbackState.value.isPlaying) pause() else play()
     }
 
     fun setMuted(muted: Boolean) {
-        isMuted.value = muted
+        _isMuted.value = muted
         player.volume = if (muted) 0f else 1f
     }
 
     fun resetToStart() {
         player.seekTo(0)
-        if (playbackState.value is BpkVideoPlaybackState.Ended) {
-            playbackState.value = BpkVideoPlaybackState.ReadyToPlay
+        if (_playbackState.value is BpkVideoPlaybackState.Ended) {
+            _playbackState.value = BpkVideoPlaybackState.ReadyToPlay
         }
     }
 
@@ -140,8 +141,8 @@ class BpkVideoPlayerController internal constructor(
         timeoutJob?.cancel()
         timeoutJob = scope.launch {
             delay(config.loadTimeoutMs.milliseconds)
-            if (playbackState.value == BpkVideoPlaybackState.Loading) {
-                playbackState.value = BpkVideoPlaybackState.Failed(BpkVideoPlayerError.LoadTimeout)
+            if (_playbackState.value == BpkVideoPlaybackState.Loading) {
+                _playbackState.value = BpkVideoPlaybackState.Failed(BpkVideoPlayerError.LoadTimeout)
                 player.stop()
             }
         }
@@ -150,10 +151,10 @@ class BpkVideoPlayerController internal constructor(
     private fun startProgressPolling() {
         progressJob?.cancel()
         progressJob = scope.launch {
-            while (true) {
+            while (isActive) {
                 val positionMs = exoPlayer.currentPosition
                 val durationMs = exoPlayer.duration
-                progressState.value = if (durationMs > 0L) {
+                _progressState.value = if (durationMs > 0L) {
                     BpkVideoPlayerProgress(positionMs, durationMs)
                 } else {
                     null
@@ -171,7 +172,7 @@ class BpkVideoPlayerController internal constructor(
     private fun emitFinalProgress() {
         val durationMs = exoPlayer.duration
         if (durationMs > 0L) {
-            progressState.value = BpkVideoPlayerProgress(durationMs, durationMs)
+            _progressState.value = BpkVideoPlayerProgress(durationMs, durationMs)
         }
     }
 
@@ -180,7 +181,7 @@ class BpkVideoPlayerController internal constructor(
     }
 
     private fun apply(event: PlaybackEvent) {
-        playbackState.value = reducePlaybackState(playbackState.value, event)
+        _playbackState.value = reducePlaybackState(_playbackState.value, event)
     }
 
     private fun playerListener() = object : Player.Listener {

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerController.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerController.kt
@@ -107,7 +107,10 @@ class BpkVideoPlayerController internal constructor(
 
     fun play() {
         if (_playbackState.value is BpkVideoPlaybackState.Failed) return
-        if (_playbackState.value is BpkVideoPlaybackState.Ended) player.seekTo(0)
+        if (_playbackState.value is BpkVideoPlaybackState.Ended) {
+            _progressState.value = exoPlayer.duration.takeIf { it > 0L }?.let { BpkVideoPlayerProgress(0L, it) }
+            player.seekTo(0)
+        }
         player.play()
     }
 
@@ -125,6 +128,7 @@ class BpkVideoPlayerController internal constructor(
     }
 
     fun resetToStart() {
+        _progressState.value = exoPlayer.duration.takeIf { it > 0L }?.let { BpkVideoPlayerProgress(0L, it) }
         player.seekTo(0)
         if (_playbackState.value is BpkVideoPlaybackState.Ended) {
             _playbackState.value = BpkVideoPlaybackState.ReadyToPlay

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerController.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerController.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.platform.LocalContext
 import androidx.media3.common.ForwardingPlayer
 import androidx.media3.common.MediaItem
@@ -42,10 +43,12 @@ import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import net.skyscanner.backpack.compose.videoplayer.internal.PlaybackEvent
 import net.skyscanner.backpack.compose.videoplayer.internal.isReducedMotionEnabled
 import net.skyscanner.backpack.compose.videoplayer.internal.reducePlaybackState
+import kotlin.time.Duration.Companion.milliseconds
 
 @Stable
 @OptIn(UnstableApi::class)
@@ -60,6 +63,9 @@ class BpkVideoPlayerController internal constructor(
 
     private val _isMuted = mutableStateOf(config.startsMuted)
     val isMuted: State<Boolean> get() = _isMuted
+
+    private val _progressState = mutableStateOf<BpkVideoPlayerProgress?>(null)
+    val progressState: State<BpkVideoPlayerProgress?> get() = _progressState
 
     private val exoPlayer: ExoPlayer = run {
         val applicationContext = context.applicationContext
@@ -96,6 +102,28 @@ class BpkVideoPlayerController internal constructor(
         player.setMediaItem(MediaItem.fromUri(config.videoUrl.value))
         player.prepare()
         startLoadTimeout()
+
+        scope.launch {
+            snapshotFlow { _playbackState.value }
+                .collect { state ->
+                    if (state is BpkVideoPlaybackState.Playing) {
+                        while (isActive && _playbackState.value is BpkVideoPlaybackState.Playing) {
+                            val pos = exoPlayer.currentPosition
+                            val dur = exoPlayer.duration
+                            _progressState.value = if (dur > 0L) BpkVideoPlayerProgress(pos, dur) else null
+                            delay(PROGRESS_POLL_INTERVAL_MS.milliseconds)
+                        }
+                    } else {
+                        if (state !is BpkVideoPlaybackState.Ended) {
+                            _progressState.value = null
+                        }
+                    }
+                }
+        }
+    }
+
+    private companion object {
+        const val PROGRESS_POLL_INTERVAL_MS = 200L
     }
 
     fun play() {
@@ -127,6 +155,7 @@ class BpkVideoPlayerController internal constructor(
     fun dispose() {
         timeoutJob?.cancel()
         player.release()
+        _progressState.value = null
     }
 
     private fun startLoadTimeout() {

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerProgress.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerProgress.kt
@@ -23,5 +23,5 @@ data class BpkVideoPlayerProgress(
     val durationMs: Long,
 ) {
     val percentage: Float
-        get() = if (durationMs > 0) positionMs.toFloat() / durationMs.toFloat() else 0f
+        get() = if (durationMs > 0) (positionMs.toFloat() / durationMs.toFloat()).coerceIn(0f, 1f) else 0f
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerProgress.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerProgress.kt
@@ -23,5 +23,5 @@ data class BpkVideoPlayerProgress(
     val durationMs: Long,
 ) {
     val percentage: Float
-        get() = if (durationMs > 0) positionMs.toFloat() / durationMs else 0f
+        get() = if (durationMs > 0) positionMs.toFloat() / durationMs.toFloat() else 0f
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerProgress.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerProgress.kt
@@ -1,0 +1,27 @@
+/**
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018 - 2026 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.skyscanner.backpack.compose.videoplayer
+
+data class BpkVideoPlayerProgress(
+    val positionMs: Long,
+    val durationMs: Long,
+) {
+    val percentage: Float
+        get() = if (durationMs > 0) positionMs.toFloat() / durationMs else 0f
+}

--- a/backpack-compose/src/test/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerProgressTest.kt
+++ b/backpack-compose/src/test/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerProgressTest.kt
@@ -1,3 +1,21 @@
+/*
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018 - 2026 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package net.skyscanner.backpack.compose.videoplayer
 
 import org.junit.Assert.assertEquals

--- a/backpack-compose/src/test/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerProgressTest.kt
+++ b/backpack-compose/src/test/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerProgressTest.kt
@@ -46,4 +46,16 @@ class BpkVideoPlayerProgressTest {
         val progress = BpkVideoPlayerProgress(positionMs = 1_000L, durationMs = 0L)
         assertEquals(0f, progress.percentage)
     }
+
+    @Test
+    fun `given positionMs greater than durationMs, then percentage is clamped to 1f`() {
+        val progress = BpkVideoPlayerProgress(positionMs = 1100L, durationMs = 1000L)
+        assertEquals(1f, progress.percentage)
+    }
+
+    @Test
+    fun `given negative positionMs, then percentage is clamped to 0f`() {
+        val progress = BpkVideoPlayerProgress(positionMs = -100L, durationMs = 1000L)
+        assertEquals(0f, progress.percentage)
+    }
 }

--- a/backpack-compose/src/test/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerProgressTest.kt
+++ b/backpack-compose/src/test/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerProgressTest.kt
@@ -1,0 +1,31 @@
+package net.skyscanner.backpack.compose.videoplayer
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class BpkVideoPlayerProgressTest {
+
+    @Test
+    fun `given positionMs equals durationMs, then percentage is 1f`() {
+        val progress = BpkVideoPlayerProgress(positionMs = 5_000L, durationMs = 5_000L)
+        assertEquals(1f, progress.percentage)
+    }
+
+    @Test
+    fun `given positionMs is half of durationMs, then percentage is 0_5f`() {
+        val progress = BpkVideoPlayerProgress(positionMs = 2_500L, durationMs = 5_000L)
+        assertEquals(0.5f, progress.percentage)
+    }
+
+    @Test
+    fun `given zero positionMs, then percentage is 0f`() {
+        val progress = BpkVideoPlayerProgress(positionMs = 0L, durationMs = 5_000L)
+        assertEquals(0f, progress.percentage)
+    }
+
+    @Test
+    fun `given zero durationMs, then percentage is 0f without throwing`() {
+        val progress = BpkVideoPlayerProgress(positionMs = 1_000L, durationMs = 0L)
+        assertEquals(0f, progress.percentage)
+    }
+}

--- a/docs/compose/VideoPlayer/README.md
+++ b/docs/compose/VideoPlayer/README.md
@@ -124,6 +124,44 @@ when (playbackState) {
     else                               -> { /* loading, buffering, etc. */ }
 }
 ```
+### Tracking playback progress
+
+`controller.progressState` exposes the current playback position as a `BpkVideoPlayerProgress?` Compose `State`. It is `null` when the duration is not yet known (e.g. before the asset is ready). Once playback starts it updates roughly every 200 ms, and a guaranteed final value at 100% is emitted at the end of each play-through — including loop boundaries.
+
+```kotlin
+val progress by controller.progressState
+
+progress?.let {
+    println("${it.positionMs} / ${it.durationMs} ms (${(it.percentage * 100).toInt()}%)")
+}
+```
+
+A common pattern is quartile tracking for analytics:
+
+```kotlin
+LaunchedEffect(Unit) {
+    val fired = mutableSetOf<Int>()
+    snapshotFlow { controller.progressState.value }
+        .filterNotNull()
+        .collect { p ->
+            listOf(25, 50, 75, 100).forEach { q ->
+                if (q !in fired && p.percentage >= q / 100f) {
+                    fired.add(q)
+                    trackEvent("video_quartile_$q")
+                }
+            }
+        }
+}
+```
+
+BpkVideoPlayerProgress fields:
+
+
+| Field  | Type | Description |
+| --- | --- | --- |
+| positionMs | Long | Current playback position in milliseconds |
+| durationMs | Long | Total video duration in milliseconds |
+| percentage | Float | positionMs / durationMs, 0f when duration is 0 |
 
 ### State reference
 


### PR DESCRIPTION
[MUON-1999]

## Description

Exposes playback progress from `BpkVideoPlayer` so consumers can track video position and fire analytics events (e.g. quartile tracking at 25%, 50%, 75%, 100%).

### Changes

- **New `BpkVideoPlayerProgress` data class** — holds `positionMs`, `durationMs`, and a derived `percentage: Float`.
- **`BpkVideoPlayerController.progressState: State<BpkVideoPlayerProgress?>`** — new observable property, updated every ~200 ms while the video is playing. Emits `null` when duration is unknown. Guarantees a final value at 100% when the video ends or loops (via `onPositionDiscontinuity(DISCONTINUITY_REASON_AUTO_TRANSITION)` for loop-safe detection).
- **Demo** — the "Default Controls" story in `VideoPlayerStory` now shows live progress percentage and position below the player.
- **Tests** — integration tests in `BpkVideoPlayerTest` covering progress polling, pause/resume state retention, end-of-video 100% guarantee, and loop boundary detection; unit tests in `BpkVideoPlayerProgressTest` for `percentage` calculation edge cases.
- **README** — new "Tracking playback progress" section with quartile tracking example.

### How to test

1. Open the demo app → `Video player` → `Default Controls`
2. Observe the progress text updating in real time below the player

https://github.com/user-attachments/assets/6bda1fd4-78a7-4cbf-8604-13558fbfdfb6

---

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [x] Component `README.md`
+ [x] Tests

[MUON-1999]: https://skyscanner.atlassian.net/browse/MUON-1999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ