### PR TITLE
[DON-3697] Add announceState option to BpkSaveButton and BpkSwitch

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cardbutton/BpkCardButton.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cardbutton/BpkCardButton.kt
@@ -42,6 +42,7 @@ fun BpkSaveButton(
     modifier: Modifier = Modifier,
     size: BpkCardButtonSize = BpkCardButtonSize.Default,
     style: BpkCardButtonStyle = BpkCardButtonStyle.Default,
+    announceState: Boolean = true,
 ) {
     BpkSaveCardButtonImpl(
         checked = checked,
@@ -50,6 +51,7 @@ fun BpkSaveButton(
         size = size,
         onCheckedChange = onCheckedChange,
         modifier = modifier,
+        announceState = announceState,
     )
 }
 

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cardbutton/BpkCardButton.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cardbutton/BpkCardButton.kt
@@ -34,6 +34,11 @@ enum class BpkCardButtonSize {
     Small,
 }
 
+/**
+ * @param announceState Whether TalkBack announces the checked state ("On"/"Off") before
+ * [contentDescription]. Set to false when the state is redundant or misleading in context,
+ * e.g. a save button that is always shown checked in a "saved items" list.
+ */
 @Composable
 fun BpkSaveButton(
     checked: Boolean,

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cardbutton/internal/BpkCardButtonImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cardbutton/internal/BpkCardButtonImpl.kt
@@ -122,7 +122,7 @@ internal fun BpkSaveCardButtonImpl(
                     )
                 } else Modifier,
             )
-            .suppressToggleableStateAnnouncement(announceState),
+            .suppressToggleableStateAnnouncement(shouldSuppress = !announceState),
         contentAlignment = Alignment.Center,
     ) {
         Box(modifier = Modifier.scale(scaleAnimation.value)) {

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cardbutton/internal/BpkCardButtonImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cardbutton/internal/BpkCardButtonImpl.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.stateDescription
 import kotlinx.coroutines.delay
 import net.skyscanner.backpack.compose.cardbutton.BpkCardButtonSize
 import net.skyscanner.backpack.compose.cardbutton.BpkCardButtonStyle
@@ -54,6 +53,7 @@ import net.skyscanner.backpack.compose.tokens.HeartOutline
 import net.skyscanner.backpack.compose.tokens.ShareAndroid
 import net.skyscanner.backpack.compose.tokens.internal.BpkCardButtonColors
 import net.skyscanner.backpack.compose.utils.clickableWithRipple
+import net.skyscanner.backpack.compose.utils.suppressToggleableStateAnnouncement
 
 private enum class BpkCardButtonState {
     Rest,
@@ -122,12 +122,7 @@ internal fun BpkSaveCardButtonImpl(
                     )
                 } else Modifier,
             )
-            .then(
-                // toggleable() attaches a ToggleableState which TalkBack auto-announces as "On"/"Off"
-                // before contentDescription; this overrides that generated stateDescription without
-                // touching the semantics tree/traversal order.
-                if (announceState) Modifier else Modifier.semantics { stateDescription = "" },
-            ),
+            .suppressToggleableStateAnnouncement(announceState),
         contentAlignment = Alignment.Center,
     ) {
         Box(modifier = Modifier.scale(scaleAnimation.value)) {

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cardbutton/internal/BpkCardButtonImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/cardbutton/internal/BpkCardButtonImpl.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import kotlinx.coroutines.delay
 import net.skyscanner.backpack.compose.cardbutton.BpkCardButtonSize
 import net.skyscanner.backpack.compose.cardbutton.BpkCardButtonStyle
@@ -67,6 +68,7 @@ internal fun BpkSaveCardButtonImpl(
     size: BpkCardButtonSize,
     style: BpkCardButtonStyle,
     modifier: Modifier = Modifier,
+    announceState: Boolean = true,
 ) {
     var state by remember { mutableStateOf(BpkCardButtonState.Rest) }
     val scaleAnimation = remember { Animatable(1f) }
@@ -119,6 +121,12 @@ internal fun BpkSaveCardButtonImpl(
                         },
                     )
                 } else Modifier,
+            )
+            .then(
+                // toggleable() attaches a ToggleableState which TalkBack auto-announces as "On"/"Off"
+                // before contentDescription; this overrides that generated stateDescription without
+                // touching the semantics tree/traversal order.
+                if (announceState) Modifier else Modifier.semantics { stateDescription = "" },
             ),
         contentAlignment = Alignment.Center,
     ) {

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/switch/BpkSwitch.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/switch/BpkSwitch.kt
@@ -156,7 +156,7 @@ fun BpkSwitch(
                     indication = null,
                     onValueChange = onCheckedChange!!,
                     enabled = enabled,
-                ).suppressToggleableStateAnnouncement(announceState)
+                ).suppressToggleableStateAnnouncement(shouldSuppress = !announceState)
             }
             .applyIf(onCheckedChange == null) {
                 semantics(mergeDescendants = true) {

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/switch/BpkSwitch.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/switch/BpkSwitch.kt
@@ -46,12 +46,17 @@ import net.skyscanner.backpack.compose.text.BpkText
 import net.skyscanner.backpack.compose.tokens.BpkSpacing
 import net.skyscanner.backpack.compose.utils.BpkToggleableContent
 import net.skyscanner.backpack.compose.utils.applyIf
+import net.skyscanner.backpack.compose.utils.suppressToggleableStateAnnouncement
 
 enum class BpkSwitchStyle {
     Default,
     OnContrast,
 }
 
+/**
+ * @param announceState Whether TalkBack announces the checked state ("On"/"Off") before [text].
+ * Set to false when the state is redundant or misleading in context.
+ */
 @Composable
 fun BpkSwitch(
     text: String,
@@ -85,6 +90,10 @@ fun BpkSwitch(
     )
 }
 
+/**
+ * @param announceState Whether TalkBack announces the checked state ("On"/"Off") before [text].
+ * Set to false when the state is redundant or misleading in context.
+ */
 @Composable
 fun BpkSwitch(
     text: AnnotatedString,
@@ -118,6 +127,10 @@ fun BpkSwitch(
     )
 }
 
+/**
+ * @param announceState Whether TalkBack announces the checked state ("On"/"Off") before
+ * [content]. Set to false when the state is redundant or misleading in context.
+ */
 @Composable
 fun BpkSwitch(
     checked: Boolean,
@@ -143,7 +156,7 @@ fun BpkSwitch(
                     indication = null,
                     onValueChange = onCheckedChange!!,
                     enabled = enabled,
-                )
+                ).suppressToggleableStateAnnouncement(announceState)
             }
             .applyIf(onCheckedChange == null) {
                 semantics(mergeDescendants = true) {
@@ -152,13 +165,10 @@ fun BpkSwitch(
                     if (!enabled) {
                         disabled()
                     }
+                    if (!announceState) {
+                        stateDescription = ""
+                    }
                 }
-            }
-            // toggleable()/the semantics block above attach a ToggleableState which TalkBack
-            // auto-announces as "On"/"Off" before the switch's label; this overrides that
-            // generated stateDescription without touching the semantics tree/traversal order.
-            .applyIf(!announceState) {
-                semantics { stateDescription = "" }
             },
     ) {
 

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/switch/BpkSwitch.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/switch/BpkSwitch.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.disabled
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.semantics.toggleableState
 import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.text.AnnotatedString
@@ -63,6 +64,7 @@ fun BpkSwitch(
     switchAlignment: Alignment.Vertical = Alignment.CenterVertically,
     textStyle: TextStyle? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    announceState: Boolean = true,
 ) {
     BpkSwitch(
         checked = checked,
@@ -73,6 +75,7 @@ fun BpkSwitch(
         switchAlignment = switchAlignment,
         textStyle = textStyle,
         interactionSource = interactionSource,
+        announceState = announceState,
         content = {
             TextWithSpacer(
                 annotatedString = buildAnnotatedString { append(text) },
@@ -94,6 +97,7 @@ fun BpkSwitch(
     switchAlignment: Alignment.Vertical = Alignment.CenterVertically,
     textStyle: TextStyle? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    announceState: Boolean = true,
 ) {
     BpkSwitch(
         checked = checked,
@@ -104,6 +108,7 @@ fun BpkSwitch(
         switchAlignment = switchAlignment,
         textStyle = textStyle,
         interactionSource = interactionSource,
+        announceState = announceState,
         content = {
             TextWithSpacer(
                 annotatedString = text,
@@ -123,6 +128,7 @@ fun BpkSwitch(
     switchAlignment: Alignment.Vertical = Alignment.CenterVertically,
     textStyle: TextStyle? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
+    announceState: Boolean = true,
     content: @Composable RowScope.(Boolean) -> Unit,
 ) {
     Row(
@@ -147,6 +153,12 @@ fun BpkSwitch(
                         disabled()
                     }
                 }
+            }
+            // toggleable()/the semantics block above attach a ToggleableState which TalkBack
+            // auto-announces as "On"/"Off" before the switch's label; this overrides that
+            // generated stateDescription without touching the semantics tree/traversal order.
+            .applyIf(!announceState) {
+                semantics { stateDescription = "" }
             },
     ) {
 

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/utils/Modifier.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/utils/Modifier.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.layout.layout
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.invisibleToUser
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.Constraints
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntRect
@@ -101,3 +102,15 @@ internal fun Modifier.alignBy(anchor: Offset, alignment: Alignment): Modifier = 
 @OptIn(ExperimentalComposeUiApi::class)
 fun Modifier.invisibleSemantic(): Modifier =
     semantics { invisibleToUser() }
+
+/**
+ * Toggleable components (e.g. via [androidx.compose.foundation.selection.toggleable] with
+ * `Role.Switch`/`Role.Checkbox`) get a platform-generated "On"/"Off" state description that
+ * TalkBack announces before the node's own label. Passing [announceState] = false overrides
+ * that generated text on this node without touching the rest of its semantics, so traversal
+ * order and grouping are unaffected.
+ */
+internal fun Modifier.suppressToggleableStateAnnouncement(announceState: Boolean): Modifier =
+    applyIf(!announceState) {
+        semantics { stateDescription = "" }
+    }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/utils/Modifier.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/utils/Modifier.kt
@@ -106,11 +106,11 @@ fun Modifier.invisibleSemantic(): Modifier =
 /**
  * Toggleable components (e.g. via [androidx.compose.foundation.selection.toggleable] with
  * `Role.Switch`/`Role.Checkbox`) get a platform-generated "On"/"Off" state description that
- * TalkBack announces before the node's own label. Passing [announceState] = false overrides
+ * TalkBack announces before the node's own label. Passing [shouldSuppress] = true overrides
  * that generated text on this node without touching the rest of its semantics, so traversal
  * order and grouping are unaffected.
  */
-internal fun Modifier.suppressToggleableStateAnnouncement(announceState: Boolean): Modifier =
-    applyIf(!announceState) {
+internal fun Modifier.suppressToggleableStateAnnouncement(shouldSuppress: Boolean): Modifier =
+    applyIf(shouldSuppress) {
         semantics { stateDescription = "" }
     }

--- a/docs/compose/CardButton/README.md
+++ b/docs/compose/CardButton/README.md
@@ -35,6 +35,10 @@ BpkSaveButton(
 )
 ```
 
+## Accessibility
+
+`BpkSaveButton` announces its checked state ("On"/"Off") to TalkBack before `contentDescription`. If the checked state is always the same in a given screen (e.g. every item in a "saved items" list), that announcement is redundant and can be confusing. Pass `announceState = false` to suppress it.
+
 Example of a Share Button on an image:
 
 ```Kotlin

--- a/docs/compose/Switch/README.md
+++ b/docs/compose/Switch/README.md
@@ -78,3 +78,7 @@ BpkSwitch(
   MyCustomContent()
 }
 ```
+
+## Accessibility
+
+`BpkSwitch` announces its checked state ("On"/"Off") to TalkBack before its label. If the checked state is always the same in a given context, that announcement is redundant and can be confusing. Pass `announceState = false` to suppress it.


### PR DESCRIPTION
_Relates to [DON-3697](https://skyscanner.atlassian.net/browse/DON-3697)_

## What changes were made

Added an `announceState: Boolean = true` parameter to `BpkSaveButton` (`backpack-compose/.../cardbutton/BpkCardButton.kt` + `internal/BpkCardButtonImpl.kt`) and to all three `BpkSwitch` overloads (`backpack-compose/.../switch/BpkSwitch.kt`). When set to `false`, an extra `Modifier.semantics { stateDescription = "" }` is appended after the existing `toggleable(...)`/`semantics(mergeDescendants = true)` block that sets `Role.Switch` + `ToggleableState`, overriding the platform-generated state text on that same semantics node. Everything else — `contentDescription`, `Role.Switch`, merge/traversal grouping — is untouched. Default is `true`, so behaviour for all existing call sites is unchanged.

## Why these changes were made

Both components rely on `Modifier.toggleable(..., role = Role.Switch, ...)`. Android's accessibility layer auto-derives a state description ("On."/"Off.") from the `ToggleableState` + `Role.Switch` combination and TalkBack reads it *before* the `contentDescription`. In screens like Saved Hub, `BpkSaveButton`'s checked state is always `true`, so TalkBack reads a redundant, confusing "On." before the actual label (e.g. "On. Remove Barcelona to Corfu…"). `clearAndSetSemantics` isn't usable here since it collapses the semantics subtree and breaks the existing traversal group order. Overriding just `stateDescription` on the same node fixes the announcement without touching the tree structure. Filing the same option on `BpkSwitch` proactively, since other in-flight a11y tickets are hitting the identical "On"/"Off" announcement issue there.

## Additional Notes

- No component `README.md` changes — neither `CardButton/README.md` nor `Switch/README.md` currently document individual optional parameters (e.g. `size`, `style`, `textStyle` aren't listed either), so `announceState` follows the same existing pattern. Happy to add explicit docs if reviewers would prefer that changed.
- No new automated tests: there's no existing Espresso/Compose UI accessibility test for either component (only Roborazzi screenshot tests, which are visual and unaffected since this is a semantics-only, opt-in change). Verified via `./gradlew :backpack-compose:compileDebugKotlin` and manual TalkBack testing with `announceState = false` confirming the "On"/"Off" announcement is suppressed while the traversal order and content description remain intact.
- No UI/visual changes — screenshots not applicable.


[DON-3697]: https://skyscanner.atlassian.net/browse/DON-3697?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ