### PR TITLE
[MUON-2062] Add size param to BpkVideoPlayerDefaultControls

### DIFF
--- a/app/src/main/java/net/skyscanner/backpack/demo/compose/VideoPlayerStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/compose/VideoPlayerStory.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import net.skyscanner.backpack.compose.button.BpkButtonSize
 import net.skyscanner.backpack.compose.icon.BpkIcon
 import net.skyscanner.backpack.compose.theme.BpkTheme
 import net.skyscanner.backpack.compose.icon.BpkIconSize
@@ -101,6 +102,40 @@ fun VideoPlayerDefaultControlsStory(modifier: Modifier = Modifier) {
             textAlign = TextAlign.Center,
             color = BpkTheme.colors.textPrimary,
             style = BpkTheme.typography.heading5,
+        )
+    }
+}
+
+// Use case 1b: same as above but with a Large size control button
+@Composable
+@VideoPlayerComponent
+@ComposeStory(name = "Default Controls - Large Button", kind = StoryKind.DemoOnly)
+fun VideoPlayerLargeControlsStory(modifier: Modifier = Modifier) {
+    val controller = rememberBpkVideoPlayerController(
+        config = BpkVideoPlayerConfig(
+            videoUrl = BpkVideoUrl(VIDEO_URL),
+            loop = false,
+            startsMuted = true,
+            accessibilityLabel = "Sample video",
+        ),
+    )
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(BpkSpacing.Base)
+            .aspectRatio(9f / 16f),
+    ) {
+        BpkVideoPlayer(
+            controller = controller,
+            scaleToFill = false,
+            modifier = Modifier.matchParentSize(),
+        )
+        BpkVideoPlayerDefaultControls(
+            controller = controller,
+            playContentDescription = "Play video",
+            pauseContentDescription = "Pause video",
+            size = BpkButtonSize.Large,
+            modifier = Modifier.align(Alignment.TopEnd),
         )
     }
 }

--- a/app/src/main/java/net/skyscanner/backpack/demo/compose/VideoPlayerStory.kt
+++ b/app/src/main/java/net/skyscanner/backpack/demo/compose/VideoPlayerStory.kt
@@ -134,8 +134,8 @@ fun VideoPlayerLargeControlsStory(modifier: Modifier = Modifier) {
             controller = controller,
             playContentDescription = "Play video",
             pauseContentDescription = "Pause video",
-            size = BpkButtonSize.Large,
             modifier = Modifier.align(Alignment.TopEnd),
+            size = BpkButtonSize.Large,
         )
     }
 }

--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerDefaultControlsTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerDefaultControlsTest.kt
@@ -238,6 +238,33 @@ class BpkVideoPlayerDefaultControlsTest {
     }
 
     @Test
+    fun givenNoSizeSpecified_whenPlaybackStateChangesToPlaying_thenPauseButtonKeepsDefaultSize() {
+        // Given
+        videoPlayerTestRule.disableReducedMotionSignal()
+        lateinit var controller: BpkVideoPlayerController
+
+        // When
+        composeTestRule.setContent {
+            BpkTheme {
+                controller = rememberBpkVideoPlayerController(playableConfig(autoPlay = true))
+                BpkVideoPlayerDefaultControls(
+                    controller = controller,
+                    playContentDescription = PLAY_LABEL,
+                    pauseContentDescription = PAUSE_LABEL,
+                )
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = PLAYING_STATE_TIMEOUT_MS) {
+            controller.playbackState.value is BpkVideoPlaybackState.Playing
+        }
+
+        // Then
+        composeTestRule.onNodeWithContentDescription(PAUSE_LABEL)
+            .assertIsDisplayed()
+            .assertHeightIsEqualTo(DEFAULT_BUTTON_HEIGHT)
+    }
+
+    @Test
     fun givenLargeSize_whenPlaybackStateChangesToPlaying_thenPauseButtonKeepsLargeSize() {
         // Given
         videoPlayerTestRule.disableReducedMotionSignal()

--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerDefaultControlsTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerDefaultControlsTest.kt
@@ -77,6 +77,8 @@ class BpkVideoPlayerDefaultControlsTest {
         // Given
         videoPlayerTestRule.disableReducedMotionSignal()
         lateinit var controller: BpkVideoPlayerController
+
+        // When
         composeTestRule.setContent {
             BpkTheme {
                 controller = rememberBpkVideoPlayerController(playableConfig(autoPlay = false))
@@ -101,6 +103,8 @@ class BpkVideoPlayerDefaultControlsTest {
         // Given
         videoPlayerTestRule.disableReducedMotionSignal()
         lateinit var controller: BpkVideoPlayerController
+
+        // When
         composeTestRule.setContent {
             BpkTheme {
                 controller = rememberBpkVideoPlayerController(playableConfig(autoPlay = true))
@@ -183,6 +187,8 @@ class BpkVideoPlayerDefaultControlsTest {
         // Given
         videoPlayerTestRule.disableReducedMotionSignal()
         lateinit var controller: BpkVideoPlayerController
+
+        // When
         composeTestRule.setContent {
             BpkTheme {
                 controller = rememberBpkVideoPlayerController(playableConfig(autoPlay = false))
@@ -208,6 +214,8 @@ class BpkVideoPlayerDefaultControlsTest {
         // Given
         videoPlayerTestRule.disableReducedMotionSignal()
         lateinit var controller: BpkVideoPlayerController
+
+        // When
         composeTestRule.setContent {
             BpkTheme {
                 controller = rememberBpkVideoPlayerController(playableConfig(autoPlay = false))
@@ -234,6 +242,8 @@ class BpkVideoPlayerDefaultControlsTest {
         // Given
         videoPlayerTestRule.disableReducedMotionSignal()
         lateinit var controller: BpkVideoPlayerController
+
+        // When
         composeTestRule.setContent {
             BpkTheme {
                 controller = rememberBpkVideoPlayerController(playableConfig(autoPlay = true))

--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerDefaultControlsTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerDefaultControlsTest.kt
@@ -18,10 +18,13 @@
 
 package net.skyscanner.backpack.compose.videoplayer
 
+import androidx.compose.ui.test.assertHeightIsEqualTo
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.unit.dp
+import net.skyscanner.backpack.compose.button.BpkButtonSize
 import net.skyscanner.backpack.compose.theme.BpkTheme
 import net.skyscanner.backpack.compose.videoplayer.VideoPlayerTestRule.Companion.PLAYING_STATE_TIMEOUT_MS
 import net.skyscanner.backpack.compose.videoplayer.VideoPlayerTestRule.Companion.READY_STATE_TIMEOUT_MS
@@ -175,8 +178,87 @@ class BpkVideoPlayerDefaultControlsTest {
         assertTrue(controller.playbackState.value is BpkVideoPlaybackState.Paused)
     }
 
+    @Test
+    fun givenNoSizeSpecified_whenControlsRendered_thenDefaultButtonSizeIsApplied() {
+        // Given
+        videoPlayerTestRule.disableReducedMotionSignal()
+        lateinit var controller: BpkVideoPlayerController
+        composeTestRule.setContent {
+            BpkTheme {
+                controller = rememberBpkVideoPlayerController(playableConfig(autoPlay = false))
+                BpkVideoPlayerDefaultControls(
+                    controller = controller,
+                    playContentDescription = PLAY_LABEL,
+                    pauseContentDescription = PAUSE_LABEL,
+                )
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = READY_STATE_TIMEOUT_MS) {
+            controller.playbackState.value is BpkVideoPlaybackState.ReadyToPlay
+        }
+
+        // Then
+        composeTestRule.onNodeWithContentDescription(PLAY_LABEL)
+            .assertIsDisplayed()
+            .assertHeightIsEqualTo(DEFAULT_BUTTON_HEIGHT)
+    }
+
+    @Test
+    fun givenLargeSize_whenControlsRendered_thenLargeButtonSizeIsApplied() {
+        // Given
+        videoPlayerTestRule.disableReducedMotionSignal()
+        lateinit var controller: BpkVideoPlayerController
+        composeTestRule.setContent {
+            BpkTheme {
+                controller = rememberBpkVideoPlayerController(playableConfig(autoPlay = false))
+                BpkVideoPlayerDefaultControls(
+                    controller = controller,
+                    playContentDescription = PLAY_LABEL,
+                    pauseContentDescription = PAUSE_LABEL,
+                    size = BpkButtonSize.Large,
+                )
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = READY_STATE_TIMEOUT_MS) {
+            controller.playbackState.value is BpkVideoPlaybackState.ReadyToPlay
+        }
+
+        // Then
+        composeTestRule.onNodeWithContentDescription(PLAY_LABEL)
+            .assertIsDisplayed()
+            .assertHeightIsEqualTo(LARGE_BUTTON_HEIGHT)
+    }
+
+    @Test
+    fun givenLargeSize_whenPlaybackStateChangesToPlaying_thenPauseButtonKeepsLargeSize() {
+        // Given
+        videoPlayerTestRule.disableReducedMotionSignal()
+        lateinit var controller: BpkVideoPlayerController
+        composeTestRule.setContent {
+            BpkTheme {
+                controller = rememberBpkVideoPlayerController(playableConfig(autoPlay = true))
+                BpkVideoPlayerDefaultControls(
+                    controller = controller,
+                    playContentDescription = PLAY_LABEL,
+                    pauseContentDescription = PAUSE_LABEL,
+                    size = BpkButtonSize.Large,
+                )
+            }
+        }
+        composeTestRule.waitUntil(timeoutMillis = PLAYING_STATE_TIMEOUT_MS) {
+            controller.playbackState.value is BpkVideoPlaybackState.Playing
+        }
+
+        // Then
+        composeTestRule.onNodeWithContentDescription(PAUSE_LABEL)
+            .assertIsDisplayed()
+            .assertHeightIsEqualTo(LARGE_BUTTON_HEIGHT)
+    }
+
     private companion object {
         const val PLAY_LABEL = "Play"
         const val PAUSE_LABEL = "Pause"
+        val DEFAULT_BUTTON_HEIGHT = 36.dp
+        val LARGE_BUTTON_HEIGHT = 48.dp
     }
 }

--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerDefaultControlsTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerDefaultControlsTest.kt
@@ -23,8 +23,8 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.performClick
-import androidx.compose.ui.unit.dp
 import net.skyscanner.backpack.compose.button.BpkButtonSize
+import net.skyscanner.backpack.compose.button.internal.minHeight
 import net.skyscanner.backpack.compose.theme.BpkTheme
 import net.skyscanner.backpack.compose.videoplayer.VideoPlayerTestRule.Companion.PLAYING_STATE_TIMEOUT_MS
 import net.skyscanner.backpack.compose.videoplayer.VideoPlayerTestRule.Companion.READY_STATE_TIMEOUT_MS
@@ -206,7 +206,7 @@ class BpkVideoPlayerDefaultControlsTest {
         // Then
         composeTestRule.onNodeWithContentDescription(PLAY_LABEL)
             .assertIsDisplayed()
-            .assertHeightIsEqualTo(DEFAULT_BUTTON_HEIGHT)
+            .assertHeightIsEqualTo(BpkButtonSize.Default.minHeight)
     }
 
     @Test
@@ -234,7 +234,7 @@ class BpkVideoPlayerDefaultControlsTest {
         // Then
         composeTestRule.onNodeWithContentDescription(PLAY_LABEL)
             .assertIsDisplayed()
-            .assertHeightIsEqualTo(LARGE_BUTTON_HEIGHT)
+            .assertHeightIsEqualTo(BpkButtonSize.Large.minHeight)
     }
 
     @Test
@@ -261,7 +261,7 @@ class BpkVideoPlayerDefaultControlsTest {
         // Then
         composeTestRule.onNodeWithContentDescription(PAUSE_LABEL)
             .assertIsDisplayed()
-            .assertHeightIsEqualTo(DEFAULT_BUTTON_HEIGHT)
+            .assertHeightIsEqualTo(BpkButtonSize.Default.minHeight)
     }
 
     @Test
@@ -289,13 +289,11 @@ class BpkVideoPlayerDefaultControlsTest {
         // Then
         composeTestRule.onNodeWithContentDescription(PAUSE_LABEL)
             .assertIsDisplayed()
-            .assertHeightIsEqualTo(LARGE_BUTTON_HEIGHT)
+            .assertHeightIsEqualTo(BpkButtonSize.Large.minHeight)
     }
 
     private companion object {
         const val PLAY_LABEL = "Play"
         const val PAUSE_LABEL = "Pause"
-        val DEFAULT_BUTTON_HEIGHT = 36.dp
-        val LARGE_BUTTON_HEIGHT = 48.dp
     }
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerDefaultControls.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerDefaultControls.kt
@@ -42,8 +42,8 @@ fun BpkVideoPlayerDefaultControls(
     controller: BpkVideoPlayerController,
     playContentDescription: String,
     pauseContentDescription: String,
-    size: BpkButtonSize = BpkButtonSize.Default,
     modifier: Modifier = Modifier,
+    size: BpkButtonSize = BpkButtonSize.Default,
 ) {
     val playbackState by controller.playbackState
     if (playbackState.isLoading) return

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerDefaultControls.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/videoplayer/BpkVideoPlayerDefaultControls.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import net.skyscanner.backpack.compose.button.BpkButton
+import net.skyscanner.backpack.compose.button.BpkButtonSize
 import net.skyscanner.backpack.compose.button.BpkButtonType
 import net.skyscanner.backpack.compose.icon.BpkIcon
 import net.skyscanner.backpack.compose.tokens.Pause
@@ -41,6 +42,7 @@ fun BpkVideoPlayerDefaultControls(
     controller: BpkVideoPlayerController,
     playContentDescription: String,
     pauseContentDescription: String,
+    size: BpkButtonSize = BpkButtonSize.Default,
     modifier: Modifier = Modifier,
 ) {
     val playbackState by controller.playbackState
@@ -50,6 +52,7 @@ fun BpkVideoPlayerDefaultControls(
         icon = if (playbackState.isPlaying) BpkIcon.Pause else BpkIcon.Play,
         contentDescription = if (playbackState.isPlaying) pauseContentDescription else playContentDescription,
         type = BpkButtonType.SecondaryOnDark,
+        size = size,
         modifier = modifier,
         onClick = { controller.toggle() },
     )

--- a/docs/compose/VideoPlayer/README.md
+++ b/docs/compose/VideoPlayer/README.md
@@ -47,8 +47,8 @@ Box {
         controller = controller,
         playContentDescription = stringResource(R.string.video_play_label),
         pauseContentDescription = stringResource(R.string.video_pause_label),
-        size = BpkButtonSize.Large,
         modifier = Modifier.align(Alignment.TopEnd),
+        size = BpkButtonSize.Large,
     )
 }
 ```

--- a/docs/compose/VideoPlayer/README.md
+++ b/docs/compose/VideoPlayer/README.md
@@ -35,7 +35,7 @@ val controller = rememberBpkVideoPlayerController(
 
 ### Simple — built-in controls
 
-`BpkVideoPlayerDefaultControls` handles play/pause taps internally. Provide localized `playContentDescription` and `pauseContentDescription` — the component owns no user-facing copy.
+`BpkVideoPlayerDefaultControls` handles play/pause taps internally. Provide localized `playContentDescription` and `pauseContentDescription` — the component owns no user-facing copy. Pass `size` (`BpkButtonSize`) to control the button size — it defaults to `BpkButtonSize.Default`.
 
 ```kotlin
 Box {
@@ -47,6 +47,7 @@ Box {
         controller = controller,
         playContentDescription = stringResource(R.string.video_play_label),
         pauseContentDescription = stringResource(R.string.video_pause_label),
+        size = BpkButtonSize.Large,
         modifier = Modifier.align(Alignment.TopEnd),
     )
 }


### PR DESCRIPTION
[MUON-2062](https://skyscanner.atlassian.net/browse/MUON-2062)

## Description

`BpkVideoPlayerDefaultControls` used to hardcode the size of its play/pause button. This PR adds a `size: BpkButtonSize` parameter so consumers can configure the control button size, defaulting to `BpkButtonSize.Default` to preserve existing appearance.

This is needed by `HomepageHeroVideo` in skyscanner-app, which wants the control button rendered at `BpkButtonSize.Large`.

## Changes

- `BpkVideoPlayerDefaultControls`: new `size: BpkButtonSize = BpkButtonSize.Default` param, forwarded to the internal `BpkButton`.
- Added test coverage verifying rendered button height for both `Default` and `Large` sizes, across ready-to-play and playing states.
- Added a new demo story ("Default Controls - Large Button") showcasing `size = BpkButtonSize.Large`.
- Updated component README to document the new parameter.

- [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
- [x] Component `README.md`
- [x] Tests

## Test plan

- [x] `./gradlew :backpack-compose:compileDebugKotlin` — builds
- [x] `./gradlew :app:compileOssDebugKotlin` — builds
- [x] `./gradlew :backpack-compose:connectedDebugAndroidTest` for `BpkVideoPlayerDefaultControlsTest` — 8/8 tests pass on emulator
- [x] Existing usages unaffected — default size unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MUON-2062]: https://skyscanner.atlassian.net/browse/MUON-2062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ