### PR TITLE
[DON-3704] Announce BpkSelect anchor as a dropdown list

### DIFF
--- a/app/src/test/java/net/skyscanner/backpack/compose/select/BpkSelectTest.kt
+++ b/app/src/test/java/net/skyscanner/backpack/compose/select/BpkSelectTest.kt
@@ -22,19 +22,23 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.isFocusable
 import androidx.compose.ui.test.isPopup
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performKeyInput
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.pressKey
 import net.skyscanner.backpack.compose.BpkSnapshotTest
+import net.skyscanner.backpack.compose.fieldset.BpkFieldStatus
 import net.skyscanner.backpack.demo.BackpackDemoTheme
 import net.skyscanner.backpack.demo.compose.DefaultSelectSample
 import net.skyscanner.backpack.demo.compose.DefaultSelectTextOnlySample
@@ -78,7 +82,7 @@ class BpkSelectTest : BpkSnapshotTest() {
 
     @Test
     fun dropdownlistMaxWidth() = snap(assertion = {
-        onNodeWithText("Placeholder").performClick()
+        onNode(isSelectAnchor()).performClick()
         onNode(isPopup()).assertIsDisplayed()
     }, captureFullScreen = true) {
         DefaultSelectSample(selectedIndex = 0, dropDownWidth = BpkDropDownWidth.MaxWidth)
@@ -86,7 +90,7 @@ class BpkSelectTest : BpkSnapshotTest() {
 
     @Test
     fun dropdownlistMatchOptionWidth() = snap(assertion = {
-        onNodeWithText("Placeholder").performClick()
+        onNode(isSelectAnchor()).performClick()
         onNode(isPopup()).assertIsDisplayed()
     }, captureFullScreen = true) {
         DefaultSelectSample(selectedIndex = 0, dropDownWidth = BpkDropDownWidth.MatchOptionWidth)
@@ -94,7 +98,7 @@ class BpkSelectTest : BpkSnapshotTest() {
 
     @Test
     fun dropdownlistMatchSelectWidth() = snap(assertion = {
-        onNodeWithText("Placeholder").performClick()
+        onNode(isSelectAnchor()).performClick()
         onNode(isPopup()).assertIsDisplayed()
     }, captureFullScreen = true) {
         DefaultSelectSample(selectedIndex = 0, dropDownWidth = BpkDropDownWidth.MatchSelectWidth)
@@ -122,4 +126,46 @@ class BpkSelectTest : BpkSnapshotTest() {
             .performKeyInput { pressKey(Key.Enter) }
         composeTestRule.onNode(isPopup()).assertIsDisplayed()
     }
+
+    @Test
+    fun anchorExposesDropdownListRoleMergedWithItsLabel() {
+        composeTestRule.setContent {
+            BackpackDemoTheme {
+                BpkSelect(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("role_select"),
+                    options = listOf("London", "Paris"),
+                    selectedIndex = null,
+                    placeholder = "Placeholder",
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("role_select")
+            .assert(isSelectAnchor())
+            .assertTextEquals("Placeholder")
+    }
+
+    @Test
+    fun disabledAnchorExposesDropdownListRole() {
+        composeTestRule.setContent {
+            BackpackDemoTheme {
+                BpkSelect(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .testTag("disabled_select"),
+                    options = listOf("London", "Paris"),
+                    selectedIndex = null,
+                    placeholder = "Placeholder",
+                    status = BpkFieldStatus.Disabled,
+                )
+            }
+        }
+        composeTestRule.onNodeWithTag("disabled_select")
+            .assert(isSelectAnchor())
+            .assertTextEquals("Placeholder")
+    }
+
+    private fun isSelectAnchor(): SemanticsMatcher =
+        SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.DropdownList)
 }

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/select/internal/BpkSelectImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/select/internal/BpkSelectImpl.kt
@@ -38,6 +38,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import net.skyscanner.backpack.compose.fieldset.BpkFieldStatus
 import net.skyscanner.backpack.compose.fieldset.LocalFieldStatus
@@ -83,6 +85,7 @@ internal fun BpkSelectImpl(
         BpkStaticFieldImpl(
             // BpkStaticFieldImpl is visual-only; the anchor needs a focus target for keyboard input.
             modifier = modifier
+                .semantics(mergeDescendants = true) { role = Role.DropdownList }
                 .onFocusChanged { anchorHasFocus = it.isFocused }
                 .focusable(enabled = status != BpkFieldStatus.Disabled)
                 .menuAnchor(


### PR DESCRIPTION
Noted while investigating [DON-3704](https://skyscanner.atlassian.net/browse/DON-3704), where keyboard focus navigation missed the cabin class dropdown and it had to be touch-focused for screen readers. Follows on from #2812.

## Problem

The select anchor did not announce itself as a dropdown list to screen readers.

Material3's `menuAnchor` *does* already set `Role.DropdownList` ([`ExposedDropdownMenu.kt:1468`](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/ExposedDropdownMenu.kt)), but two things stopped it reaching the user:

1. `BpkStaticFieldImpl` does not merge its descendants, so the role landed on the anchor node while the label lived on a separate child text node. TalkBack announced a roleless label and a labelless role as two items.
2. `menuAnchor` skips its semantics block entirely when `enabled = false`, so a disabled select had no role at all.

## Change

Merge the anchor's descendants and set the role explicitly, so the label and role are announced together as a single item — `"<label>, Drop down list"` — including when disabled.

## Testing

+ `anchorExposesDropdownListRoleMergedWithItsLabel` — asserts the role and the label resolve to the same semantics node.
+ `disabledAnchorExposesDropdownListRole` — covers the gap `menuAnchor` leaves when disabled.
+ The three `dropdownlist*` snapshot tests now locate the anchor by role rather than by placeholder text.

`./gradlew detekt` and `./gradlew app:testOssDebugUnitTest --tests '*BpkSelectTest*'` both pass — 12 tests, 0 failures. No snapshots are committed, per [CONTRIBUTING.md](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md#debugging-snapshot-tests); CI will regenerate them. This is a semantics-only change, so no visual diff is expected.

## Follow-up

The disabled anchor now announces a role but carries no `disabled()` semantics, so TalkBack will not say it is unavailable. Left out of scope here.

+ [x] Check this if you have read and followed the [contributing guidelines](https://github.com/Skyscanner/backpack-android/blob/main/CONTRIBUTING.md)

Remember to include the following changes:
+ [ ] Component `README.md` — not needed, no API or usage change
+ [x] Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DON-3704]: https://skyscanner.atlassian.net/browse/DON-3704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ