### PR TITLE
[MUON-2081] Add tapActionAccessibilityLabel to BpkGraphicPromo

### DIFF
--- a/backpack-compose/build.gradle.kts
+++ b/backpack-compose/build.gradle.kts
@@ -74,6 +74,7 @@ dependencies {
     androidTestImplementation(libs.test.compose)
     androidTestImplementation(libs.test.junitAndroid)
     androidTestImplementation(libs.test.rules)
+    androidTestImplementation(libs.test.espressoCore)
     androidTestImplementation(libs.test.mockitoKotlin)
     androidTestImplementation(libs.test.mockitoAndroid)
     debugImplementation(libs.compose.uiTooling)

--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/graphicpromotion/BpkGraphicPromoTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/graphicpromotion/BpkGraphicPromoTest.kt
@@ -23,8 +23,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
 import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertHasClickAction
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasText
@@ -46,6 +50,7 @@ class BpkGraphicPromoTest {
         subHeadline: String? = null,
         sponsor: BpkGraphicsPromoSponsor? = null,
         sponsorLogo: (@Composable () -> Unit)? = null,
+        tapActionAccessibilityLabel: String? = null,
     ) {
         composeTestRule.setContent {
             BpkTheme {
@@ -55,6 +60,7 @@ class BpkGraphicPromoTest {
                     subHeadline = subHeadline,
                     sponsor = sponsor,
                     sponsorLogo = sponsorLogo,
+                    tapActionAccessibilityLabel = tapActionAccessibilityLabel,
                     background = { Box(Modifier.fillMaxSize()) },
                 )
             }
@@ -158,6 +164,34 @@ class BpkGraphicPromoTest {
 
     // endregion
 
+    // region Tap action accessibility label tests
+
+    @Test
+    fun givenTapActionAccessibilityLabel_whenRendered_thenRootClickActionHasCustomLabel() {
+        // When
+        renderGraphicPromo(tapActionAccessibilityLabel = TAP_ACTION_LABEL)
+
+        // Then
+        composeTestRule.onNode(
+            matcher = hasContentDescription(HEADLINE),
+            useUnmergedTree = false,
+        ).assertOnClickLabelEquals(TAP_ACTION_LABEL)
+    }
+
+    @Test
+    fun givenNoTapActionAccessibilityLabel_whenRendered_thenRootClickActionHasNoLabel() {
+        // When
+        renderGraphicPromo()
+
+        // Then
+        composeTestRule.onNode(
+            matcher = hasContentDescription(HEADLINE),
+            useUnmergedTree = false,
+        ).assertOnClickLabelEquals(null)
+    }
+
+    // endregion
+
     private fun defaultSponsor(
         onCtaClick: () -> Unit = { },
     ) = BpkGraphicsPromoSponsor(
@@ -177,5 +211,12 @@ class BpkGraphicPromoTest {
         const val SPONSOR_TITLE = "Sponsored"
         const val SPONSOR_ACCESSIBILITY_LABEL = "Sponsored"
         const val CTA_LABEL = "Learn more about our sponsor"
+        const val TAP_ACTION_LABEL = "Open video"
     }
 }
+
+private fun SemanticsNodeInteraction.assertOnClickLabelEquals(value: String?): SemanticsNodeInteraction = assert(
+    SemanticsMatcher("${SemanticsActions.OnClick.name} = [$value]") {
+        it.config.getOrNull(SemanticsActions.OnClick)?.label == value
+    },
+)

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/graphicpromotion/BpkGraphicPromo.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/graphicpromotion/BpkGraphicPromo.kt
@@ -57,6 +57,7 @@ fun BpkGraphicPromo(
     sponsorLogo: (@Composable () -> Unit)? = null,
     interactionSource: MutableInteractionSource = remember { MutableInteractionSource() },
     tapAction: () -> Unit = {},
+    tapActionAccessibilityLabel: String? = null,
     animationIndicationNode: IndicationNodeFactory = getInteractiveBackgroundIndicationNodeFactory(),
 ) {
     BpkGraphicPromoImpl(
@@ -72,6 +73,7 @@ fun BpkGraphicPromo(
         sponsorLogo = sponsorLogo,
         interactionSource = interactionSource,
         tapAction = tapAction,
+        tapActionAccessibilityLabel = tapActionAccessibilityLabel,
         animationIndicationNode = animationIndicationNode,
     )
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/graphicpromotion/internal/BpkGraphicPromoImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/graphicpromotion/internal/BpkGraphicPromoImpl.kt
@@ -100,6 +100,7 @@ internal fun BpkGraphicPromoImpl(
     sponsor: BpkGraphicsPromoSponsor? = null,
     sponsorLogo: (@Composable () -> Unit)? = null,
     tapAction: () -> Unit = {},
+    tapActionAccessibilityLabel: String? = null,
     animationIndicationNode: IndicationNodeFactory = InteractiveBackgroundIndicationNodeFactory,
 ) {
     val (aspectRatio, maxHeight) = getDeviceConstrains()
@@ -115,6 +116,7 @@ internal fun BpkGraphicPromoImpl(
             .clickable(
                 interactionSource = interactionSource,
                 indication = null,
+                onClickLabel = tapActionAccessibilityLabel,
                 onClick = tapAction,
             )
             .semantics(mergeDescendants = true) {


### PR DESCRIPTION
## Summary
- Adds an optional `tapActionAccessibilityLabel: String?` param to `BpkGraphicPromo`/`BpkGraphicPromoImpl`, threaded into the existing `Modifier.clickable`'s native `onClickLabel` — lets a consumer set a custom TalkBack tap hint (e.g. "Double tap to open video") without needing to wrap the whole component in `clearAndSetSemantics`.
- That workaround matters because `clearAndSetSemantics` erases descendant semantics wholesale, breaking independent TalkBack focus on nested elements — e.g. the sponsor "Ad info" CTA icon set via `sponsorFor(...)`. This change keeps the existing `.semantics(mergeDescendants = true) { role; contentDescription }` block untouched, so that property is preserved by construction.
- Also pins `espresso-core` to the version catalog's `3.7.0` in `backpack-compose` (previously resolved transitively to `3.5.0`, unlike every other module which already declares it explicitly). `3.5.0`'s reflective `InputManager.getInstance()` call crashes Compose UI instrumented tests on newer Android builds; `3.7.0` fixed this by switching to `getSystemService`.

## Integration

Consumer-side integration for this change: [skyscanner-app#48955](https://github.com/Skyscanner/skyscanner-app/pull/48955) swaps its `clearAndSetSemantics` workaround for `tapActionAccessibilityLabel`, currently tested there against a local `84.2.0-SNAPSHOT` build of this branch. That PR is blocked on this one merging/releasing — attaching here so reviewers can check the real consuming behaviour side by side.

_Check the "Double tap to open video" text when the video card is focused_

https://github.com/user-attachments/assets/4515e00c-573c-4738-a26f-80ba9acfdd14

## Jira
https://skyscanner.atlassian.net/browse/MUON-2081

## Test plan
- [x] `BpkGraphicPromoTest` (androidTest) extended with 3 new cases: custom label applied to the click action, default (no label) behaviour unchanged, and — the regression this whole ticket exists to prevent — the sponsor CTA icon stays independently focusable in the merged tree even with a custom tap label set.
- [x] All 8 tests in `BpkGraphicPromoTest` pass on-device (`./gradlew :backpack-compose:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=net.skyscanner.backpack.compose.graphicpromotion.BpkGraphicPromoTest`).
- [x] Manual on-device TalkBack check that the announced hint text is correct (not exercised by the automated tests, which assert on the semantics action's label rather than actual TTS output).