### PR TITLE
[DON-3704] Keep BpkNudger keyboard focus when a button hits min or max

### DIFF
--- a/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/nudger/BpkNudgerAccessibilityTest.kt
+++ b/backpack-compose/src/androidTest/kotlin/net/skyscanner/backpack/compose/nudger/BpkNudgerAccessibilityTest.kt
@@ -1,0 +1,198 @@
+/**
+ * Backpack for Android - Skyscanner's Design System
+ *
+ * Copyright 2018 - 2026 Skyscanner Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package net.skyscanner.backpack.compose.nudger
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.focus.Focusability
+import androidx.compose.ui.input.InputMode
+import androidx.compose.ui.input.InputModeManager
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.platform.LocalInputModeManager
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsNotFocused
+import androidx.compose.ui.test.isFocusable
+import androidx.compose.ui.test.junit4.v2.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performKeyInput
+import androidx.compose.ui.test.performSemanticsAction
+import androidx.compose.ui.test.pressKey
+import net.skyscanner.backpack.compose.button.BpkButton
+import net.skyscanner.backpack.compose.theme.BpkTheme
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+class BpkNudgerAccessibilityTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun givenFocusOnDecrement_whenMinReached_thenFocusMovesToIncrement() {
+        val value = setUpNudger(initialValue = MIN + 1)
+
+        composeTestRule.onNodeWithTag(DECREMENT_TAG)
+            .assert(isFocusable())
+            .performSemanticsAction(SemanticsActions.RequestFocus)
+            .assertIsFocused()
+            .performKeyInput { pressKey(Key.Enter) }
+
+        assertEquals(MIN, value.get())
+        composeTestRule.onNodeWithTag(INCREMENT_TAG).assertIsFocused()
+    }
+
+    @Test
+    fun givenFocusOnIncrement_whenMaxReached_thenFocusMovesToDecrement() {
+        val value = setUpNudger(initialValue = MAX - 1)
+
+        composeTestRule.onNodeWithTag(INCREMENT_TAG)
+            .assert(isFocusable())
+            .performSemanticsAction(SemanticsActions.RequestFocus)
+            .assertIsFocused()
+            .performKeyInput { pressKey(Key.Enter) }
+
+        assertEquals(MAX, value.get())
+        composeTestRule.onNodeWithTag(DECREMENT_TAG).assertIsFocused()
+    }
+
+    /**
+     * With a range of one step the receiving button is itself disabled until this very click
+     * enables it, so it has no focus target while `onClick` runs. Guards against regressing to a
+     * synchronous `requestFocus()`, which would throw because the target does not exist yet.
+     */
+    @Test
+    fun givenSingleStepRange_whenMinReached_thenFocusStillMovesToIncrement() {
+        val value = setUpNudger(initialValue = 1, min = 0, max = 1)
+
+        composeTestRule.onNodeWithTag(DECREMENT_TAG)
+            .performSemanticsAction(SemanticsActions.RequestFocus)
+            .assertIsFocused()
+            .performKeyInput { pressKey(Key.Enter) }
+
+        assertEquals(0, value.get())
+        composeTestRule.onNodeWithTag(INCREMENT_TAG).assertIsFocused()
+    }
+
+    /**
+     * In touch mode the buttons are not focusable at all, so reaching a bound by tapping must not
+     * hand a touch user a focus highlight they never asked for.
+     */
+    @Test
+    fun givenTouchMode_whenMinReached_thenNoFocusIsGranted() {
+        val value = setUpNudger(initialValue = MIN + 1, emulateKeyboard = false)
+
+        composeTestRule.onNodeWithTag(DECREMENT_TAG).performClick()
+
+        assertEquals(MIN, value.get())
+        composeTestRule.onNodeWithTag(INCREMENT_TAG).assertIsNotFocused()
+    }
+
+    /** The row overload merges semantics on its own parent, so it needs covering separately. */
+    @Test
+    fun givenRowVariant_whenMinReached_thenFocusMovesToIncrement() {
+        val value = setUpNudger(initialValue = MIN + 1, title = "Adults")
+
+        composeTestRule.onNodeWithTag(DECREMENT_TAG)
+            .performSemanticsAction(SemanticsActions.RequestFocus)
+            .assertIsFocused()
+            .performKeyInput { pressKey(Key.Enter) }
+
+        assertEquals(MIN, value.get())
+        composeTestRule.onNodeWithTag(INCREMENT_TAG).assertIsFocused()
+    }
+
+    /**
+     * With an empty range both buttons are permanently disabled, so there is nowhere to move focus
+     * to. Documents that this degenerate case renders without crashing.
+     */
+    @Test
+    fun givenMinEqualsMax_thenBothButtonsAreDisabled() {
+        setUpNudger(initialValue = 0, min = 0, max = 0)
+
+        composeTestRule.onNodeWithTag(DECREMENT_TAG).assertIsNotEnabled()
+        composeTestRule.onNodeWithTag(INCREMENT_TAG).assertIsNotEnabled()
+    }
+
+    /**
+     * [BpkButton]'s focus target is [Focusability.SystemDefined], so it can only be focused outside
+     * of touch input mode. Emulating a hardware keyboard is therefore a precondition for the focus
+     * assertions - in touch mode the buttons are not focusable at all.
+     */
+    private fun setUpNudger(
+        initialValue: Int,
+        min: Int = MIN,
+        max: Int = MAX,
+        title: String? = null,
+        emulateKeyboard: Boolean = true,
+    ): AtomicInteger {
+        val value = AtomicInteger(initialValue)
+        lateinit var inputModeManager: InputModeManager
+        composeTestRule.setContent {
+            inputModeManager = LocalInputModeManager.current
+            BpkTheme {
+                var current by remember { mutableIntStateOf(initialValue) }
+                val onValueChange: (Int) -> Unit = {
+                    current = it
+                    value.set(it)
+                }
+                if (title == null) {
+                    BpkNudger(
+                        value = current,
+                        onValueChange = onValueChange,
+                        min = min,
+                        max = max,
+                        testTag = NUDGER_TEST_TAG,
+                    )
+                } else {
+                    BpkNudger(
+                        value = current,
+                        onValueChange = onValueChange,
+                        min = min,
+                        max = max,
+                        title = title,
+                        subtitle = "Aged 16+",
+                        testTag = NUDGER_TEST_TAG,
+                    )
+                }
+            }
+        }
+        composeTestRule.waitForIdle()
+        if (emulateKeyboard) {
+            composeTestRule.runOnUiThread { inputModeManager.requestInputMode(InputMode.Keyboard) }
+            composeTestRule.waitForIdle()
+        }
+        return value
+    }
+
+    private companion object {
+        const val MIN = 0
+        const val MAX = 10
+        const val NUDGER_TEST_TAG = "nudger"
+        const val DECREMENT_TAG = "${NUDGER_TEST_TAG}Decrement"
+        const val INCREMENT_TAG = "${NUDGER_TEST_TAG}Increment"
+    }
+}

--- a/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/nudger/internal/BpkNudgerImpl.kt
+++ b/backpack-compose/src/main/kotlin/net/skyscanner/backpack/compose/nudger/internal/BpkNudgerImpl.kt
@@ -24,9 +24,17 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.progressSemantics
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.disabled
@@ -67,6 +75,35 @@ internal fun BpkNudgerImpl(
     fun setValue(value: Int) =
         onValueChange(value.coerceIn(range))
 
+    val decrementEnabled = enabled && coerced > range.first
+    val incrementEnabled = enabled && coerced < range.last
+
+    // A disabled button loses its focus target, which would drop keyboard focus to the root.
+    // Hand focus to the opposite button instead (DON-3704).
+    val decrementFocusRequester = remember { FocusRequester() }
+    val incrementFocusRequester = remember { FocusRequester() }
+    var decrementHasFocus by remember { mutableStateOf(false) }
+    var incrementHasFocus by remember { mutableStateOf(false) }
+    var pendingFocusMove by remember { mutableStateOf<NudgerButton?>(null) }
+
+    // The move has to wait for recomposition: when both buttons change enabled state on the same
+    // click the receiving button has no focus target yet while onClick is running.
+    LaunchedEffect(pendingFocusMove) {
+        val target = pendingFocusMove ?: return@LaunchedEffect
+        pendingFocusMove = null
+        when (target) {
+            // Only move once the button really did become disabled - the value is hoisted, so the
+            // host is free to ignore onValueChange and leave it enabled and focused.
+            NudgerButton.Increment -> if (!decrementEnabled && incrementEnabled) {
+                incrementFocusRequester.requestFocus()
+            }
+            NudgerButton.Decrement -> if (!incrementEnabled && decrementEnabled) {
+                decrementFocusRequester.requestFocus()
+            }
+        }
+        // When min == max both buttons are disabled and there is nowhere to move focus to.
+    }
+
     Row(
         modifier = if (allowSemantics) modifier.nudgerSemantics(value, ::setValue, range, enabled) else modifier,
         verticalAlignment = Alignment.CenterVertically,
@@ -75,11 +112,20 @@ internal fun BpkNudgerImpl(
         BpkButton(
             icon = BpkIcon.Minus,
             contentDescription = "", // handled by semantics modifier
-            enabled = enabled && coerced > range.first,
+            enabled = decrementEnabled,
             size = BpkButtonSize.Default,
             type = BpkButtonType.Secondary,
-            onClick = { setValue(coerced - 1) },
-            modifier = Modifier.generateNudgerTestTag(testTag, "Decrement"),
+            onClick = {
+                // Recorded here because this is the last moment the button is still focused.
+                if (decrementHasFocus && coerced - 1 <= range.first) {
+                    pendingFocusMove = NudgerButton.Increment
+                }
+                setValue(coerced - 1)
+            },
+            modifier = Modifier
+                .focusRequester(decrementFocusRequester)
+                .onFocusChanged { decrementHasFocus = it.hasFocus }
+                .generateNudgerTestTag(testTag, "Decrement"),
         )
 
         BpkText(
@@ -102,11 +148,20 @@ internal fun BpkNudgerImpl(
         BpkButton(
             icon = BpkIcon.Plus,
             contentDescription = "", // handled by semantics modifier
-            enabled = enabled && coerced < range.last,
+            enabled = incrementEnabled,
             size = BpkButtonSize.Default,
             type = BpkButtonType.Secondary,
-            onClick = { setValue(coerced + 1) },
-            modifier = Modifier.generateNudgerTestTag(testTag, "Increment"),
+            onClick = {
+                // Recorded here because this is the last moment the button is still focused.
+                if (incrementHasFocus && coerced + 1 >= range.last) {
+                    pendingFocusMove = NudgerButton.Decrement
+                }
+                setValue(coerced + 1)
+            },
+            modifier = Modifier
+                .focusRequester(incrementFocusRequester)
+                .onFocusChanged { incrementHasFocus = it.hasFocus }
+                .generateNudgerTestTag(testTag, "Increment"),
         )
     }
 }
@@ -144,6 +199,8 @@ internal fun Modifier.nudgerSemantics(
             valueRange = range.first.toFloat()..range.last.toFloat(),
             steps = range.last - range.first,
         )
+
+private enum class NudgerButton { Decrement, Increment }
 
 @OptIn(ExperimentalComposeUiApi::class)
 private fun Modifier.generateNudgerTestTag(testTag: String?, action: String): Modifier {

--- a/docs/compose/Nudger/README.md
+++ b/docs/compose/Nudger/README.md
@@ -10,6 +10,17 @@
 |-------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Nudger/screenshots/default.png" alt="Nudger component" width="375" /> | <img src="https://raw.githubusercontent.com/Skyscanner/backpack-android/main/docs/compose/Nudger/screenshots/default_dm.png" alt="Nudger component - dark mode" width="375" /> |
 
+## Accessibility
+
+The nudger is exposed to screen readers as a single adjustable control, so TalkBack announces the
+current value and offers the volume keys to change it rather than reading the `+` and `-` buttons
+separately.
+
+For external keyboards the two buttons are separate focus stops. When a button becomes disabled
+because the value reached `min` or `max`, keyboard focus moves to the opposite button so it is never
+lost. Note that Compose only makes buttons focusable outside of touch input mode, so this has no
+effect on touch interaction.
+
 ## Installation
 
 Backpack Compose is available through [Maven Central](https://search.maven.org/artifact/net.skyscanner.backpack/backpack-compose). Check the main [Readme](https://github.com/skyscanner/backpack-android#installation) for a complete installation guide.


### PR DESCRIPTION
Fixes the nudger half of [DON-3704](https://skyscanner.atlassian.net/browse/DON-3704) — *"Travelers: External keyboard: focus jumps to top after using +/- buttons"* (WCAG SC 2.4.3, Usablenet `SG3410-4-UXN11`).

## The bug

The `+`/`-` buttons are disabled at the bounds. Material 3's `Button` derives its focus target from `Modifier.clickable(enabled = …)`, so when `enabled` flips to `false` that target is removed, Compose has no fallback, and focus is cleared to the root — an external-keyboard user pressing Enter down to `min` is dumped back to the top of the screen.

## The fix

Focus moves to the **opposite** button. Three details worth reviewing:

1. **The intent is recorded inside `onClick`**, the last moment the activated button is still focused. Reacting to the `enabled` transition instead would be too late — the focus target is already gone by then.
2. **The move runs in a `LaunchedEffect`, not synchronously.** With a one-step range (`min = 0, max = 1` at `value = 1`) the receiving button is itself disabled and has no focus target until the recomposition this click triggers, so a synchronous `requestFocus()` throws `IllegalStateException: FocusRequester is not initialized`. `givenSingleStepRange_whenMinReached_thenFocusStillMovesToIncrement` guards against regressing this.
3. **Two guards keep it honest.** The move only happens if the button actually held focus, so touch users are never handed a focus highlight; and only if the button really became disabled, since `value` is hoisted and a host may ignore `onValueChange`.

No visual state was added, and no snapshots change.

## Why not keep the disabled button focused

The audit's boilerplate says *"Make sure that it remains on the same element"*, which reads like the `aria-disabled` pattern. That isn't available on Android: `View.canTakeFocus()` requires the `ENABLED` flag, and Compose's `clickable(enabled = false)` installs no focus target at all. Keeping a disabled button focusable would mean inventing both the behaviour and a focus visual for a disabled button. Nothing in WCAG requires disabled controls to be focusable — 2.4.3 asks that focus order preserve meaning and operability, which moving to the sibling satisfies, and movement within a single composite control is not a change of context under 3.2.1/3.2.2.

## Screen reader behaviour is untouched

The ticket notes the TalkBack implementation is good and should be preserved. It is: the nudger remains a single adjustable node via `progressSemantics`/`setProgress`, announcing the value and offering the volume keys. This change only affects the physical-keyboard path, where the two buttons are separate tab stops.

## Testing

New `BpkNudgerAccessibilityTest` in `backpack-compose/src/androidTest`, per the CONTRIBUTING guidance that logic which can't be verified by snapshots belongs in the module's espresso tests. `app/src/test/.../BpkNudgerTest.kt` is unchanged and stays purely snapshot-based.

Verified **6/6 across three consecutive runs on a physical SM-N960F (Android 10)**, plus the full `app:testOssDebugUnitTest` suite and `detekt`.

One non-obvious thing for anyone extending these tests: `clickable` builds its focus target with `Focusability.SystemDefined`, whose `canFocus` is literally `inputMode != InputMode.Touch`. So **no Backpack button is focusable in a test until the input mode is switched to `Keyboard`** — the helper does this via `LocalInputModeManager`, and it's a real platform mechanism (`AndroidComposeView` implements it as `requestFocusFromTouch()`), not a test-only affordance. `BpkSelect`'s existing test avoids this only because `Modifier.focusable()` is `Focusability.Always`.

## Notes for review

- **This is the only file in the module using the v2 `createComposeRule`.** The other 14 `androidTest` files use the deprecated v1. Chosen because this is a new file with no migration risk, and it removes the deprecation warning; happy to align either way.
- `invisibleToUser()` at `BpkNudgerImpl.kt:137` is deprecated in favour of `hideFromAccessibility()`, but it's pre-existing and affects 9 files across the module, so it wants its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DON-3704]: https://skyscanner.atlassian.net/browse/DON-3704?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ