### PR TITLE
[DON-2175] Fix stale bottom sheet content

### DIFF
--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/bottomsheet/BottomSheetContentTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/bottomsheet/BottomSheetContentTest.kt
@@ -1,0 +1,85 @@
+/**
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018 - 2026 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.skyscanner.backpack.compose.bottomsheet
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import net.skyscanner.backpack.compose.text.BpkText
+import net.skyscanner.backpack.compose.theme.BpkTheme
+import org.junit.Rule
+import org.junit.Test
+
+class BottomSheetContentTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun bottomSheet_updatesWhenContentLambdaChanges() {
+        val showFirstContent = mutableStateOf(true)
+
+        composeTestRule.setContent {
+            BpkTheme {
+                BpkBottomSheet(
+                    state = rememberBpkBottomSheetState(BpkBottomSheetValue.Expanded),
+                    sheetContent = if (showFirstContent.value) {
+                        { BpkText(text = "First content") }
+                    } else {
+                        { BpkText(text = "Second content") }
+                    },
+                    content = {},
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("First content").assertExists()
+
+        composeTestRule.runOnIdle { showFirstContent.value = false }
+
+        composeTestRule.onNodeWithText("Second content").assertExists()
+        composeTestRule.onNodeWithText("First content").assertDoesNotExist()
+    }
+
+    @Test
+    fun modalBottomSheetWithHeader_updatesWhenContentLambdaChanges() {
+        val showFirstContent = mutableStateOf(true)
+
+        composeTestRule.setContent {
+            BpkTheme {
+                BpkModalBottomSheet(
+                    onDismissRequest = {},
+                    title = "Title",
+                    content = if (showFirstContent.value) {
+                        { BpkText(text = "First content") }
+                    } else {
+                        { BpkText(text = "Second content") }
+                    },
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText("First content").assertExists()
+
+        composeTestRule.runOnIdle { showFirstContent.value = false }
+
+        composeTestRule.onNodeWithText("Second content").assertExists()
+        composeTestRule.onNodeWithText("First content").assertDoesNotExist()
+    }
+}

--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/bottomsheet/BottomSheetContentTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/bottomsheet/BottomSheetContentTest.kt
@@ -26,6 +26,9 @@ import net.skyscanner.backpack.compose.theme.BpkTheme
 import org.junit.Rule
 import org.junit.Test
 
+private const val FIRST_CONTENT = "First content"
+private const val SECOND_CONTENT = "Second content"
+
 class BottomSheetContentTest {
 
     @get:Rule
@@ -40,21 +43,21 @@ class BottomSheetContentTest {
                 BpkBottomSheet(
                     state = rememberBpkBottomSheetState(BpkBottomSheetValue.Expanded),
                     sheetContent = if (showFirstContent.value) {
-                        { BpkText(text = "First content") }
+                        { BpkText(text = FIRST_CONTENT) }
                     } else {
-                        { BpkText(text = "Second content") }
+                        { BpkText(text = SECOND_CONTENT) }
                     },
                     content = {},
                 )
             }
         }
 
-        composeTestRule.onNodeWithText("First content").assertExists()
+        composeTestRule.onNodeWithText(FIRST_CONTENT).assertExists()
 
         composeTestRule.runOnIdle { showFirstContent.value = false }
 
-        composeTestRule.onNodeWithText("Second content").assertExists()
-        composeTestRule.onNodeWithText("First content").assertDoesNotExist()
+        composeTestRule.onNodeWithText(SECOND_CONTENT).assertExists()
+        composeTestRule.onNodeWithText(FIRST_CONTENT).assertDoesNotExist()
     }
 
     @Test
@@ -67,19 +70,19 @@ class BottomSheetContentTest {
                     onDismissRequest = {},
                     title = "Title",
                     content = if (showFirstContent.value) {
-                        { BpkText(text = "First content") }
+                        { BpkText(text = FIRST_CONTENT) }
                     } else {
-                        { BpkText(text = "Second content") }
+                        { BpkText(text = SECOND_CONTENT) }
                     },
                 )
             }
         }
 
-        composeTestRule.onNodeWithText("First content").assertExists()
+        composeTestRule.onNodeWithText(FIRST_CONTENT).assertExists()
 
         composeTestRule.runOnIdle { showFirstContent.value = false }
 
-        composeTestRule.onNodeWithText("Second content").assertExists()
-        composeTestRule.onNodeWithText("First content").assertDoesNotExist()
+        composeTestRule.onNodeWithText(SECOND_CONTENT).assertExists()
+        composeTestRule.onNodeWithText(FIRST_CONTENT).assertDoesNotExist()
     }
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/bottomsheet/internal/BottomSheetContent.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/bottomsheet/internal/BottomSheetContent.kt
@@ -34,7 +34,7 @@ internal fun BottomSheetContent(
     content: @Composable (ColumnScope.() -> Unit),
 ) {
     Column(modifier) {
-        val contentSlot = remember { movableContentOf { content() } }
+        val contentSlot = remember(content) { movableContentOf { content() } }
         when (dragHandleStyle) {
             BpkDragHandleStyle.Default -> contentSlot()
             is BpkDragHandleStyle.OnImage -> Box {

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/bottomsheet/internal/BpkModalBottomSheetImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/bottomsheet/internal/BpkModalBottomSheetImpl.kt
@@ -117,7 +117,7 @@ private fun ModalBottomSheetContent(
     if (closeButton is BpkModalBottomSheetCloseAction.Close || !title.isNullOrEmpty() || action != null) {
         Box(modifier = modifier) {
             Column {
-                val contentSlot = remember { movableContentOf { content() } }
+                val contentSlot = remember(content) { movableContentOf { content() } }
                 when (dragHandleStyle) {
                     BpkDragHandleStyle.Default -> {
                         BpkModalBottomSheetHeader(


### PR DESCRIPTION
Resolves DON-2175

## Context
`BpkBottomSheet` and `BpkModalBottomSheet` move caller-provided content with Compose `movableContentOf`. The movable content was previously created inside an unkeyed `remember { ... }`, so the first content lambda could remain cached for the lifetime of the composition. If a sheet stayed composed while the caller supplied different content, the sheet could continue displaying stale UI. Passing a wrapper such as `sheetContent = { content() }` could hide the issue by changing the lambda identity, but passing the content lambda directly should also update correctly.

## Change
- Key the remembered movable content with `content` in both the persistent and modal bottom-sheet implementations.
- Compose now recreates the movable content slot when the supplied content lambda changes, while retaining the existing movable-content behaviour when it remains stable.
- No public API changes are required.

## Regression coverage
Added instrumentation tests for both paths:
- persistent bottom sheet content changes from the old value to the new value while the sheet remains open
- modal bottom sheet content changes with a header present

Each test verifies that the new content is rendered and the stale content is no longer present.

## Verification
- Android Studio MCP project build passed
- Android Studio MCP instrumentation tests passed on the connected device
- detekt commit hook passed