### PR TITLE
[DON-2269] Keep Latin digits in RTL BpkRating

### DIFF
--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/rating/internal/BpkRatingComponents.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/rating/internal/BpkRatingComponents.kt
@@ -170,7 +170,12 @@ internal fun formatValue(value: Float, scale: BpkRatingScale, locale: Locale): S
     val decimalValue = BigDecimal(coercedValue.toString()).stripTrailingZeros()
     val fractionDigits = decimalValue.scale().coerceAtLeast(1)
 
-    return NumberFormat.getNumberInstance(locale).apply {
+    val latinNumeralsLocale = Locale.Builder()
+        .setLocale(locale)
+        .setUnicodeLocaleKeyword("nu", "latn")
+        .build()
+
+    return NumberFormat.getNumberInstance(latinNumeralsLocale).apply {
         isGroupingUsed = false
         minimumFractionDigits = fractionDigits
         maximumFractionDigits = fractionDigits

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/rating/internal/BpkRatingComponents.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/rating/internal/BpkRatingComponents.kt
@@ -57,10 +57,13 @@ internal fun BpkRatingNumbers(
 ) {
     Row(modifier = modifier) {
         val locale = LocalConfiguration.current.locales[0]
+        val formattedValue = remember(value, scale, locale) {
+            formatValue(value, scale, locale)
+        }
 
         BpkText(
             modifier = Modifier.alignByBaseline(),
-            text = formatValue(value, scale, locale),
+            text = formattedValue,
             style = when (size) {
                 BpkRatingSize.Base -> BpkTheme.typography.label1
                 BpkRatingSize.Large -> BpkTheme.typography.hero5

--- a/backpack-compose/src/test/kotlin/net/skyscanner/backpack/compose/rating/internal/BpkRatingComponentsTest.kt
+++ b/backpack-compose/src/test/kotlin/net/skyscanner/backpack/compose/rating/internal/BpkRatingComponentsTest.kt
@@ -44,6 +44,11 @@ class BpkRatingComponentsTest {
     }
 
     @Test
+    fun formatValueUsesLatinDigitsInRtlLocale() {
+        assertEquals("8.5", formatValue(8.5f, BpkRatingScale.ZeroToTen, Locale.forLanguageTag("ar")))
+    }
+
+    @Test
     fun formatValueMapsNaNToScaleMinimum() {
         assertEquals("0.0", formatValue(Float.NaN, BpkRatingScale.ZeroToFive, Locale.US))
     }

--- a/backpack-compose/src/test/kotlin/net/skyscanner/backpack/compose/rating/internal/BpkRatingComponentsTest.kt
+++ b/backpack-compose/src/test/kotlin/net/skyscanner/backpack/compose/rating/internal/BpkRatingComponentsTest.kt
@@ -45,7 +45,15 @@ class BpkRatingComponentsTest {
 
     @Test
     fun formatValueUsesLatinDigitsInRtlLocale() {
-        assertEquals("8.5", formatValue(8.5f, BpkRatingScale.ZeroToTen, Locale.forLanguageTag("ar")))
+        val formattedValue = formatValue(
+            8.5f,
+            BpkRatingScale.ZeroToTen,
+            Locale.forLanguageTag("ar"),
+        )
+        val decimalSeparator = formattedValue.single { it !in '0'..'9' }
+
+        assertEquals("8", formattedValue.substringBefore(decimalSeparator))
+        assertEquals("5", formattedValue.substringAfter(decimalSeparator))
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Keep BpkRating decimal precision while forcing Latin numerals for RTL locales.
- Preserve locale-aware decimal formatting and scale clamping.
- Add Arabic RTL regression coverage.

## Context

DON-2269 removed the one-decimal truncation in Backpack, but the locale-aware formatter introduced a regression visible in [app PR #48988](https://github.com/Skyscanner/skyscanner-app/pull/48988): the Arabic RTL snapshot renders ٨,٥ instead of the previous 8.5.

The formatter now requests the latn Unicode numbering system from the active locale. This keeps the RTL layout and locale handling while ensuring the rating digits match the existing app numeric presentation.

## Validation

- :backpack-compose:testDebugUnitTest --tests net.skyscanner.backpack.compose.rating.internal.BpkRatingComponentsTest passed via the Android Studio terminal.
- Repository-wide Detekt passed with Android Studio configured Microsoft JDK 21.
- Android Studio analysis reported no issues for the changed source and test files.
- git diff --check passed.

[DON-2269](https://skyscanner.atlassian.net/browse/DON-2269)

- [x] I have read and followed the contributing guidelines.
- [x] Tests added.

[DON-2269]: https://skyscanner.atlassian.net/browse/DON-2269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ