### PR TITLE
Fix keyboard accessibility for BpkSelect

### DIFF
--- a/app/src/test/java/net/skyscanner/backpack/compose/select/BpkSelectTest.kt
+++ b/app/src/test/java/net/skyscanner/backpack/compose/select/BpkSelectTest.kt
@@ -18,11 +18,21 @@
 
 package net.skyscanner.backpack.compose.select
 
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.isFocusable
 import androidx.compose.ui.test.isPopup
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.pressKey
 import net.skyscanner.backpack.compose.BpkSnapshotTest
+import net.skyscanner.backpack.demo.BackpackDemoTheme
 import net.skyscanner.backpack.demo.compose.DefaultSelectSample
 import net.skyscanner.backpack.demo.compose.DefaultSelectTextOnlySample
 import net.skyscanner.backpack.demo.compose.DisabledSelectSample
@@ -85,5 +95,21 @@ class BpkSelectTest : BpkSnapshotTest() {
         onNode(isPopup()).assertIsDisplayed()
     }, captureFullScreen = true) {
         DefaultSelectSample(selectedIndex = 0, dropDownWidth = BpkDropDownWidth.MatchSelectWidth)
+    }
+
+    @Test
+    fun dropdownCanBeOpenedWithExternalKeyboard() {
+        composeTestRule.setContent {
+            BackpackDemoTheme {
+                DefaultSelectSample(dropDownWidth = BpkDropDownWidth.MaxWidth)
+            }
+        }
+        composeTestRule.waitForIdle()
+        composeTestRule.onNode(isFocusable() and hasClickAction())
+            .assert(isFocusable())
+            .performSemanticsAction(SemanticsActions.RequestFocus)
+            .assertIsFocused()
+            .performKeyInput { pressKey(Key.Enter) }
+        composeTestRule.onNode(isPopup()).assertIsDisplayed()
     }
 }

--- a/app/src/test/java/net/skyscanner/backpack/compose/select/BpkSelectTest.kt
+++ b/app/src/test/java/net/skyscanner/backpack/compose/select/BpkSelectTest.kt
@@ -18,14 +18,17 @@
 
 package net.skyscanner.backpack.compose.select
 
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsFocused
-import androidx.compose.ui.test.hasClickAction
 import androidx.compose.ui.test.isFocusable
 import androidx.compose.ui.test.isPopup
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performKeyInput
@@ -101,11 +104,18 @@ class BpkSelectTest : BpkSnapshotTest() {
     fun dropdownCanBeOpenedWithExternalKeyboard() {
         composeTestRule.setContent {
             BackpackDemoTheme {
-                DefaultSelectSample(dropDownWidth = BpkDropDownWidth.MaxWidth)
+                BpkSelect(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("keyboard_select"),
+                    options = listOf("London", "Paris"),
+                    selectedIndex = null,
+                    placeholder = "Placeholder",
+                )
             }
         }
         composeTestRule.waitForIdle()
-        composeTestRule.onNode(isFocusable() and hasClickAction())
+        composeTestRule.onNodeWithTag("keyboard_select")
             .assert(isFocusable())
             .performSemanticsAction(SemanticsActions.RequestFocus)
             .assertIsFocused()

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/select/internal/BpkSelectImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/select/internal/BpkSelectImpl.kt
@@ -90,7 +90,7 @@ internal fun BpkSelectImpl(
                     enabled = status != BpkFieldStatus.Disabled,
                 ),
             value = selectText,
-            isFocused = expanded || anchorHasFocus,
+            isFocused = status != BpkFieldStatus.Disabled && (expanded || anchorHasFocus),
             placeholder = placeholder,
             status = status,
             trailingIcon = BpkIcon.ArrowDown,

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/select/internal/BpkSelectImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/select/internal/BpkSelectImpl.kt
@@ -19,6 +19,7 @@
 package net.skyscanner.backpack.compose.select.internal
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.rememberScrollState
@@ -34,6 +35,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextOverflow
@@ -67,6 +69,7 @@ internal fun BpkSelectImpl(
     val selectText = selectedIndex?.let { options.getOrNull(selectedIndex) } ?: ""
     val focusManager = LocalFocusManager.current
     val scrollState = rememberScrollState()
+    var anchorHasFocus by remember { mutableStateOf(false) }
 
     LaunchedEffect(expanded, selectedIndex) {
         if (expanded && selectedIndex != null) {
@@ -78,9 +81,16 @@ internal fun BpkSelectImpl(
         onExpandedChange = { expanded = !expanded },
     ) {
         BpkStaticFieldImpl(
-            modifier = modifier.menuAnchor(ExposedDropdownMenuAnchorType.PrimaryNotEditable),
+            // BpkStaticFieldImpl is visual-only; the anchor needs a focus target for keyboard input.
+            modifier = modifier
+                .onFocusChanged { anchorHasFocus = it.isFocused }
+                .focusable(enabled = status != BpkFieldStatus.Disabled)
+                .menuAnchor(
+                    type = ExposedDropdownMenuAnchorType.PrimaryNotEditable,
+                    enabled = status != BpkFieldStatus.Disabled,
+                ),
             value = selectText,
-            isFocused = expanded,
+            isFocused = expanded || anchorHasFocus,
             placeholder = placeholder,
             status = status,
             trailingIcon = BpkIcon.ArrowDown,


### PR DESCRIPTION
## Summary

- Restore a focus target for the BpkSelect dropdown anchor.
- Reuse the existing Backpack focus border while the anchor is focused or expanded.
- Keep disabled selects out of keyboard focus and menu-anchor handling.
- This also resolves the same issue in the Travelers selector because `SelectRow` uses `BpkSelect`.

Fixes [DON-3703](https://skyscanner.atlassian.net/browse/DON-3703) and [DON-3702](https://skyscanner.atlassian.net/browse/DON-3702).

## Validation

- Android Studio diagnostics: no issues in the changed files.
- Android Studio build: successful.
- Focused BpkSelect keyboard regression test: passed.
- mobile-mcp emulator check: Tab shows the collapsed MaxWidth focus ring; Enter opens the dropdown.
- Local Backpack snapshot publish and sibling-app dependency resolution: `99.9.9-SNAPSHOT` resolved successfully.

https://github.com/user-attachments/assets/27a4cca1-ba13-4999-9f1c-ac6d586abcb5



+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)
+ [ ] Component README.md (no public API or usage changes)
+ [x] Tests

[DON-3703]: https://skyscanner.atlassian.net/browse/DON-3703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DON-3702]: https://skyscanner.atlassian.net/browse/DON-3702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ